### PR TITLE
Add a small script to automate building & serve

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+from __future__ import print_function
+import os, sys
+
+if len(sys.argv) < 2:
+    build_type = 'html'
+else:
+    build_type = sys.argv[1]
+
+os.system('make %s' % build_type)
+
+os.chdir('./build/%s' % build_type)
+
+if sys.version_info[0] < 3:
+    import SimpleHTTPServer as server
+    import SocketServer as socketserver
+else:
+    from http import server
+    import socketserver
+
+HOST = 'localhost'
+PORT = 8000
+
+Handler = server.SimpleHTTPRequestHandler
+
+httpd = socketserver.TCPServer((HOST, PORT), Handler)
+
+print("serving at http://%s:%d" % (HOST, PORT))
+httpd.serve_forever()


### PR DESCRIPTION
For convenience' sake, I'm not sure if you guys like reducing repetitive sets of build & run commands to one :)

Just run with `./serve.py` or `python serve.py`

You can pass an argument that would normally be passed to `make`,
like `./serve.py dirhtml`.
