### PR TITLE
Fixed use of it's that should be its instead

### DIFF
--- a/source/technical.rst
+++ b/source/technical.rst
@@ -42,7 +42,7 @@ install_requires
 ``install_requires`` is a :ref:`setuptools` ``setup.py`` keyword that should be
 used to specify what a project **minimally** needs to run correctly.  When the
 project is installed by :ref:`pip`, this is the specification that is used to
-install it's dependencies.
+install its dependencies.
 
 For example, if the project requires A and B, your ``install_requires`` would be
 like so:

--- a/source/tutorial.rst
+++ b/source/tutorial.rst
@@ -131,7 +131,7 @@ and options.  For details, see the `pip docs
 
 Below are the most common use cases:
 
-Install `SomePackage` and it's dependencies from :term:`PyPI <Python Package
+Install `SomePackage` and its dependencies from :term:`PyPI <Python Package
 Index (PyPI)>` using :ref:`pip:Requirement Specifiers`
 
 ::
@@ -216,7 +216,7 @@ Installing Wheels
 Distribution (or "sdist")>` that provides faster installation, especially when a
 project contains compiled extensions.
 
-For a detailed comparison of wheel to it's :term:`Egg` predecessor, see
+For a detailed comparison of wheel to its :term:`Egg` predecessor, see
 :ref:`Wheel vs Egg`.
 
 As of v1.5, :ref:`pip` prefers :term:`wheels <Wheel>` over :term:`sdists <Source


### PR DESCRIPTION
This commit fixes three uses of "it's" that should be "its".
