### PR TITLE
Fix typo: Remove wrong linebreak

### DIFF
--- a/source/tutorial.rst
+++ b/source/tutorial.rst
@@ -575,8 +575,7 @@ write a ``~/.pypirc`` file like so.
    ::
 
     [distutils]
-    index-servers=
-    pypi
+    index-servers=pypi
 
     [pypi]
     repository = https://pypi.python.org/pypi


### PR DESCRIPTION
  ParsingError: Source contains parsing errors: '/home/user/.pypirc'
          [line  3]: 'pypi\n'
