### PR TITLE
Intro text for "supporting multiple Python versions".

### DIFF
--- a/source/deployment.rst
+++ b/source/deployment.rst
@@ -33,6 +33,17 @@ Supporting multiple Python versions
   - mention version classifiers for distribution metadata
 
 
+In addition to the work required to create a Python package, it is often
+necessary that the package must be made available on different versions of
+Python.  Different Python versions may contain different (or renamed) standard
+library packages, and the changes between Python versions 2.x and 3.x include
+changes in the language syntax.
+
+Performed manually, all the testing required to ensure that the package works
+correctly on all the target Python versions (and OSs!) could be very
+time-consuming. Fortunately, several tools are available for dealing with
+this, and these will briefly be discussed here.
+
 Supporting multiple hardware platforms
 ======================================
 


### PR DESCRIPTION
This one should come before the others. In my efforts to make review of these PRs easy (by splitting up the changes), I may have messed things up. Hopefully there are no merge conflicts.

This PR is some intro text that appears first in the "multiple python versions" section.

The order should be:
- pymultiverintrotext
- greghewgillref
- continuousintegration
- singlesourcepython
- whatwhichpython
