### PR TITLE
reduce our use of the distribution meaning of "package"

### DIFF
--- a/source/current.rst
+++ b/source/current.rst
@@ -14,8 +14,8 @@ what tools are currently recommended, then here it is.
 Installation Tool Recommendations
 =================================
 
-* Use :ref:`pip` to install Python :term:`packages <Package (Meaning #2)>`
-  from :term:`PyPI <Python Package Index (PyPI)>`. [1]_ [2]_
+* Use :ref:`pip` to install Python :term:`distributions <Distribution>` from
+  :term:`PyPI <Python Package Index (PyPI)>`. [1]_ [2]_
 
 * Use :ref:`virtualenv`, or `pyvenv`_ to isolate application specific
   dependencies from a shared Python installation. [3]_
@@ -69,13 +69,13 @@ Packaging Tool Recommendations
 
 .. [5] Although you can use pure ``distutils`` for many projects, it does not
        support defining dependencies on other projects and is missing several
-       convenience utilities for automatically populating package metadata
+       convenience utilities for automatically populating distribution metadata
        correctly that are provided by ``setuptools``. Being outside the
        standard library, ``setuptools`` also offers a more consistent feature
        set across different versions of Python, and (unlike ``distutils``),
        ``setuptools`` will be updated to produce the upcoming "Metadata 2.0"
        standard formats on all supported versions.
-       
+
        Even for projects that do choose to use ``distutils``, when :ref:`pip`
        installs such projects directly from source (rather than installing
        from a prebuilt :term:`wheel <Wheel>` file), it will actually build

--- a/source/deployment.rst
+++ b/source/deployment.rst
@@ -43,9 +43,9 @@ Automated Testing and Continuous Integration
 Several hosted services for automated testing are available. These services
 will typically monitor your source code repository (e.g. at
 `Github <https://github.com>`_ or `Bitbucket <https://bitbucket.org>`_)
-and run your package's test suite every time a new commit is made.
+and run your project's test suite every time a new commit is made.
 
-These services also offer facilities to run your package's test suite on
+These services also offer facilities to run your project's test suite on
 *multiple versions of Python*, giving rapid feedback about whether the code
 will work, without the developer having to perform such tests themselves.
 
@@ -74,8 +74,9 @@ Both `Travis CI`_ and Appveyor_ require a `YAML
 for testing. If any tests fail, the output log for that specific configuration
 can be inspected.
 
-For Python packages that are intended to be deployed on both Python 2 and 3
+For Python projects that are intended to be deployed on both Python 2 and 3
 with a single-source strategy, there are a number of options.
+
 Supporting multiple hardware platforms
 ======================================
 
@@ -85,10 +86,10 @@ Supporting multiple hardware platforms
 
   Meaning: x86, x64, ARM, others?
 
-  For Python-only packages, it *should* be straightforward to deploy on all
+  For Python-only distributions, it *should* be straightforward to deploy on all
   platforms where Python can run.
 
-  For packages with binary extensions, deployment is major headache.  Not only
+  For distributions with binary extensions, deployment is major headache.  Not only
   must the extensions be built on all the combinations of operating system and
   hardware platform, but they must also be tested, preferably on continuous
   integration platforms.  The issues are similar to the "multiple python
@@ -141,7 +142,7 @@ There are a few techniques to store the version in your project code without dup
 
 
 #.  Set the value to a ``__version__`` global variable in a dedicated module in
-    your package (e.g. ``version.py``), then have ``setup.py`` read and ``exec`` the
+    your project (e.g. ``version.py``), then have ``setup.py`` read and ``exec`` the
     value into a variable.
 
     Using ``execfile``:
@@ -214,7 +215,7 @@ There are a few techniques to store the version in your project code without dup
 PyPI mirrors and caches
 =======================
 
-Mirroring or caching of PyPI can be used to speed up local package
+Mirroring or caching of PyPI can be used to speed up local distribution
 installation, allow offline work, handle corporate firewalls or just plain
 Internet flakiness.
 
@@ -223,14 +224,14 @@ Three options are available in this area:
 1. pip provides local caching options,
 2. devpi provides higher-level caching option, potentially shared amongst
    many users or machines, and
-3. bandersnatch provides a local complete mirror of all packages on PyPI.
+3. bandersnatch provides a local complete mirror of all PyPI distributions.
 
 
 Caching with pip
 ----------------
 
 pip provides a number of facilities for speeding up installation by using
-local cached copies of packages:
+local cached copies of distributions:
 
 1. `Fast & local installs
    <https://pip.pypa.io/en/latest/user_guide.html#fast-local-installs>`_ by
@@ -240,8 +241,8 @@ local cached copies of packages:
    the requirements using `pip wheel
    <http://pip.readthedocs.org/en/latest/reference/pip_wheel.html>`_::
 
-    $ pip wheel --wheel-dir=/tmp/wheelhouse SomePackage
-    $ pip install --no-index --find-links=/tmp/wheelhouse SomePackage
+    $ pip wheel --wheel-dir=/tmp/wheelhouse SomeProject
+    $ pip install --no-index --find-links=/tmp/wheelhouse SomeProject
 
 
 Caching with devpi
@@ -257,14 +258,14 @@ __ http://doc.devpi.net/latest/quickstart-pypimirror.html
 Complete mirror with bandersnatch
 ----------------------------------
 
-bandersnatch will set up a complete local mirror of all packages on PyPI
-(externally-hosted packages are not mirrored). See the
+bandersnatch will set up a complete local mirror of all PyPI distributions
+(externally-hosted distributions are not mirrored). See the
 `bandersnatch documentation for getting that going`__.
 
 __ https://bitbucket.org/pypa/bandersnatch/overview
 
-A benefit of devpi is that it will create a mirror which includes packages
-that are external to PyPI, unlike bandersnatch which will only cache packages
+A benefit of devpi is that it will create a mirror which includes distributions
+that are external to PyPI, unlike bandersnatch which will only cache distributions
 hosted on PyPI.
 
 

--- a/source/history.rst
+++ b/source/history.rst
@@ -91,10 +91,10 @@ dependencies.
 **2002**: Richard Jones started work on :term:`PyPI <Python Package Index
 (PyPI)>`, and created `PEP301`_ to describe it.
 
-**2001**: `PEP241`_ was written to standardize the metadata for packages.
+**2001**: `PEP241`_ was written to standardize the metadata for distributions.
 
 **2000**: `catalog-sig`_ was created to discuss creating a centralized index of
-packages.
+distributions.
 
 **2000**: :ref:`distutils` was added to the Python standard library in Python 1.6.
 

--- a/source/platforms.rst
+++ b/source/platforms.rst
@@ -61,8 +61,8 @@ Installing on OSX
 
 .. _`NumPy and the Science Stack`:
 
-Installing Scientific Packages
-==============================
+Installing Scientific Distributions
+===================================
 
 Scientific software tends to have more complex dependencies than most, and
 it will often have multiple build options to take advantage of different
@@ -111,8 +111,8 @@ For Linux users, the system package manager will often have pre-compiled
 versions of various pieces of scientific software, including NumPy and
 other parts of the scientific Python stack.
 
-If using versions which may be several months old is acceptable, then this
-is likely to be a good option (just make sure to allow access to packages
+If using versions which may be several months old is acceptable, then this is
+likely to be a good option (just make sure to allow access to distributions
 installed into the system Python when using virtual environments).
 
 
@@ -133,9 +133,9 @@ a `collection of Windows installers
 <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`__. Many Python users on
 Windows have reported a positive experience with these prebuilt versions.
 
-As with Linux system packages, the Windows installers will only install into
-a system Python installation - they do not support installation in virtual
-environments. Allowing access to packages installed into the system Python
+As with Linux system packages, the Windows installers will only install into a
+system Python installation - they do not support installation in virtual
+environments. Allowing access to distributions installed into the system Python
 when using virtual environments is a common approach to working around this
 limitation.
 

--- a/source/projects.rst
+++ b/source/projects.rst
@@ -91,7 +91,7 @@ Dev irc:#pypa-dev
 
 setuptools (which includes ``easy_install``) is a collection of enhancements to
 the Python distutils that allow you to more easily build and distribute Python
-packages, especially ones that have dependencies on other packages.
+distributions, especially ones that have dependencies on other packages.
 
 `distribute`_ was a fork of setuptools that was merged back into setuptools (in
 v0.7), thereby making setuptools the primary choice for Python packaging.
@@ -218,7 +218,7 @@ Conda does not install packages from PyPI and can install only from
 the official Continuum repositories, or binstar.org (a place for
 user-contributed *conda* packages), or a local (e.g. intranet) package server.
 However, note that pip can be installed into, and work side-by-side with conda
-for managing packages from PyPI.
+for managing distributions from PyPI.
 
 
 devpi

--- a/source/technical.rst
+++ b/source/technical.rst
@@ -141,12 +141,12 @@ Here's a breakdown of the important differences between pip and easy_install now
 |Installs from :term:`Wheels   |Yes                               |No                             |
 |<Wheel>`                      |                                  |                               |
 +------------------------------+----------------------------------+-------------------------------+
-|Uninstall Packages            |Yes (``pip uninstall``)           |No                             |
+|Uninstall Distributions       |Yes (``pip uninstall``)           |No                             |
 +------------------------------+----------------------------------+-------------------------------+
 |Dependency Overrides          |Yes (:ref:`Requirements Files     |No                             |
 |                              |<pip:Requirements Files>`)        |                               |
 +------------------------------+----------------------------------+-------------------------------+
-|List Installed Packages       |Yes (``pip list`` and ``pip       |No                             |
+|List Installed Distributions  |Yes (``pip list`` and ``pip       |No                             |
 |                              |freeze``)                         |                               |
 +------------------------------+----------------------------------+-------------------------------+
 |:ref:`PEP438 <PEP438s>`       |Yes                               |No                             |
@@ -186,7 +186,7 @@ easy_install and sys.path
 
    FIXME
 
-   - global easy_install'd packages override --user installs
+   - global easy_install'd distributions override --user installs
 
 
 .. _`Wheel vs Egg`:
@@ -226,8 +226,8 @@ Multi-version Installs
 ======================
 
 easy_install allows simultaneous installation of different versions of the same
-package into a single environment shared by multiple programs which must
-``require`` the appropriate version of the package at run time (using
+project into a single environment shared by multiple programs which must
+``require`` the appropriate version of the project at run time (using
 ``pkg_resources``).
 
 For many use cases, virtual environments address this need without the
@@ -275,7 +275,7 @@ Dependency Resolution
    - console_scripts complaining about conflicts
    - scenarios to breakdown:
       - conficting dependencies within the dep tree of one argument `
-      - conflicts across arguments: ``pip|easy_install  OnePackage TwoPackage``
+      - conflicts across arguments: ``pip|easy_install  OneProject TwoProject``
       - conflicts with what's already installed
 
 

--- a/source/tutorial.rst
+++ b/source/tutorial.rst
@@ -55,9 +55,10 @@ We recommend the following installation sequence:
     source <DIR>/bin/activate
 
 
-3. For building wheels: ``pip install wheel`` [2]_
+3. For building :term:`wheels <Wheel>`: ``pip install wheel`` [2]_
 
-4. For uploading distributions: ``pip install twine`` [2]_
+4. For uploading :term:`distributions <Distribution>`: ``pip install twine``
+   [2]_
 
 
 .. _`Creating and using Virtual Environments`:
@@ -65,8 +66,9 @@ We recommend the following installation sequence:
 Virtual Environments
 ====================
 
-Python "Virtual Environments" allow packages to be installed in an isolated
-location for a particular application, rather than being installed globally.
+Python "Virtual Environments" allow Python :term:`distributions <Distribution>`
+to be installed in an isolated location for a particular application, rather
+than being installed globally.
 
 Imagine you have an application that needs version 1 of LibFoo, but another
 application requires version 2. How can you use both these applications? If you
@@ -78,8 +80,8 @@ Or more generally, what if you want to install an application and leave it be?
 If an application works, any change in its libraries or the versions of those
 libraries can break the application.
 
-Also, what if you can’t install packages into the global site-packages
-directory? For instance, on a shared host.
+Also, what if you can’t install :term:`distributions <Distribution>` into the
+global site-packages directory? For instance, on a shared host.
 
 In all these cases, virtual environments can help you. They have their own
 installation directories and they don’t share libraries with other virtual
@@ -114,8 +116,8 @@ For more information, see the `virtualenv <http://virtualenv.pypa.io>`_ docs or
 the `pyvenv`_ docs.
 
 
-Installing Python packages
-==========================
+Installing Python Distributions
+===============================
 
 :ref:`pip` is the recommended installer, and supports various requirement forms
 and options.  For details, see the `pip docs
@@ -124,14 +126,14 @@ and options.  For details, see the `pip docs
 Examples
 --------
 
-Install `SomePackage` and its dependencies from :term:`PyPI <Python Package
+Install `SomeProject` and its dependencies from :term:`PyPI <Python Package
 Index (PyPI)>` using :ref:`pip:Requirement Specifiers`
 
 ::
 
- pip install SomePackage           # latest version
- pip install SomePackage==1.0.4    # specific version
- pip install 'SomePackage>=1.0.4'  # minimum version
+ pip install SomeProject           # latest version
+ pip install SomeProject==1.0.4    # specific version
+ pip install 'SomeProject>=1.0.4'  # minimum version
 
 
 Install a list of requirements specified in a :ref:`Requirements File
@@ -142,11 +144,11 @@ Install a list of requirements specified in a :ref:`Requirements File
  pip install -r requirements.txt
 
 
-Upgrade an already installed `SomePackage` to the latest from PyPI.
+Upgrade an already installed `SomeProject` to the latest from PyPI.
 
 ::
 
- pip install --upgrade SomePackage
+ pip install --upgrade SomeProject
 
 
 Install a project from VCS in "editable" mode.  For a full breakdown of the
@@ -154,25 +156,25 @@ syntax, see pip's section on :ref:`VCS Support <pip:VCS Support>`.
 
 ::
 
- pip install -e git+https://git.repo/some_pkg.git#egg=SomePackage          # from git
- pip install -e hg+https://hg.repo/some_pkg.git#egg=SomePackage            # from mercurial
- pip install -e svn+svn://svn.repo/some_pkg/trunk/#egg=SomePackage         # from svn
- pip install -e git+https://git.repo/some_pkg.git@feature#egg=SomePackage  # from a branch
+ pip install -e git+https://git.repo/some_pkg.git#egg=SomeProject          # from git
+ pip install -e hg+https://hg.repo/some_pkg.git#egg=SomeProject            # from mercurial
+ pip install -e svn+svn://svn.repo/some_pkg/trunk/#egg=SomeProject         # from svn
+ pip install -e git+https://git.repo/some_pkg.git@feature#egg=SomeProject  # from a branch
 
 
 Install a particular source archive file.
 
 ::
 
- pip install ./downloads/SomePackage-1.0.4.tar.gz
- pip install http://my.package.repo/SomePackage-1.0.4.zip
+ pip install ./downloads/SomeProject-1.0.4.tar.gz
+ pip install http://my.package.repo/SomeProject-1.0.4.zip
 
 
 Install from an alternate index
 
 ::
 
- pip install --index-url http://my.package.repo/simple/ SomePackage
+ pip install --index-url http://my.package.repo/simple/ SomeProject
 
 
 Search an additional index during install, in addition to :term:`PyPI <Python
@@ -180,7 +182,7 @@ Package Index (PyPI)>`
 
 ::
 
- pip install --extra-index-url http://my.package.repo/simple SomePackage
+ pip install --extra-index-url http://my.package.repo/simple SomeProject
 
 
 Install from a local directory containing archives (and don't check :term:`PyPI
@@ -188,9 +190,9 @@ Install from a local directory containing archives (and don't check :term:`PyPI
 
 ::
 
- pip install --no-index --find-links=file:///local/dir/ SomePackage
- pip install --no-index --find-links=/local/dir/ SomePackage
- pip install --no-index --find-links=relative/dir/ SomePackage
+ pip install --no-index --find-links=file:///local/dir/ SomeProject
+ pip install --no-index --find-links=/local/dir/ SomeProject
+ pip install --no-index --find-links=relative/dir/ SomeProject
 
 
 Find pre-release and development versions, in addition to stable versions.  By
@@ -198,15 +200,16 @@ default, pip only finds stable versions.
 
 ::
 
- pip install --pre SomePackage
+ pip install --pre SomeProject
 
 
 Wheels
 ------
 
-:term:`Wheel` is a pre-built package format that provides faster installation
-compared to :term:`Source Distributions (sdist) <Source Distribution (or
-"sdist")>`, especially when a project contains compiled extensions.
+:term:`Wheel` is a pre-built :term:`distribution <Distribution>` format that
+provides faster installation compared to :term:`Source Distributions (sdist)
+<Source Distribution (or "sdist")>`, especially when a project contains compiled
+extensions.
 
 As of v1.5, :ref:`pip` prefers :term:`wheels <Wheel>` over :term:`sdists <Source
 Distribution (or "sdist")>` when searching indexes.
@@ -235,11 +238,12 @@ comparison, see :ref:`Wheel vs Egg`.
 User Installs
 -------------
 
-To install packages that are isolated to the current user, use the ``-user`` flag:
+To install :term:`distributions <Distribution>` that are isolated to the current
+user, use the ``-user`` flag:
 
 ::
 
-  pip install --user SomePackage
+  pip install --user SomeProject
 
 
 For more information see the `User Installs
@@ -414,15 +418,17 @@ specification that is used to install its dependencies.
 
 For more on using "install_requires" see :ref:`install_requires vs Requirements files`.
 
+
 .. _`Package Data`:
 
 Package Data
 ------------
 
-Often, additional files need to be installed into a package. These files are
-often data that’s closely related to the package’s implementation, or text files
-containing documentation that might be of interest to programmers using the
-package. These files are called "package data".
+Often, additional files need to be installed into a :term:`package <Package
+(Meaning #1)>`. These files are often data that’s closely related to the
+package’s implementation, or text files containing documentation that might be
+of interest to programmers using the package. These files are called "package
+data".
 
 from `sampleproject/setup.py
 <https://github.com/pypa/sampleproject/blob/master/setup.py>`_
@@ -449,8 +455,8 @@ Data Files
 ----------
 
 Although configuring :ref:`Package Data` is sufficient for most needs, in some
-cases you may need to place data files *outside* of your packages.  The
-``data_files`` directive allows you to do that.
+cases you may need to place data files *outside* of your :term:`packages
+<Package (Meaning #1)>`.  The ``data_files`` directive allows you to do that.
 
 from `sampleproject/setup.py
 <https://github.com/pypa/sampleproject/blob/master/setup.py>`_
@@ -462,9 +468,9 @@ from `sampleproject/setup.py
 Each (directory, files) pair in the sequence specifies the installation
 directory and the files to install there. If directory is a relative path, it is
 interpreted relative to the installation prefix (Python’s sys.prefix for
-pure-Python packages, sys.exec_prefix for packages that contain extension
-modules). Each file name in files is interpreted relative to the ``setup.py`` script
-at the top of the package source distribution.
+pure-Python distributions, sys.exec_prefix for distributions that contain
+extension modules). Each file name in files is interpreted relative to the
+``setup.py`` script at the top of the project source distribution.
 
 For more information see the distutils section on `Installing Additional Files
 <http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files>`_.
@@ -499,8 +505,8 @@ keyword for pointing to pre-made scripts, the recommended approach to achieve
 cross-platform compatibility, is to use "console_script" `entry points
 <http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
 that register your script interfaces, and let the toolchain handle the work of
-turning these interfaces into actual scripts [6]_.  The scripts will be generated
-during the install of your package.
+turning these interfaces into actual scripts [6]_.  The scripts will be
+generated during the install of your :term:`distribution <Distribution>`.
 
 For more information, see `Automatic Script Creation
 <http://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation>`_


### PR DESCRIPTION
in response to the conversation in #87
- when "package" is clearly the distribution meaning, replace it with "distribution"
- also, in some cases, replace "package" with "project".
