### PR TITLE
Remove duplicated document title from tutorial contents

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -5,7 +5,8 @@ Tutorial on Packaging and Distributing Projects
 :Page Status: Complete
 :Last Reviewed: 2014-09-30
 
-.. contents::
+.. contents:: Contents
+   :local:
 
 This tutorial covers the basics of how to create and distribute your
 own Python projects.  This tutorial assumes that you are already familiar

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -5,7 +5,8 @@ Tutorial on Installing Distributions
 :Page Status: Complete
 :Last Reviewed: 2014-09-30
 
-.. contents::
+.. contents:: Contents
+   :local:
 
 This tutorial covers the basics of how to install Python :term:`packages
 <Package (Meaning #2)>`, which are known more formally as


### PR DESCRIPTION
I noticed that the document title is repeated inside the table of contents on both tutorials.  Removing the title makes the contents much easier to follow because it reduces the nesting level of every item.

It looks like there are other places this can be fixed, but I only addressed it in these two pages for now.
