### PR TITLE
Clarify scope of packaging tutorial

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -12,10 +12,11 @@ This tutorial covers the basics of how to create and distribute your
 own Python projects.  It assumes that you are already familiar
 with the contents of the :doc:`installing`.
 
-The tutorial aims to cover core packaging tasks and features and does *not*
-aim to cover project "best practices."  For example, it does not provide
-guidance or recommendations on selecting third-party tools or services
-such as for documentation, automated testing, continuous integration, etc.
+The tutorial aims to cover core packaging tasks and features and does
+not aim to cover best practices for Python project development as a whole.
+For example, it does not provide guidance or recommendations on selecting
+third-party tools or services such as for documentation, automated
+testing, continuous integration, etc.
 
 
 Setup for Project Distributors


### PR DESCRIPTION
Various issues crop up here and in the sampleproject repo asking for certain recommendations to be included within the Guide (e.g. documentation, testing, etc).  For this reason, it would be good to clarify the scope -- at least of the packaging tutorial.
