### PR TITLE
Minor bugfix: pip user flag was missing a dash

### DIFF
--- a/source/installing.rst
+++ b/source/installing.rst
@@ -239,7 +239,7 @@ User Installs
 -------------
 
 To install :term:`distributions <Distribution>` that are isolated to the current
-user, use the ``-user`` flag:
+user, use the ``--user`` flag:
 
 ::
 


### PR DESCRIPTION
Signed-off-by: Daniel Farrell dfarrell@redhat.com
