### PR TITLE
Mention that pip install -e can take local paths

### DIFF
--- a/source/installing.rst
+++ b/source/installing.rst
@@ -168,7 +168,7 @@ syntax, see pip's section on :ref:`VCS Support <pip:VCS Support>`.
  pip install -e hg+https://hg.repo/some_pkg.git#egg=SomeProject            # from mercurial
  pip install -e svn+svn://svn.repo/some_pkg/trunk/#egg=SomeProject         # from svn
  pip install -e git+https://git.repo/some_pkg.git@feature#egg=SomeProject  # from a branch
-
+ pip install -e ~/src/some_pkg                                             # from a source tree
 
 Install a particular source archive file.
 


### PR DESCRIPTION
It's a bit strange to see all examples of `pip install -e` using full URLs.  It might give a beginner the wrong impression that you must always use a VCS URL.
