### PR TITLE
Update packaging-projects.rst

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -87,6 +87,7 @@ Open :file:`setup.py` and enter the following content. You **should** update the
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
         ],
+        data_files = [("", ["LICENSE"])],
     )
 
 


### PR DESCRIPTION
The tutorial tells the reader not to forget to have a LICENSE file but, in the end, the LICENSE file was not shipped.
IMHO, an extra line to the minimalist setup.py ensures consistency between what is said and what is done.