### PR TITLE
SIngle-sourcing the package version: Remove a py2-only option; simplify a py3 option

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -48,16 +48,6 @@ number of your project:
     your project (e.g. :file:`version.py`), then have :file:`setup.py` read and
     ``exec`` the value into a variable.
 
-    Using ``execfile``:
-
-    ::
-
-        execfile('...sample/version.py')
-        # now we have a `__version__` variable
-        # later on we use: __version__
-
-    Using ``exec``:
-
     ::
 
         version = {}

--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -51,8 +51,7 @@ number of your project:
     ::
 
         version = {}
-        with open("...sample/version.py") as fp:
-            exec(fp.read(), version)
+        exec(open("...sample/version.py").read(), version)
         # later on we use: version['__version__']
 
     Example using this technique: `warehouse <https://github.com/pypa/warehouse/blob/64ca42e42d5613c8339b3ec5e1cb7765c6b23083/warehouse/__about__.py>`_.

--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -51,7 +51,8 @@ number of your project:
     ::
 
         version = {}
-        exec(open("...sample/version.py").read(), version)
+        with open("...sample/version.py") as fp:
+            exec(fp.read(), version)
         # later on we use: version['__version__']
 
     Example using this technique: `warehouse <https://github.com/pypa/warehouse/blob/64ca42e42d5613c8339b3ec5e1cb7765c6b23083/warehouse/__about__.py>`_.


### PR DESCRIPTION
Thanks for this guide! I was using this and tried `execfile()` without realizing it didn't work in Python 3.

I thought about leaving the Python 2 version here with a disclaimer, though this list is already very long, and it seems more helpful to steer people toward a good solution than to exhaustively document an obsolete solution.

I simplified the Python 3 option to a version which seems equally safe without the context handler (it seems the file handle should be closed when it goes out of scope), which should be immediately upon return.