### PR TITLE
[pipx] replace ensurepath with userpath

### DIFF
--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -24,8 +24,8 @@ packages, and allows you to safely run the program from anywhere.
 
 ::
 
-  $ pip install --user pipx
-  $ userpath ~/.local/bin  # ensures the path of the CLI application directory is on your $PATH
+  $ python3 -m pip install --user pipx
+  $ python3 -m userpath ~/.local/bin  # ensures the path of the CLI application directory is on your $PATH
 
 .. Note:: You may need to restart your terminal for the path updates to take effect.
 

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -25,7 +25,7 @@ packages, and allows you to safely run the program from anywhere.
 ::
 
   $ pip install --user pipx
-  $ pipx ensurepath  # ensures the path of the CLI application directory is on your $PATH
+  $ userpath ~/.local/bin  # ensures the path of the CLI application directory is on your $PATH
 
 .. Note:: You may need to restart your terminal for the path updates to take effect.
 

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -25,7 +25,7 @@ packages, and allows you to safely run the program from anywhere.
 ::
 
   $ python3 -m pip install --user pipx
-  $ python3 -m userpath ~/.local/bin  # ensures the path of the CLI application directory is on your $PATH
+  $ python3 -m userpath append ~/.local/bin  # ensures the path of the CLI application directory is on your $PATH
 
 .. Note:: You may need to restart your terminal for the path updates to take effect.
 


### PR DESCRIPTION
pipx is now relying on the PyPI package [userpath](https://pypi.org/project/userpath/) and has deprecated its `ensurepath` command.