### PR TITLE
Change directory layout examples for consistency

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -17,8 +17,8 @@ To create this project locally, create the following file structure:
 
 .. code-block:: text
 
-    /packaging_tutorial
-      /example_pkg
+    packaging_tutorial/
+      example_pkg/
         __init__.py
 
 
@@ -48,8 +48,8 @@ them in the following steps.
 
 .. code-block:: text
 
-    /packaging_tutorial
-      /example_pkg
+    packaging_tutorial/
+      example_pkg/
         __init__.py
       setup.py
       LICENSE


### PR DESCRIPTION
Directory layout examples were changed to use trailing slashes.

Rationale:

* consistent with examples in the Python [modules tutorial](https://docs.python.org/3/tutorial/modules.html#packages)
* consistent with example currently on line 208 (dist/) 
* removing the first leading slash avoids possible confusion that you are to work in the root directory