### PR TITLE
add python_requires usage to example

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -87,6 +87,7 @@ Open :file:`setup.py` and enter the following content. Update the package name t
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
         ],
+        python_requires='>=3.6',
     )
 
 


### PR DESCRIPTION
Updating documentation based off discussion at the Python Packaging Summit during PyCon 2019. Should address #612 