### PR TITLE
Mention find_namespace_packages

### DIFF
--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -101,16 +101,17 @@ logic to fail and the other sub-packages will not be importable.
 
 Because ``mynamespace`` doesn't contain an :file:`__init__.py`,
 :func:`setuptools.find_packages` won't find the sub-package. You must
-explicitly list all packages in your :file:`setup.py`. For example:
+use :func:`setuptools.find_namespace_packages` instead or explicitly
+list all packages in your :file:`setup.py`. For example:
 
 .. code-block:: python
 
-    from setuptools import setup
+    from setuptools import setup, find_namespace_packages
 
     setup(
         name='mynamespace-subpackage-a',
         ...
-        packages=['mynamespace.subpackage_a']
+        packages=find_namespace_packages(include=['mynamespace.*'])
     )
 
 A complete working example of two native namespace packages can be found in


### PR DESCRIPTION
packaging-namespace-packages.rst previously recommended listing all packages manually.

This function is available since [setuptools v4.0.1](https://setuptools.readthedocs.io/en/latest/history.html#v40-1-0) from 17 Aug 2018.