### PR TITLE
guides/packaging-namespace-packages.rst: mention setuptools.find_name…

### DIFF
--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -100,7 +100,8 @@ package omits the :file:`__init__.py` or uses a pkgutil-style
 logic to fail and the other sub-packages will not be importable.
 
 Because ``mynamespace`` doesn't contain an :file:`__init__.py`,
-:func:`setuptools.find_packages` won't find the sub-package. You must
+:func:`setuptools.find_packages` won't find the sub-package. To get the
+sub-packages, you must either use :func:`setuptools.find_namespace_packages` or
 explicitly list all packages in your :file:`setup.py`. For example:
 
 .. code-block:: python


### PR DESCRIPTION
Adds a mention to setuptools.find_namespace_packages() in the packaging guide since setuptools.find_packages() will not work on PEP 420 packages

fixes #580