### PR TITLE
Upgrade Sphinx version, remove pypa.io intersphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.8.3
+sphinx==2.1.2
 sphinx-autobuild==0.7.1
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -354,7 +354,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6', None),
     'pip': ('https://pip.pypa.io/en/latest/', None),
-    'pypa': ('https://pypa.io/en/latest/', None),
 }
 
 


### PR DESCRIPTION
pypa.io's cert is invalid, but it doesn't matter as we're not actually using its intersphinx inventory for anything.