### PR TITLE
pypa.io -> www.pypa.io

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -29,7 +29,7 @@ This guide is maintained on `GitHub`_ by the `Python Packaging Authority`_. We
 happily accept any :doc:`contributions and feedback <contribute>`. 😊
 
 .. _GitHub: https://github.com/pypa/python-packaging-user-guide
-.. _Python Packaging Authority: https://pypa.io
+.. _Python Packaging Authority: https://www.pypa.io
 
 
 Get started


### PR DESCRIPTION
pypa.io doesn't appear to be a navigable link. Safari & Firefox complain they can't connect because the site is misconfigured, and they don't seem to redirect to www.pypa.io, which does work.

![Screen Shot 2019-07-16 at 7 05 31 AM](https://user-images.githubusercontent.com/2435101/61301593-03f91080-a799-11e9-8632-127fef18f79f.png)
