### PR TITLE
use python3 -m when installing pipx

### DIFF
--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -24,8 +24,8 @@ packages, and allows you to safely run the program from anywhere.
 
 ::
 
-  $ pip install --user pipx
-  $ pipx ensurepath  # ensures the path of the CLI application directory is on your $PATH
+  $ python3 -m pip install --user pipx
+  $ python3 -m pipx ensurepath  # ensures the path of the CLI application directory is on your $PATH
 
 .. Note:: You may need to restart your terminal for the path updates to take effect.
 


### PR DESCRIPTION
As noted in https://github.com/pypa/packaging.python.org/pull/607, `pipx` may not be on the user's PATH when installed with the `--user` flag. This PR adds the `python3 -m` prefix when ensuring the PATH has paths pipx expects. Note that pipx now considers `ensurepath` best practice again (it's no longer deprecated).