### PR TITLE
Properly exclude test/ and tests/ in find_packages() example

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -353,7 +353,7 @@ packages
 
 ::
 
-  packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+  packages=find_packages(exclude=['contrib', 'docs', 'test', 'test.*', 'tests', 'tests.*']),
 
 Set ``packages`` to a list of all :term:`packages <Import Package>` in your
 project, including their subpackages, sub-subpackages, etc.  Although the


### PR DESCRIPTION
This pull request edits the code snippet [in the "packages" `setup()` keyword description](https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages) so that `find_packages()` properly excludes `test` *and* `tests` *and* everything under them.