### PR TITLE
Modify `Requests` package link to correct URL

### DIFF
--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -95,7 +95,7 @@ when you share your project with others. You should get output similar to this
 
     Adding requests to Pipfile's [packages]...
 
-.. _Requests: https://python-requests.org
+.. _Requests: https://2.python-requests.org
 .. _pipenv-tox: https://docs.pipenv.org/advanced/#tox-automation-project
 
 


### PR DESCRIPTION
The `https://python-requests.org` is currently unavailable; So modified to `https://2.python-requests.org` valid URL.