### PR TITLE
Add field name for the Project-URL example

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -523,7 +523,7 @@ separated by a comma.
 
 Example::
 
-    Bug Tracker, http://bitbucket.org/tarek/distribute/issues/
+    Project-URL: Bug Tracker, http://bitbucket.org/tarek/distribute/issues/
 
 The label is a free text limited to 32 signs.
 


### PR DESCRIPTION
Every other example in the guide has the field name included in the example, I think it was likely just an oversight that this one was missing it.