### PR TITLE
Update description of how Pynsist installs Python

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -67,12 +67,11 @@ the Python-interpreter and declare the dependencies of the program. The tool
 downloads the specified Python-interpreter for Windows and packages it with all
 the dependencies in a single Windows-executable installer.
 
-The installer installs or updates the Python-interpreter on the users system,
-which can be used independently of the packaged program. The program itself,
-can be started from a shortcut, that the installer places in the start-menu.
-Uninstalling the program leaves the Python installation of the user intact.
+The installed program can be started from a shortcut that the installer adds to
+the start-menu. It uses a Python interpreter installed within its application
+directory, indepedent of any other Python installation on the computer.
 
-A big advantage of pynsist is that the Windows packages can be built on Linux.
+A big advantage of Pynsist is that the Windows packages can be built on Linux.
 There are several examples for different kinds of programs (console, GUI) in
 the `documentation <https://pynsist.readthedocs.io>`__. The tool is released
 under the MIT-licence.

--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -69,7 +69,7 @@ the dependencies in a single Windows-executable installer.
 
 The installed program can be started from a shortcut that the installer adds to
 the start-menu. It uses a Python interpreter installed within its application
-directory, indepedent of any other Python installation on the computer.
+directory, independent of any other Python installation on the computer.
 
 A big advantage of Pynsist is that the Windows packages can be built on Linux.
 There are several examples for different kinds of programs (console, GUI) in


### PR DESCRIPTION
Early versions of Pynsist worked as this note described before, but then an [option to bundle Python](https://pynsist.readthedocs.io/en/1.12/cfgfile.html#bundled-python) was added, then made the default, and has been the only mechanism supported since Pynsist 2.0, 2 years ago.