### PR TITLE
Change keywords field to be comma separated

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -268,12 +268,19 @@ Keywords
 
 .. versionadded:: 1.0
 
-A list of additional keywords to be used to assist searching
-for the distribution in a larger catalog.
+A list of additional keywords, separated by commas, to be used to assist
+searching for the distribution in a larger catalog.
 
 Example::
 
-    Keywords: dog puppy voting election
+    Keywords: dog,puppy,voting,election
+
+.. note::
+
+   The specification previously showed keywords separated by spaces,
+   but distutils and setuptools implemented it with commas.
+   These tools have been very widely used for many years, so it was
+   easier to update the specification to match the de facto standard.
 
 .. _home-page-optional:
 


### PR DESCRIPTION
distutils and setuptools have gone against the spec for years, possibly without anyone noticing. Changing the spec to record what's in widespread use is much easier than trying to fix the tools to match the spec.

Discussion on distutils-sig: https://mail.python.org/archives/list/distutils-sig@python.org/thread/LFTLGMIIB5PRG7NUUIGGGX4COGX53DMR/