### PR TITLE
Update sdist default contents list for setuptools 42.0.0

### DIFF
--- a/source/guides/using-manifest-in.rst
+++ b/source/guides/using-manifest-in.rst
@@ -32,6 +32,8 @@ The following files are included in a source distribution by default:
   arguments
 - the file specified by the ``license_file`` option in :file:`setup.cfg`
   (setuptools 40.8.0+)
+- all files specified by the ``license_files`` option in :file:`setup.cfg`
+  (setuptools 42.0.0+)
 - all files matching the pattern :file:`test/test*.py`
 - :file:`setup.py` (or whatever you called your setup script)
 - :file:`setup.cfg`


### PR DESCRIPTION
setuptools 42.0.0 introduces support for including files specified with the `license_files` option.  This PR updates the list of files included in a source distribution by default to reflect that.