### PR TITLE
Remove GH actions beta warning

### DIFF
--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -15,13 +15,6 @@ It will use the `pypa/gh-action-pypi-publish GitHub Action`_ https://github.com/
    This guide *assumes* that you already have a project that
    you know how to build distributions for and *it lives on GitHub*.
 
-.. warning::
-
-   At the time of writing, `GitHub Actions CI/CD`_
-   is in public beta. If you don't have it enabled,
-   you should `join the waitlist`_ to gain access.
-
-
 Saving credentials on GitHub
 ============================
 


### PR DESCRIPTION
This PR removes a public beta warning from the GitHub Actions guide as GH actions is publically available and no longer in beta (ref https://github.blog/changelog/2019-11-11-github-actions-is-generally-available)