### PR TITLE
Update contributing purpose formatting

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -126,10 +126,8 @@ contributions to be accepted into the project.
 Purpose
 -------
 
-The purpose of the |PyPUG| is
-
-    to be the authoritative resource on how to package, publish, and install
-    Python projects using current tools.
+The purpose of the |PyPUG| is to be the authoritative resource on how to
+package, publish, and install Python projects using current tools.
 
 
 Scope


### PR DESCRIPTION
This PR contains a small update to the "Purpose" subsection of the contributing page, which is currently rendered as a block quote:

<img width="830" alt="Screen Shot 2019-11-27 at 10 47 16 PM" src="https://user-images.githubusercontent.com/11656932/69778078-927a9700-1168-11ea-8a43-5ca8361819fc.png">

Happy to close this PR if this formatting is intended