### PR TITLE
Use utf-8 to read README

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -62,7 +62,7 @@ Open :file:`setup.py` and enter the following content. Update the package name t
 
     import setuptools
 
-    with open("README.md", "r") as fh:
+    with open("README.md", "r", encoding="utf-8") as fh:
         long_description = fh.read()
 
     setuptools.setup(


### PR DESCRIPTION
On Windows, default file encoding is not UTF-8 in most environments.