### PR TITLE
Update wording, links in key projects page

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -227,12 +227,13 @@ User irc:#pypa  |
 Dev irc:#pypa-dev
 
 virtualenv is a tool which uses the command-line path environment
-variable to (like venv) create isolated Python :term:`Virtual
-Environments <Virtual Environment>`. virtualenv goes beyond venv by
-supporting Python 2.7 and by providing convenient features for
-configuring, maintaining, duplicating, and troubleshooting the virtual
-environments. For more information, see the section on :ref:`Creating
-and using Virtual Environments`.
+variable to create isolated Python :term:`Virtual Environments
+<Virtual Environment>`, much as ``venv`` does. virtualenv provides
+additional functionality, compared to ``venv``, by supporting Python
+2.7 and by providing convenient features for configuring, maintaining,
+duplicating, and troubleshooting the virtual environments. For more
+information, see the section on :ref:`Creating and using Virtual
+Environments`.
 
 
 .. _warehouse:

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -69,7 +69,7 @@ Dev irc:#pypa-dev
 
 Core utilities for Python packaging used by :ref:`pip` and :ref:`setuptools`.
 
-The core utilities in the packaging bundle handle version handling,
+The core utilities in the packaging library handle version handling,
 specifiers, markers, requirements, tags, and similar attributes and
 tasks for Python packages. Most Python users rely on this bundle
 without needing to explicitly call it; developers of the other Python

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -22,7 +22,7 @@ bandersnatch
 `Issues <https://github.com/pypa/bandersnatch/issues>`__ |
 `GitHub <https://github.com/pypa/bandersnatch>`__ |
 `PyPI <https://pypi.org/project/bandersnatch>`__ |
-Dev irc:#bandersnatch
+Dev IRC:`#bandersnatch <https://webchat.freenode.net/?channels=%23bandersnatch>`__
 
 ``bandersnatch`` is a PyPI mirroring client designed to efficiently
 create a complete mirror of the contents of PyPI. Organizations thus
@@ -68,8 +68,8 @@ packaging
 `Issues <https://github.com/pypa/packaging/issues>`__ |
 `GitHub <https://github.com/pypa/packaging>`__ |
 `PyPI <https://pypi.org/project/packaging>`__ |
-User irc:#pypa |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 Core utilities for Python packaging used by :ref:`pip` and :ref:`setuptools`.
 
@@ -101,8 +101,8 @@ pip
 `Issues <https://github.com/pypa/pip/issues>`__ |
 `GitHub <https://github.com/pypa/pip>`__ |
 `PyPI <https://pypi.org/project/pip/>`__ |
-User irc:#pypa |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 The most popular tool for installing Python packages, and the one
 included with modern versions of Python.
@@ -153,8 +153,8 @@ Python Packaging User Guide
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ |
 `Issues <https://github.com/pypa/python-packaging-user-guide/issues>`__ |
 `GitHub <https://github.com/pypa/python-packaging-user-guide>`__ |
-User irc:#pypa |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 This guide!
 
@@ -185,8 +185,8 @@ setuptools
 `Issues <https://github.com/pypa/setuptools/issues>`__ |
 `GitHub <https://github.com/pypa/setuptools>`__ |
 `PyPI <https://pypi.org/project/setuptools>`__ |
-User irc:#pypa  |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 
 setuptools (which includes ``easy_install``) is a collection of
@@ -226,8 +226,8 @@ virtualenv
 `Issues <https://github.com/pypa/virtualenv/issues>`__ |
 `GitHub <https://github.com/pypa/virtualenv>`__ |
 `PyPI <https://pypi.org/project/virtualenv/>`__ |
-User irc:#pypa  |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 virtualenv is a tool which uses the command-line path environment
 variable to create isolated Python :term:`Virtual Environments
@@ -248,7 +248,8 @@ Warehouse
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/warehouse/issues>`__ |
 `GitHub <https://github.com/pypa/warehouse>`__ |
-Dev irc:#pypa-dev
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
+
 
 
 The current codebase powering the :term:`Python Package Index
@@ -266,8 +267,8 @@ wheel
 `Issues <https://github.com/pypa/wheel/issues>`__ |
 `GitHub <https://github.com/pypa/wheel>`__ |
 `PyPI <https://pypi.org/project/wheel>`__ |
-User irc:#pypa  |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 Primarily, the wheel project offers the ``bdist_wheel`` :ref:`setuptools` extension for
 creating :term:`wheel distributions <Wheel>`.  Additionally, it offers its own
@@ -310,7 +311,7 @@ buildout
 `Issues <https://bugs.launchpad.net/zc.buildout>`__ |
 `PyPI <https://pypi.org/project/zc.buildout>`__ |
 `GitHub <https://github.com/buildout/buildout/>`__ |
-irc:#buildout
+IRC:`#buildout <https://webchat.freenode.net/?channels=%23buildout>`__
 
 Buildout is a Python-based build system for creating, assembling and deploying
 applications from multiple parts, some of which may be non-Python-based.  It
@@ -499,7 +500,7 @@ run on Raspbian use Piwheels as their primary Python package index.
     Note that Piwheels `does not yet fully support
     <https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
     thus some users have trouble installing certain wheels; this is in
-    progress.)
+    progress.
 
 .. _poetry:
 
@@ -628,8 +629,8 @@ distutils
 `Docs <https://docs.python.org/3/library/distutils.html>`__ |
 `User list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <http://bugs.python.org>`__ |
-User irc:#pypa  |
-Dev irc:#pypa-dev
+User IRC:`#pypa <https://webchat.freenode.net/?channels=%23pypa>`__ |
+Dev IRC:`#pypa-dev <https://webchat.freenode.net/?channels=%23pypa-dev>`__
 
 The original Python packaging system, added to the standard library in
 Python 2.0.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -104,7 +104,7 @@ The most popular tool for installing Python packages, and the one
 included with modern versions of Python.
 
 It provides the essential core features for finding, downloading, and
-installing packages from pypi.org and other index servers, and can be
+installing packages from PyPI and other Python package indexes, and can be
 incorporated into a wide range of development workflows via its
 command-line interface (CLI).
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -484,8 +484,8 @@ run on Raspbian use Piwheels as their primary Python package index.
 
     Note that Piwheels `does not yet fully support
 <https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
-thus some wheels have trouble with inconsistent ``Requires-Python``
-specifications.)
+thus some users have trouble installing certain wheels; this is in
+progress.)
 
 poetry
 ======

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -24,8 +24,11 @@ bandersnatch
 `PyPI <https://pypi.org/project/bandersnatch>`__ |
 Dev irc:#bandersnatch
 
-bandersnatch is a PyPI mirroring client designed to efficiently create a
-complete mirror of the contents of PyPI.
+bandersnatch is a PyPI mirroring client designed to efficiently create
+a complete mirror of the contents of PyPI. Organizations thus save
+bandwidth and latency on package downloads (especially in the context
+of automated tests) and to prevent heavily loading PyPI's Content
+Delivery Network (CDN).
 
 
 .. _distlib:
@@ -122,6 +125,13 @@ Pipenv is a project that aims to bring the best of all packaging worlds to the
 Python world. It harnesses :ref:`Pipfile`, :ref:`pip`, and :ref:`virtualenv`
 into one single toolchain. It features very pretty terminal colors.
 
+Pipenv aims to help users manage environments, dependencies, and
+imported packages on the command line. It also works well on Windows
+(which other tools often underserve), makes and checkes file hashes,
+to ensure compliance with hash-locked dependency specifiers, and eases
+uninstallation of packages and dependencies. It is used by Python
+users and system administrators, but has been less maintained since
+late 2018.
 
 .. _Pipfile:
 
@@ -150,6 +160,18 @@ This guide!
 
 .. _setuptools:
 .. _easy_install:
+
+readme_renderer
+===============
+
+`GitHub and docs <https://github.com/pypa/readme_renderer/>`__ |
+`PyPI <https://pypi.org/project/readme_renderer/>`__
+
+``readme_renderer`` is a library that package developers use to render
+their user documentation (README) files into HTML from markup
+languages such as Markdown or reStructuredText. Developers call it on
+its own or via twine, as part of their release management process, to
+check that their package descriptions will properly display on PyPI.
 
 setuptools
 ==========
@@ -204,7 +226,13 @@ virtualenv
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
-A tool for creating isolated Python environments.
+virtualenv is a tool which uses the command-line path environment
+variable to (like venv) create isolated Python :term:`Virtual
+Environments <Virtual Environment>`. virtualenv goes beyond venv by
+supporting Python 2.7 and by providing convenient features for
+configuring, maintaining, duplicating, and troubleshooting the virtual
+environments. For more information, see the section on :ref:`Creating
+and using Virtual Environments`.
 
 
 .. _warehouse:
@@ -302,9 +330,13 @@ management and deployment of binary extensions.
 
 Conda does not install packages from PyPI and can install only from
 the official Anaconda repositories, or anaconda.org (a place for
-user-contributed *conda* packages), or a local (e.g. intranet) package server.
-However, note that pip can be installed into, and work side-by-side with conda
-for managing :term:`distributions <Distribution Package>` from PyPI.
+user-contributed *conda* packages), or a local (e.g. intranet) package
+server.  However, note that pip can be installed into, and work
+side-by-side with conda for managing :term:`distributions
+<Distribution Package>` from PyPI. Also, `conda skeleton
+<https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html>`__
+is a tool to make Python packages installable by conda by first
+fetching them from PyPI and modifying their metadata.
 
 
 devpi
@@ -315,9 +347,10 @@ devpi
 `Issues <https://bitbucket.org/hpk42/devpi/issues>`__ |
 `PyPI <https://pypi.org/project/devpi>`__
 
-devpi features a powerful PyPI-compatible server and PyPI proxy cache with
-a complimentary command line tool to drive packaging, testing and release
-activities with Python.
+devpi features a powerful PyPI-compatible server and PyPI proxy cache
+with a complementary command line tool to drive packaging, testing and
+release activities with Python. devpi also provides a browsable and
+searchable web interface.
 
 
 .. _flit:
@@ -334,6 +367,14 @@ a single importable module or package at a time, using the import name as the
 name on PyPI. All subpackages and data files within a package are included
 automatically. Flit requires Python 3, but you can use it to distribute modules
 for Python 2, so long as they can be imported on Python 3.
+
+Flit provides its own implementation (instead of calling
+``distutils``, ``distlib``, or ``twine`` abstractions) of PyPI package
+upload functionality. You can use it to quickly set up package
+configuration files for simple packages (instead of manually writing a
+file that works with setuptools), and build and upload packages to
+PyPI. All wheels built by flit are reproducible, which provides added
+verifiability.
 
 enscons
 =======
@@ -360,12 +401,29 @@ Hashdist
 `Docs <https://hashdist.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/hashdist/hashdist/>`__
 
-Hashdist is a library for building non-root software distributions. Hashdist is
-trying to be “the Debian of choice for cases where Debian technology doesn’t
-work”. The best way for Pythonistas to think about Hashdist may be a more
-powerful hybrid of virtualenv and buildout.
+Hashdist is a library for building non-root software
+distributions. Hashdist is trying to be “the Debian of choice for
+cases where Debian technology doesn’t work”. The best way for
+Pythonistas to think about Hashdist may be a more powerful hybrid of
+virtualenv and buildout. It is aimed at solving the problem of
+installing scientific software, and making package distribution
+stateless, cached, and branchable. It is used by some researchers but
+has been lacking in maintenance since 2016.
 
 .. _pex:
+
+hatch
+=====
+
+`GitHub and Docs <https://github.com/ofek/hatch>`__ |
+`PyPI <https://pypi.org/project/hatch>`__
+
+Hatch is a unified command-line tool meant to conveniently manage
+dependencies and environment isolation for Python developers. Python
+package developers use Hatch to configure, version, specify
+dependencies for, and publish packages to PyPI. Under the hood, it
+uses ``Twine`` to upload packages to PyPI, and pip to download and
+install packages.
 
 pex
 ===
@@ -393,6 +451,21 @@ pipx is a tool to safely install and run Python CLI applications globally.
 
 .. _scikit-build:
 
+pip-tools
+=========
+
+`GitHub and Docs <https://github.com/jazzband/pip-tools/>`__ |
+`PyPI <https://pypi.org/project/pip-tools/>`__
+
+pip-tools is a suite of tools meant for Python system administrators
+and release managers who particularly want to keep their builds
+deterministic yet stay up to date with new versions of their
+dependencies. Users can specify particular release of their
+dependencies via hash, conveniently make a properly formatted list of
+requirements from information in other parts of their program, update
+all dependencies (a feature pip currently does not provide), and
+create layers of constraints for the program to obey.
+
 piwheels
 ========
 
@@ -418,9 +491,13 @@ poetry
 `GitHub <https://github.com/python-poetry/poetry>`__ |
 `PyPI <https://pypi.org/project/poetry/>`__
 
-poetry is a tool to handle dependency installation as well as building
-and packaging of Python packages. It uses ``pyproject.toml`` and
-provides its own dependency resolver.
+poetry is a command-line tool to handle dependency installation and
+isolation as well as building and packaging of Python packages. It
+uses ``pyproject.toml`` and provides its own dependency resolver, and,
+instead of depending on the resolver functionality within pip,
+provides its own dependency resolver. It attempts to speed users'
+experience of installation and dependency resolution by locally
+caching metadata about dependencies.
 
 pypiserver
 ==========
@@ -431,11 +508,10 @@ pypiserver
 
 pypiserver is a minimalist application that serves as a private Python
 package index within organizations, implementing a simple API and
-browser interface. Developers can upload private packages using
-standard upload tools, and users can download and install them with
-pip, without publishing them publicly. Organizations who use
-pypiserver usually download packages both from pypiserver and from
-PyPI.
+browser interface. You can upload private packages using standard
+upload tools, and users can download and install them with pip,
+without publishing them publicly. Organizations who use pypiserver
+usually download packages both from pypiserver and from PyPI.
 
 scikit-build
 ============
@@ -463,8 +539,9 @@ shiv
 `GitHub <https://github.com/linkedin/shiv>`__ |
 `PyPI <https://pypi.org/project/shiv/>`__
 
-shiv is a command line utility for building fully self contained Python zipapps as outlined in PEP
-441, but with all their dependencies included. Its primary goal is making distributing Python
+shiv is a command line utility for building fully self contained
+Python zipapps as outlined in :pep:`441`, but with all their
+dependencies included. Its primary goal is making distributing Python
 applications and command line tools fast & easy.
 
 .. _spack:
@@ -478,7 +555,7 @@ Spack
 `Slides <https://tgamblin.github.io/files/Gamblin-Spack-SC15-Talk.pdf>`__
 
 A flexible package manager designed to support multiple versions,
-configurations, platforms, and compilers.  Spack is like homebrew, but
+configurations, platforms, and compilers.  Spack is like Homebrew, but
 packages are written in Python and parameterized to allow easy
 swapping of compilers, library versions, build options,
 etc. Arbitrarily many versions of packages can coexist on the same
@@ -486,7 +563,7 @@ system. Spack was designed for rapidly building high performance
 scientific applications on clusters and supercomputers.
 
 Spack is not in PyPI (yet), but it requires no installation and can be
-used immediately after cloning from github.
+used immediately after cloning from GitHub.
 
 
 zest.releaser

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -385,7 +385,7 @@ make deployment of Python applications as simple as ``cp``.
 pipx
 ====
 
-`Docs <https://github.com/pipxproject/pipx>`__ |
+`Docs <https://pipxproject.github.io/pipx/>`__ |
 `GitHub <https://github.com/pipxproject/pipx>`__ |
 `PyPI <https://pypi.org/project/pipx/>`__
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -492,7 +492,7 @@ zest.releaser
 `GitHub <https://github.com/zestsoftware/zest.releaser/>`__ |
 `PyPI <https://pypi.org/project/zest.releaser/>`__
 
-zest.releaser is a Python package release tool providing an
+``zest.releaser`` is a Python package release tool providing an
 abstraction layer on top of twine. Python developers use zest.releaser
 to automate incrementing package version numbers, updating changelogs,
 tagging releases in source control, and uploading new packages to

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -71,7 +71,7 @@ Core utilities for Python packaging used by :ref:`pip` and :ref:`setuptools`.
 
 The core utilities in the packaging library handle version handling,
 specifiers, markers, requirements, tags, and similar attributes and
-tasks for Python packages. Most Python users rely on this bundle
+tasks for Python packages. Most Python users rely on this library
 without needing to explicitly call it; developers of the other Python
 packaging, distribution, and installation tools listed here often use
 its functionality to parse, discover, and otherwise handle dependency

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -24,11 +24,11 @@ bandersnatch
 `PyPI <https://pypi.org/project/bandersnatch>`__ |
 Dev irc:#bandersnatch
 
-bandersnatch is a PyPI mirroring client designed to efficiently create
-a complete mirror of the contents of PyPI. Organizations thus save
-bandwidth and latency on package downloads (especially in the context
-of automated tests) and to prevent heavily loading PyPI's Content
-Delivery Network (CDN).
+``bandersnatch`` is a PyPI mirroring client designed to efficiently
+create a complete mirror of the contents of PyPI. Organizations thus
+save bandwidth and latency on package downloads (especially in the
+context of automated tests) and to prevent heavily loading PyPI's
+Content Delivery Network (CDN).
 
 
 .. _distlib:
@@ -42,13 +42,14 @@ distlib
 `Bitbucket <https://bitbucket.org/pypa/distlib>`__ |
 `PyPI <https://pypi.org/project/distlib>`__
 
-Distlib is a library which implements low-level functions that relate
-to packaging and distribution of Python software.  distlib implements
-several relevant PEPs (Python Enhancement Proposal standards) and is
-useful for developers of third-party packaging tools to make and
-upload binary and source :term:`distributions <Distribution Package>`,
-achieve interoperability, resolve dependencies, manage package
-resources, and do other similar functions.
+``distlib`` is a library which implements low-level functions that
+relate to packaging and distribution of Python software.  ``distlib``
+implements several relevant PEPs (Python Enhancement Proposal
+standards) and is useful for developers of third-party packaging tools
+to make and upload binary and source :term:`distributions
+<Distribution Package>`, achieve interoperability, resolve
+dependencies, manage package resources, and do other similar
+functions.
 
 Unlike the stricter :ref:`packaging` project (below), which
 specifically implements modern Python packaging interoperability
@@ -86,8 +87,8 @@ packaging interoperability standards defined at
 sufficiently old legacy packages that are incompatible with those
 standards. In contrast, the :ref:`distlib` project is a more
 permissive library that attempts to provide a plausible reading of
-ambiguous metadata in cases where ``packaging`` will instead report on
-error.
+ambiguous metadata in cases where :ref:`packaging` will instead report
+on error.
 
 .. _pip:
 
@@ -157,9 +158,7 @@ Dev irc:#pypa-dev
 
 This guide!
 
-
-.. _setuptools:
-.. _easy_install:
+.. _readme_renderer:
 
 readme_renderer
 ===============
@@ -170,8 +169,12 @@ readme_renderer
 ``readme_renderer`` is a library that package developers use to render
 their user documentation (README) files into HTML from markup
 languages such as Markdown or reStructuredText. Developers call it on
-its own or via twine, as part of their release management process, to
-check that their package descriptions will properly display on PyPI.
+its own or via :ref:`twine`, as part of their release management
+process, to check that their package descriptions will properly
+display on PyPI.
+
+.. _setuptools:
+.. _easy_install:
 
 setuptools
 ==========
@@ -228,8 +231,8 @@ Dev irc:#pypa-dev
 
 virtualenv is a tool which uses the command-line path environment
 variable to create isolated Python :term:`Virtual Environments
-<Virtual Environment>`, much as ``venv`` does. virtualenv provides
-additional functionality, compared to ``venv``, by supporting Python
+<Virtual Environment>`, much as :ref:`venv` does. virtualenv provides
+additional functionality, compared to :ref:`venv`, by supporting Python
 2.7 and by providing convenient features for configuring, maintaining,
 duplicating, and troubleshooting the virtual environments. For more
 information, see the section on :ref:`Creating and using Virtual
@@ -248,8 +251,9 @@ Warehouse
 Dev irc:#pypa-dev
 
 
-The current codebase powering the :term:`Python Package Index (PyPI)`. It is
-hosted at `pypi.org <https://pypi.org/>`_.
+The current codebase powering the :term:`Python Package Index
+(PyPI)`. It is hosted at `pypi.org <https://pypi.org/>`_. The default
+source for :ref:`pip` downloads.
 
 
 .. _wheel:
@@ -292,8 +296,9 @@ bento
 `PyPI <https://pypi.org/project/bento>`__
 
 Bento is a packaging tool solution for Python software, targeted as an
-alternative to distutils, setuptools, distribute, etc....  Bento's philosophy is
-reproducibility, extensibility and simplicity (in that order).
+alternative to :ref:`distutils`, :ref:`setuptools`, etc....  Bento's
+philosophy is reproducibility, extensibility and simplicity (in that
+order).
 
 .. _buildout:
 
@@ -325,20 +330,21 @@ Anaconda Python is a distribution from `Anaconda, Inc
 community, and in particular on Windows where the installation of binary
 extensions is often difficult.
 
-Conda is a completely separate tool to pip, virtualenv and wheel, but provides
+Conda is a completely separate tool from :ref:`pip`, virtualenv and wheel, but provides
 many of their combined features in terms of package management, virtual environment
 management and deployment of binary extensions.
 
 Conda does not install packages from PyPI and can install only from
 the official Anaconda repositories, or anaconda.org (a place for
 user-contributed *conda* packages), or a local (e.g. intranet) package
-server.  However, note that pip can be installed into, and work
+server.  However, note that :ref:`pip` can be installed into, and work
 side-by-side with conda for managing :term:`distributions
 <Distribution Package>` from PyPI. Also, `conda skeleton
 <https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html>`__
 is a tool to make Python packages installable by conda by first
 fetching them from PyPI and modifying their metadata.
 
+.. _devpi:
 
 devpi
 =====
@@ -370,12 +376,14 @@ automatically. Flit requires Python 3, but you can use it to distribute modules
 for Python 2, so long as they can be imported on Python 3.
 
 Flit provides its own implementation (instead of calling
-``distutils``, ``distlib``, or ``twine`` abstractions) of PyPI package
+:ref:`distutils`, :ref:`distlib`, or :ref:`twine` abstractions) of PyPI package
 upload functionality. You can use it to quickly set up package
 configuration files for simple packages (instead of manually writing a
-file that works with setuptools), and build and upload packages to
+file that works with :ref:`setuptools`), and build and upload packages to
 PyPI. All wheels built by flit are reproducible, which provides added
 verifiability.
+
+.. _enscons:
 
 enscons
 =======
@@ -384,13 +392,15 @@ enscons
 `Issues <https://bitbucket.org/dholth/enscons/issues>`__ |
 `PyPI <https://pypi.org/project/enscons>`__
 
-Enscons is a Python packaging tool based on `SCons`_. It builds pip-compatible
-source distributions and wheels without using distutils or setuptools,
-including distributions with C extensions. Enscons has a different architecture
-and philosophy than distutils. Rather than adding build features to a Python
-packaging system, enscons adds Python packaging to a general purpose build
-system. Enscons helps you to build sdists that can be automatically built by
-pip, and wheels that are independent of enscons.
+Enscons is a Python packaging tool based on `SCons`_. It builds
+:ref:`pip`-compatible source distributions and wheels without using
+distutils or setuptools, including distributions with C
+extensions. Enscons has a different architecture and philosophy than
+:ref:`distutils`. Rather than adding build features to a Python
+packaging system, enscons adds Python packaging to a general purpose
+build system. Enscons helps you to build sdists that can be
+automatically built by :ref:`pip`, and wheels that are independent of
+enscons.
 
 .. _SCons: http://scons.org/
 
@@ -406,12 +416,12 @@ Hashdist is a library for building non-root software
 distributions. Hashdist is trying to be “the Debian of choice for
 cases where Debian technology doesn’t work”. The best way for
 Pythonistas to think about Hashdist may be a more powerful hybrid of
-virtualenv and buildout. It is aimed at solving the problem of
-installing scientific software, and making package distribution
-stateless, cached, and branchable. It is used by some researchers but
-has been lacking in maintenance since 2016.
+:ref:`virtualenv` and :ref:`buildout`. It is aimed at solving the
+problem of installing scientific software, and making package
+distribution stateless, cached, and branchable. It is used by some
+researchers but has been lacking in maintenance since 2016.
 
-.. _pex:
+.. _hatch:
 
 hatch
 =====
@@ -423,8 +433,10 @@ Hatch is a unified command-line tool meant to conveniently manage
 dependencies and environment isolation for Python developers. Python
 package developers use Hatch to configure, version, specify
 dependencies for, and publish packages to PyPI. Under the hood, it
-uses ``Twine`` to upload packages to PyPI, and pip to download and
+uses :ref:`twine` to upload packages to PyPI, and :ref:`pip` to download and
 install packages.
+
+.. _pex:
 
 pex
 ===
@@ -450,7 +462,7 @@ pipx
 
 pipx is a tool to safely install and run Python CLI applications globally.
 
-.. _scikit-build:
+.. _pip-tools:
 
 pip-tools
 =========
@@ -464,8 +476,10 @@ deterministic yet stay up to date with new versions of their
 dependencies. Users can specify particular release of their
 dependencies via hash, conveniently make a properly formatted list of
 requirements from information in other parts of their program, update
-all dependencies (a feature pip currently does not provide), and
+all dependencies (a feature :ref:`pip` currently does not provide), and
 create layers of constraints for the program to obey.
+
+.. _piwheels:
 
 piwheels
 ========
@@ -483,9 +497,11 @@ run on Raspbian use Piwheels as their primary Python package index.
   .. warning::
 
     Note that Piwheels `does not yet fully support
-<https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
-thus some users have trouble installing certain wheels; this is in
-progress.)
+    <https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
+    thus some users have trouble installing certain wheels; this is in
+    progress.)
+
+.. _poetry:
 
 poetry
 ======
@@ -497,10 +513,12 @@ poetry
 poetry is a command-line tool to handle dependency installation and
 isolation as well as building and packaging of Python packages. It
 uses ``pyproject.toml`` and provides its own dependency resolver, and,
-instead of depending on the resolver functionality within pip,
+instead of depending on the resolver functionality within :ref:`pip`,
 provides its own dependency resolver. It attempts to speed users'
 experience of installation and dependency resolution by locally
 caching metadata about dependencies.
+
+.. _pypiserver:
 
 pypiserver
 ==========
@@ -512,9 +530,11 @@ pypiserver
 pypiserver is a minimalist application that serves as a private Python
 package index within organizations, implementing a simple API and
 browser interface. You can upload private packages using standard
-upload tools, and users can download and install them with pip,
+upload tools, and users can download and install them with :ref:`pip`,
 without publishing them publicly. Organizations who use pypiserver
 usually download packages both from pypiserver and from PyPI.
+
+.. _scikit-build:
 
 scikit-build
 ============
@@ -568,6 +588,7 @@ scientific applications on clusters and supercomputers.
 Spack is not in PyPI (yet), but it requires no installation and can be
 used immediately after cloning from GitHub.
 
+.. _zestreleaser:
 
 zest.releaser
 =============
@@ -577,10 +598,10 @@ zest.releaser
 `PyPI <https://pypi.org/project/zest.releaser/>`__
 
 ``zest.releaser`` is a Python package release tool providing an
-abstraction layer on top of twine. Python developers use zest.releaser
-to automate incrementing package version numbers, updating changelogs,
-tagging releases in source control, and uploading new packages to
-PyPI.
+abstraction layer on top of :ref:`twine`. Python developers use
+``zest.releaser`` to automate incrementing package version numbers,
+updating changelogs, tagging releases in source control, and uploading
+new packages to PyPI.
 
 Standard Library Projects
 #########################
@@ -615,9 +636,9 @@ Python 2.0.
 
 Due to the challenges of maintaining a packaging system
 where feature updates are tightly coupled to language runtime updates,
-direct usage of ``distutils`` is now actively discouraged, with
+direct usage of :ref:`distutils` is now actively discouraged, with
 :ref:`Setuptools` being the preferred replacement. :ref:`Setuptools`
-not only provides features that plain ``distutils`` doesn't offer
+not only provides features that plain :ref:`distutils` doesn't offer
 (such as dependency declarations and entry point declarations), it
 also provides a consistent build interface and feature set across all
 supported Python versions.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -113,7 +113,7 @@ command-line interface (CLI).
 Pipenv
 ======
 
-`Docs <https://docs.pipenv.org>`__ |
+`Docs <https://docs.pipenv.org>`__ [3]_ |
 `Source <https://github.com/pypa/pipenv>`__ |
 `Issues <https://github.com/pypa/pipenv/issues>`__ |
 `PyPI <https://pypi.org/project/pipenv>`__
@@ -563,5 +563,9 @@ information, see the section on :ref:`Creating and using Virtual Environments`.
 
 .. [2] Multiple projects reuse the distutils-sig mailing list as their user list.
 
+.. [3] The pipenv docs usually live at `http://docs.pipenv.org/
+       <http://docs.pipenv.org/>`__ but that is currently an expired
+       domain name. `This temporary workaround
+       <https://pipenv.kennethreitz.org/en/latest/>`__ works.
 
 .. _distribute: https://pypi.org/project/distribute

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -401,11 +401,15 @@ piwheels
 `GitHub <https://github.com/piwheels/piwheels/>`__
 
 Piwheels is a website, and software underpinning it, that fetches
-source code distribution packages from PyPI and
-compiles them into binary wheels that are optimized for installation
-onto Raspberry Pi computers. Many Raspberry Pi users who use or
-develop Python tools to run on Raspbian use piwheels as their primary
-Python package index.
+source code distribution packages from PyPI and compiles them into
+binary wheels that are optimized for installation onto Raspberry Pi
+computers. Many Raspberry Pi users who use or develop Python tools to
+run on Raspbian use Piwheels as their primary Python package index.
+
+(Note that Piwheels `does not yet fully support
+<https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
+thus some wheels have trouble with inconsistent ``Requires-Python``
+specifications.)
 
 poetry
 ======

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -20,7 +20,7 @@ bandersnatch
 
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/bandersnatch/issues>`__ |
-`Github <https://github.com/pypa/bandersnatch>`__ |
+`GitHub <https://github.com/pypa/bandersnatch>`__ |
 `PyPI <https://pypi.org/project/bandersnatch>`__ |
 Dev irc:#bandersnatch
 
@@ -39,12 +39,17 @@ distlib
 `Bitbucket <https://bitbucket.org/pypa/distlib>`__ |
 `PyPI <https://pypi.org/project/distlib>`__
 
-Distlib is a library which implements low-level functions that relate to
-packaging and distribution of Python software.  It consists in part of the
-functions from the `distutils2 <https://pypi.org/project/Distutils2>`_
-project, which was intended to be released as ``packaging`` in the Python 3.3
-stdlib, but was removed shortly before Python 3.3 entered beta testing.
-
+Distlib is a library which implements low-level functions that relate
+to packaging and distribution of Python software.  It consists in part
+of the functions from the `distutils2
+<https://pypi.org/project/Distutils2>`_ project, which was intended to
+be released as ``packaging`` in the Python 3.3 stdlib, but was removed
+shortly before Python 3.3 entered beta testing. distlib implements
+several relevant PEPs (Python Enhancement Proposal standards) and is
+useful for developers of third-party packaging tools to make and
+upload binary and source distributions, achieve interoperability,
+resolve dependencies, manage package resources, and do other similar
+functions.
 
 .. _packaging:
 
@@ -54,13 +59,20 @@ packaging
 `Docs <https://packaging.pypa.io>`__ |
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/packaging/issues>`__ |
-`Github <https://github.com/pypa/packaging>`__ |
+`GitHub <https://github.com/pypa/packaging>`__ |
 `PyPI <https://pypi.org/project/packaging>`__ |
 User irc:#pypa |
 Dev irc:#pypa-dev
 
 Core utilities for Python packaging used by :ref:`pip` and :ref:`setuptools`.
 
+The core utilities in the packaging bundle handle version handling,
+specifiers, markers, requirements, tags, and similar attributes and
+tasks for Python packages. Most Python users rely on this bundle
+without needing to explicitly call it; developers of the other Python
+packaging, distribution, and installation tools listed here often use
+its functionality to parse, discover, and otherwise handle dependency
+attributes.
 
 .. _pip:
 
@@ -71,12 +83,13 @@ pip
 `User list <http://groups.google.com/group/python-virtualenv>`__ [1]_ |
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/pip/issues>`__ |
-`Github <https://github.com/pypa/pip>`__ |
+`GitHub <https://github.com/pypa/pip>`__ |
 `PyPI <https://pypi.org/project/pip/>`__ |
 User irc:#pypa |
 Dev irc:#pypa-dev
 
-A tool for installing Python packages.
+The most popular tool for installing Python packages, and the one
+included with modern versions of Python.
 
 
 .. _Pipenv:
@@ -112,7 +125,7 @@ Python Packaging User Guide
 `Docs <https://packaging.python.org/en/latest/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ |
 `Issues <https://github.com/pypa/python-packaging-user-guide/issues>`__ |
-`Github <https://github.com/pypa/python-packaging-user-guide>`__ |
+`GitHub <https://github.com/pypa/python-packaging-user-guide>`__ |
 User irc:#pypa |
 Dev irc:#pypa-dev
 
@@ -150,7 +163,7 @@ twine
 
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/twine/issues>`__ |
-`Github <https://github.com/pypa/twine>`__ |
+`GitHub <https://github.com/pypa/twine>`__ |
 `PyPI <https://pypi.org/project/twine>`__
 
 Twine is a utility for interacting with PyPI, that offers a secure replacement for
@@ -167,7 +180,7 @@ virtualenv
 `User list <http://groups.google.com/group/python-virtualenv>`__ |
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/virtualenv/issues>`__ |
-`Github <https://github.com/pypa/virtualenv>`__ |
+`GitHub <https://github.com/pypa/virtualenv>`__ |
 `PyPI <https://pypi.org/project/virtualenv/>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev
@@ -183,7 +196,7 @@ Warehouse
 `Docs <https://warehouse.pypa.io/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/warehouse/issues>`__ |
-`Github <https://github.com/pypa/warehouse>`__ |
+`GitHub <https://github.com/pypa/warehouse>`__ |
 Dev irc:#pypa-dev
 
 
@@ -199,15 +212,21 @@ wheel
 `Docs <https://wheel.readthedocs.io/en/latest/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/wheel/issues>`__ |
-`Github <https://github.com/pypa/wheel>`__ |
+`GitHub <https://github.com/pypa/wheel>`__ |
 `PyPI <https://pypi.org/project/wheel>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
-
 Primarily, the wheel project offers the ``bdist_wheel`` :ref:`setuptools` extension for
 creating :term:`wheel distributions <Wheel>`.  Additionally, it offers its own
 command line utility for creating and installing wheels.
+
+See also `auditwheel <https://github.com/pypa/auditwheel>`__, a tool
+that package developers use to check and fix Python packages they are
+making in the binary wheel format. It provides functionality to
+discover dependencies, check metadata for compliance, and repair the
+wheel and metadata to properly link and include external shared
+libraries in a package.
 
 
 Non-PyPA Projects
@@ -221,7 +240,7 @@ bento
 `Docs <http://cournape.github.io/Bento/>`__ |
 `Mailing list <http://librelist.com/browser/bento>`__ |
 `Issues <https://github.com/cournape/Bento/issues>`__ |
-`Github <https://github.com/cournape/Bento>`__ |
+`GitHub <https://github.com/cournape/Bento>`__ |
 `PyPI <https://pypi.org/project/bento>`__
 
 Bento is a packaging tool solution for Python software, targeted as an
@@ -320,7 +339,7 @@ Hashdist
 ========
 
 `Docs <https://hashdist.readthedocs.io/en/latest/>`__ |
-`Github <https://github.com/hashdist/hashdist/>`__
+`GitHub <https://github.com/hashdist/hashdist/>`__
 
 Hashdist is a library for building non-root software distributions. Hashdist is
 trying to be “the Debian of choice for cases where Debian technology doesn’t
@@ -333,7 +352,7 @@ pex
 ===
 
 `Docs <https://pex.readthedocs.io/en/latest/>`__ |
-`Github <https://github.com/pantsbuild/pex/>`__ |
+`GitHub <https://github.com/pantsbuild/pex/>`__ |
 `PyPI <https://pypi.org/project/pex>`__
 
 pex is both a library and tool for generating :file:`.pex` (Python EXecutable)
@@ -348,7 +367,7 @@ pipx
 ====
 
 `Docs <https://github.com/pipxproject/pipx>`__ |
-`Github <https://github.com/pipxproject/pipx>`__ |
+`GitHub <https://github.com/pipxproject/pipx>`__ |
 `PyPI <https://pypi.org/project/pipx/>`__
 
 pipx is a tool to safely install and run Python CLI applications globally.
@@ -360,7 +379,7 @@ scikit-build
 
 `Docs <https://scikit-build.readthedocs.io/en/latest/>`__ |
 `Mailing list <https://groups.google.com/forum/#!forum/scikit-build>`__ |
-`Github <https://github.com/scikit-build/scikit-build/>`__ |
+`GitHub <https://github.com/scikit-build/scikit-build/>`__ |
 `PyPI <https://pypi.org/project/scikit-build>`__
 
 Scikit-build is an improved build system generator for CPython
@@ -378,11 +397,11 @@ shiv
 ====
 
 `Docs <https://shiv.readthedocs.io/en/latest/>`__ |
-`Github <https://github.com/linkedin/shiv>`__ |
+`GitHub <https://github.com/linkedin/shiv>`__ |
 `PyPI <https://pypi.org/project/shiv/>`__
 
 shiv is a command line utility for building fully self contained Python zipapps as outlined in PEP
-441, but with all their dependencies included. It's primary goal is making distributing Python
+441, but with all their dependencies included. Its primary goal is making distributing Python
 applications and command line tools fast & easy.
 
 .. _spack:
@@ -390,8 +409,8 @@ applications and command line tools fast & easy.
 Spack
 =====
 
-`Docs <http://software.llnl.gov/spack/>`__ |
-`Github <https://github.com/llnl/spack/>`__ |
+`Docs <https://spack.readthedocs.io/>`__ |
+`GitHub <https://github.com/llnl/spack/>`__ |
 `Paper <http://www.computer.org/csdl/proceedings/sc/2015/3723/00/2807623.pdf>`__ |
 `Slides <https://tgamblin.github.io/files/Gamblin-Spack-SC15-Talk.pdf>`__
 
@@ -435,7 +454,7 @@ distutils
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
-A package in the Python Standard Library that has support for creating and
+A module in the Python Standard Library that has support for creating and
 installing :term:`distributions <Distribution Package>`. :ref:`Setuptools`
 provides enhancements to distutils, and is much more commonly used than just
 using distutils by itself.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -40,16 +40,19 @@ distlib
 `PyPI <https://pypi.org/project/distlib>`__
 
 Distlib is a library which implements low-level functions that relate
-to packaging and distribution of Python software.  It consists in part
-of the functions from the `distutils2
-<https://pypi.org/project/Distutils2>`_ project, which was intended to
-be released as ``packaging`` in the Python 3.3 stdlib, but was removed
-shortly before Python 3.3 entered beta testing. distlib implements
+to packaging and distribution of Python software.  distlib implements
 several relevant PEPs (Python Enhancement Proposal standards) and is
 useful for developers of third-party packaging tools to make and
-upload binary and source distributions, achieve interoperability,
-resolve dependencies, manage package resources, and do other similar
-functions.
+upload binary and source :term:`distributions <Distribution Package>`,
+achieve interoperability, resolve dependencies, manage package
+resources, and do other similar functions.
+
+Unlike the stricter :ref:`packaging` project (below), which
+specifically implements modern Python packaging interoperability
+standards, ``distlib`` also attempts to provide reasonable fallback
+behaviours when asked to handle legacy packages and metadata that
+predate the modern interoperability standards and fall into the subset
+of packages that are incompatible with those standards.
 
 .. _packaging:
 
@@ -74,6 +77,15 @@ packaging, distribution, and installation tools listed here often use
 its functionality to parse, discover, and otherwise handle dependency
 attributes.
 
+This project specifically focuses on implementing the modern Python
+packaging interoperability standards defined at
+:ref:`packaging-specifications`, and will report errors for
+sufficiently old legacy packages that are incompatible with those
+standards. In contrast, the :ref:`distlib` project is a more
+permissive library that attempts to provide a plausible reading of
+ambiguous metadata in cases where ``packaging`` will instead report on
+error.
+
 .. _pip:
 
 pip
@@ -91,6 +103,10 @@ Dev irc:#pypa-dev
 The most popular tool for installing Python packages, and the one
 included with modern versions of Python.
 
+It provides the essential core features for finding, downloading, and
+installing packages from pypi.org and other index servers, and can be
+incorporated into a wide range of development workflows via its
+command-line interface (CLI).
 
 .. _Pipenv:
 
@@ -148,9 +164,10 @@ User irc:#pypa  |
 Dev irc:#pypa-dev
 
 
-setuptools (which includes ``easy_install``) is a collection of enhancements to
-the Python distutils that allow you to more easily build and distribute Python
-distributions, especially ones that have dependencies on other packages.
+setuptools (which includes ``easy_install``) is a collection of
+enhancements to the Python distutils that allow you to more easily
+build and distribute Python :term:`distributions <Distribution
+Package>`, especially ones that have dependencies on other packages.
 
 `distribute`_ was a fork of setuptools that was merged back into setuptools (in
 v0.7), thereby making setuptools the primary choice for Python packaging.
@@ -166,9 +183,11 @@ twine
 `GitHub <https://github.com/pypa/twine>`__ |
 `PyPI <https://pypi.org/project/twine>`__
 
-Twine is a utility for interacting with PyPI, that offers a secure replacement for
-``setup.py upload``.
-
+Twine is the primary tool developers use to upload packages to the
+Python Package Index or other Python package indexes. It is a
+command-line program that passes program files and metadata to a web
+API. Developers use it because it's the official PyPI upload tool,
+it's fast and secure, it's maintained, and it reliably works.
 
 
 .. _virtualenv:
@@ -454,10 +473,17 @@ distutils
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
-A module in the Python Standard Library that has support for creating and
-installing :term:`distributions <Distribution Package>`. :ref:`Setuptools`
-provides enhancements to distutils, and is much more commonly used than just
-using distutils by itself.
+The original Python packaging system, added to the standard library in
+Python 2.0.
+
+Due to the challenges of maintaining a packaging system
+where feature updates are tightly coupled to language runtime updates,
+direct usage of ``distutils`` is now actively discouraged, with
+:ref:`Setuptools` being the preferred replacement. :ref:`Setuptools`
+not only provides features that plain ``distutils`` doesn't offer
+(such as dependency declarations and entry point declarations), it
+also provides a consistent build interface and feature set across all
+supported Python versions.
 
 
 .. _venv:

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -401,7 +401,7 @@ piwheels
 `GitHub <https://github.com/piwheels/piwheels/>`__
 
 Piwheels is a website, and software underpinning it, that fetches
-source code distribution packages from the Python Package Index and
+source code distribution packages from PyPI and
 compiles them into binary wheels that are optimized for installation
 onto Raspberry Pi computers. Many Raspberry Pi users who use or
 develop Python tools to run on Raspbian use piwheels as their primary

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -304,7 +304,7 @@ Conda does not install packages from PyPI and can install only from
 the official Anaconda repositories, or anaconda.org (a place for
 user-contributed *conda* packages), or a local (e.g. intranet) package server.
 However, note that pip can be installed into, and work side-by-side with conda
-for managing distributions from PyPI.
+for managing :term:`distributions <Distribution Package>` from PyPI.
 
 
 devpi
@@ -393,6 +393,46 @@ pipx is a tool to safely install and run Python CLI applications globally.
 
 .. _scikit-build:
 
+piwheels
+========
+
+`Website <https://piwheels.org/>`__ |
+`Docs <https://piwheels.readthedocs.io/>`__ |
+`GitHub <https://github.com/piwheels/piwheels/>`__
+
+Piwheels is a website, and software underpinning it, that fetches
+source code distribution packages from the Python Package Index and
+compiles them into binary wheels that are optimized for installation
+onto Raspberry Pi computers. Many Raspberry Pi users who use or
+develop Python tools to run on Raspbian use piwheels as their primary
+Python package index.
+
+poetry
+======
+
+`Docs <https://python-poetry.org/>`__ |
+`GitHub <https://github.com/python-poetry/poetry>`__ |
+`PyPI <https://pypi.org/project/poetry/>`__
+
+poetry is a tool to handle dependency installation as well as building
+and packaging of Python packages. It uses ``pyproject.toml`` and
+provides its own dependency resolver.
+
+pypiserver
+==========
+
+`Docs <https://github.com/pypiserver/pypiserver/blob/master/README.rst>`__ |
+`GitHub <https://github.com/pypiserver/pypiserver>`__ |
+`PyPI <https://pypi.org/project/pypiserver/>`__
+
+pypiserver is a minimalist application that serves as a private Python
+package index within organizations, implementing a simple API and
+browser interface. Developers can upload private packages using
+standard upload tools, and users can download and install them with
+pip, without publishing them publicly. Organizations who use
+pypiserver usually download packages both from pypiserver and from
+PyPI.
+
 scikit-build
 ============
 
@@ -444,6 +484,19 @@ scientific applications on clusters and supercomputers.
 Spack is not in PyPI (yet), but it requires no installation and can be
 used immediately after cloning from github.
 
+
+zest.releaser
+=============
+
+`Docs <https://zestreleaser.readthedocs.io/en/latest/>`__ |
+`GitHub <https://github.com/zestsoftware/zest.releaser/>`__ |
+`PyPI <https://pypi.org/project/zest.releaser/>`__
+
+zest.releaser is a Python package release tool providing an
+abstraction layer on top of twine. Python developers use zest.releaser
+to automate incrementing package version numbers, updating changelogs,
+tagging releases in source control, and uploading new packages to
+PyPI.
 
 Standard Library Projects
 #########################

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -479,7 +479,9 @@ binary wheels that are optimized for installation onto Raspberry Pi
 computers. Many Raspberry Pi users who use or develop Python tools to
 run on Raspbian use Piwheels as their primary Python package index.
 
-(Note that Piwheels `does not yet fully support
+  .. warning::
+
+    Note that Piwheels `does not yet fully support
 <https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
 thus some wheels have trouble with inconsistent ``Requires-Python``
 specifications.)

--- a/source/specifications/index.rst
+++ b/source/specifications/index.rst
@@ -1,3 +1,5 @@
+.. _`packaging-specifications`:
+
 PyPA specifications
 ###################
 


### PR DESCRIPTION
A few link fixes, clearer explanations regarding wheel, packaging, pip, and distlib, and a few wording/capitalization fixes.