### PR TITLE
Don't show full URL to gh-action-pypi-publish in anchor text

### DIFF
--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -8,7 +8,7 @@ popular choice is having a workflow that's triggered by a
 ``push`` event.
 This guide shows you how to publish a Python distribution
 whenever a tagged commit is pushed.
-It will use the `pypa/gh-action-pypi-publish GitHub Action`_ https://github.com/marketplace/actions/pypi-publish
+It will use the `pypa/gh-action-pypi-publish GitHub Action <https://github.com/marketplace/actions/pypi-publish>`_.
 
 .. attention::
 

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -8,7 +8,7 @@ popular choice is having a workflow that's triggered by a
 ``push`` event.
 This guide shows you how to publish a Python distribution
 whenever a tagged commit is pushed.
-It will use the `pypa/gh-action-pypi-publish GitHub Action <https://github.com/marketplace/actions/pypi-publish>`_.
+It will use the `pypa/gh-action-pypi-publish GitHub Action`_.
 
 .. attention::
 


### PR DESCRIPTION
The current guide links to [pypa/gh-action-pypi-publish](https://github.com/marketplace/actions/py-package-publish) with both the name and URL in the link text. This is unnecessary, as you can mouseover the link to see the full URL anyway. This commit improves readability by removing the URL portion from the link text.

This is what the [web version of the guide](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) currently looks like:

>It will use the [pypa/gh-action-pypi-publish GitHub Action https://github.com/marketplace/actions/pypi-publish](https://github.com/marketplace/actions/pypi-publish)

This commit changes it to:

>It will use the [pypa/gh-action-pypi-publish GitHub Action](https://github.com/marketplace/actions/pypi-publish).