### PR TITLE
Organize index of guides into 3 categories

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -7,13 +7,18 @@ introduction to packaging, see :doc:`/tutorials/index`.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Installing Packages:
 
-   tool-recommendations
    installing-using-pip-and-virtual-environments
    installing-stand-alone-command-line-tools
    installing-using-linux-tools
    installing-scientific-packages
    multi-version-installs
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Building and Publishing Projects:
+
    distributing-packages-using-setuptools
    using-manifest-in
    single-sourcing-package-version
@@ -23,10 +28,16 @@ introduction to packaging, see :doc:`/tutorials/index`.
    supporting-windows-using-appveyor
    packaging-namespace-packages
    creating-and-discovering-plugins
-   analyzing-pypi-package-downloads
-   index-mirrors-and-caches
-   hosting-your-own-index
    migrating-to-pypi-org
    using-testpypi
    making-a-pypi-friendly-readme
    publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Miscellaneous:
+
+   tool-recommendations
+   analyzing-pypi-package-downloads
+   index-mirrors-and-caches
+   hosting-your-own-index

--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -14,6 +14,8 @@ introduction to packaging, see :doc:`/tutorials/index`.
    installing-using-linux-tools
    installing-scientific-packages
    multi-version-installs
+   index-mirrors-and-caches
+   hosting-your-own-index
 
 .. toctree::
    :maxdepth: 1
@@ -39,5 +41,3 @@ introduction to packaging, see :doc:`/tutorials/index`.
 
    tool-recommendations
    analyzing-pypi-package-downloads
-   index-mirrors-and-caches
-   hosting-your-own-index


### PR DESCRIPTION
Split the toctree of guides into three broad categories:

- Installing Packages
    - Includes guides for installing and managing dependencies.
- Building and Publishing Projects
    - Includes guides for project configuration, distribution
- Miscellaneous
    - Guides that do not clearly fit into any of the above

This commit primarily affects the Guides index page; it does not create nested lists for each category in the sidebar.