### PR TITLE
Explain why README.md should be added to sdist

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -310,6 +310,13 @@ if you'd like.
     to write your content.
 
 
+Because our build script loads :file:`README.md` to provide a ``long_description``
+for :func:`setup`, the :file:`README.md` must be included along with your code
+when you `generate a source distribution <generating archives>`_.
+:ref:`setuptools` 36.4.0 or above will automatically include :file:`README.md`
+if it exists.
+
+
 Creating a LICENSE
 ------------------
 


### PR DESCRIPTION
~~Update sample setup.py to correctly load README.md when cwd is not the same directory that setup.py lives in (discussed in #696). The updated README-loading code is for Python 3+. Since Python 2 has been deprecated, it is probably safe to assume that anyone reading this guide is most likely using Python 3.~~ The guide has been updated significantly since the inception of this PR, which obviates the `setup.py` changes. Also see https://github.com/pypa/packaging.python.org/pull/711#issuecomment-783835643

Also explain why README.md should be added to the package (discussed in #696).