### PR TITLE
Suggest read_version library for single-sourcing option #1

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -34,7 +34,10 @@ number of your project:
 
     .. note::
 
-        This technique has the disadvantage of having to deal with complexities of regular expressions.
+        This technique has the disadvantage of having to deal with the
+        complexities of regular expressions.  The `read_version
+        <https://pypi.org/project/read_version>`_ library provides a function
+        that does this for you.
 
 #.  Use an external build tool that either manages updating both locations, or
     offers an API that both locations can use.


### PR DESCRIPTION
This PR adds a note to the regex-based option for single-sourcing project versions that the `read_version` library provides a function that takes care of the logic for you.

Full disclosure: I am the author of `read_version`.