### PR TITLE
packaging-projects tutorial: Update find_packages call to exclude tests folder

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -81,7 +81,7 @@ Open :file:`setup.py` and enter the following content. Update the package name t
         long_description=long_description,
         long_description_content_type="text/markdown",
         url="https://github.com/pypa/sampleproject",
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=('tests', 'tests.*')),
         classifiers=[
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Without this, the test suite could be globally installed in site-packages, as `import tests`.