### PR TITLE
Replace repo URLs with defaults

### DIFF
--- a/source/guides/using-testpypi.rst
+++ b/source/guides/using-testpypi.rst
@@ -23,15 +23,12 @@ https://test.pypi.org/account/register/ to register your account.
 Using TestPyPI with Twine
 -------------------------
 
-You can upload your distributions to TestPyPI using :ref:`twine` by passing
-in the ``--repository-url`` flag
+You can upload your distributions to TestPyPI using :ref:`twine` by specifying
+the ``--repository`` flag
 
 .. code::
 
-    $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-
-The ``legacy`` in the URL above refers to the legacy API for PyPI, which may
-change as the Warehouse project progresses.
+    $ twine upload --repository testpypi dist/*
 
 You can see if your package has successfully uploaded by navigating to the URL
 ``https://test.pypi.org/project/<sampleproject>`` where ``sampleproject`` is
@@ -59,29 +56,16 @@ you're testing has dependencies:
 Setting up TestPyPI in pypirc
 -----------------------------
 
-If you want to avoid entering the TestPyPI url and your username
-you can configure TestPyPI in your ``$HOME/.pypirc``.
+If you want to avoid entering your username, you can configure TestPyPI in
+your ``$HOME/.pypirc``.
 
 Create or modify ``$HOME/.pypirc`` with the following:
 
 .. code::
 
-    [distutils]
-    index-servers=
-        pypi
-        testpypi
-
     [testpypi]
-    repository: https://test.pypi.org/legacy/
     username: your testpypi username
 
 
 .. Warning:: Do not store passwords in the pypirc file.
     Storing passwords in plain text is never a good idea.
-
-You can then tell :ref:`twine` to upload to TestPyPI by specifying the
-``--repository`` flag:
-
-.. code::
-
-    $ twine upload --repository testpypi dist/*

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -261,7 +261,7 @@ Once installed, run Twine to upload all of the archives under :file:`dist`:
 
 .. code-block:: bash
 
-    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    python3 -m twine upload --repository testpypi dist/*
 
 You will be prompted for a username and password. For the username,
 use ``__token__``. For the password, use the token value, including
@@ -346,7 +346,7 @@ differences:
   main server.
 * Use ``twine upload dist/*`` to upload your package and enter your credentials
   for the account you registered on the real PyPI.  Now that you're uploading
-  the package in production, you don't need to specify ``--repository-url``; the
+  the package in production, you don't need to specify ``--repository``; the
   package will upload to https://pypi.org/ by default.
 * Install your package from the real PyPI using ``pip install [your-package]``.
 


### PR DESCRIPTION
Since Twine provides defaults for `pypi` and `testpypi`, it seems friendlier (and more maintainable) to rely on those, instead of the `/legacy` URLs. I made a similar change in https://github.com/pypa/twine/pull/592.

I didn't update the [migrating to pypi.org doc](https://github.com/pypa/packaging.python.org/blob/master/source/guides/migrating-to-pypi-org.rst), partially because I'm assuming it's less relevant, but also because the explicit URLs felt like useful information.