### PR TITLE
Update pipenv docs link and remove related footnote

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -117,7 +117,7 @@ command-line interface (CLI).
 Pipenv
 ======
 
-`Docs <https://docs.pipenv.org>`__ [3]_ |
+`Docs <https://pipenv.pypa.io/>`__ |
 `Source <https://github.com/pypa/pipenv>`__ |
 `Issues <https://github.com/pypa/pipenv/issues>`__ |
 `PyPI <https://pypi.org/project/pipenv>`__
@@ -662,10 +662,5 @@ information, see the section on :ref:`Creating and using Virtual Environments`.
        the virtualenv mailing list, and it's stuck ever since.
 
 .. [2] Multiple projects reuse the distutils-sig mailing list as their user list.
-
-.. [3] The pipenv docs usually live at `http://docs.pipenv.org/
-       <http://docs.pipenv.org/>`__ but that is currently an expired
-       domain name. `This temporary workaround
-       <https://pipenv.kennethreitz.org/en/latest/>`__ works.
 
 .. _distribute: https://pypi.org/project/distribute


### PR DESCRIPTION
The pipenv "Docs" link points to an expired domain (pipenv.org). This problem is acknowledged in a footnote. 

Since there now looks to be a stable official home for the docs at https://pipenv.pypa.io/ this PR proposes that the "Docs" link point there directly.

The footnote, made superfluous by the working "Docs" link, is removed.