### PR TITLE
Remove pipenv "state of project" caveat

### DIFF
--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -26,31 +26,6 @@ as Python libraries, should also consider the
 `poetry <https://github.com/python-poetry/poetry>`_ project as an alternative dependency
 management solution.
 
-
-Recommendation caveats (as of April 2020)
------------------------------------------
-
-While this tutorial covers the ``pipenv`` project as a tool that focuses
-primarily on the needs of Python application development rather than Python
-library development, the project itself is currently working through several
-`process and maintenance issues <https://github.com/pypa/pipenv/issues/3369>`_
-that are preventing bug fixes and new features from being published (with the
-entirety of 2019 passing without a new release).
-
-This means that in the near term, ``pipenv`` still suffers from several quirks
-and performance problems without a clear timeline for resolution of those isses.
-
-While this remains the case, project maintainers are likely to want to
-investigate :ref:`other-dependency-management-tools` for use instead of, or
-together with, ``pipenv``.
-
-Assuming the April 2020 ``pipenv`` release goes ahead as planned, and the
-release after that also remains on track, then this caveat on the tutorial will
-be removed. If those releases *don't* remain on track, then the tutorial itself
-will be removed, and replaced with a discussion page on the available dependency
-management options.
-
-
 Installing Pipenv
 -----------------
 
@@ -65,6 +40,12 @@ Use ``pip`` to install Pipenv:
 .. code-block:: python
 
     pip install --user pipenv
+
+At present, the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_ is in pre-release stage after a long hiatus. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try installing the pre-release by specifying the version in `pip` as follows:
+
+.. code-block:: python
+
+    pip install pipenv==2020.4.1b2
 
 .. _pipenv-user-base:
 

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -26,22 +26,6 @@ as Python libraries, should also consider the
 `poetry <https://github.com/python-poetry/poetry>`_ project as an alternative dependency
 management solution.
 
-Recommendation caveats (circa June 2020)	
------------------------------------------	
-
-At present, the ``pipenv`` project team is `staging multiple bug fixes and features <https://github.com/pypa/pipenv/issues/3369>`_, so the tool continues to suffer from several quirks and performance problems. The latest updates are in pre-release stage after long hiatus.
-
-Because of these issues, you may find you need to troubleshoot the tool itself. While this tutorial covers ``pipenv`` for Python *application* development, troubleshooting necessitates thinking of ``pipenv`` itself as a *library* in development. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_. In such a case, you would install the pre-release by specifying the version string in `pip` as follows:
-
-.. code-block:: python
-
-    pip install pipenv==2020.4.1b2
-
-Alternatively, project maintainers may want to investigate :ref:`other-dependency-management-tools` for use instead or	
-alongside ``pipenv``.
-
-The above caveat on the tutorial will remain until the most recent ``pipenv`` is a stable release.
-
 Installing Pipenv
 -----------------
 

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -26,6 +26,22 @@ as Python libraries, should also consider the
 `poetry <https://github.com/python-poetry/poetry>`_ project as an alternative dependency
 management solution.
 
+Recommendation caveats (circa June 2020)	
+-----------------------------------------	
+
+At present, the ``pipenv`` project team is `staging multiple bug fixes and features <https://github.com/pypa/pipenv/issues/3369>`_, so the tool continues to suffer from several quirks and performance problems. The latest updates are in pre-release stage after long hiatus in its project activity.
+
+Because of these issues, you may find you need to troubleshoot the tool itself. While this tutorial covers ``pipenv`` project as a tool for Python *application* development, the abovementioned troubleshooting may necessitate thinking of ``pipenv`` itself as a *library* in development. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_. In such a case, you may want to install the pre-release by specifying the version string in `pip` as follows:
+
+.. code-block:: python
+
+    pip install pipenv==2020.4.1b2
+
+Alternatively, project maintainers may want to investigate :ref:`other-dependency-management-tools` for use instead or	
+alongside ``pipenv``.
+
+The above caveat on the tutorial will remain until the most recent ``pipenv`` is a stable release.
+
 Installing Pipenv
 -----------------
 
@@ -40,12 +56,6 @@ Use ``pip`` to install Pipenv:
 .. code-block:: python
 
     pip install --user pipenv
-
-At present, the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_ is in pre-release stage after a long hiatus. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try installing the pre-release by specifying the version in `pip` as follows:
-
-.. code-block:: python
-
-    pip install pipenv==2020.4.1b2
 
 .. _pipenv-user-base:
 

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -29,9 +29,9 @@ management solution.
 Recommendation caveats (circa June 2020)	
 -----------------------------------------	
 
-At present, the ``pipenv`` project team is `staging multiple bug fixes and features <https://github.com/pypa/pipenv/issues/3369>`_, so the tool continues to suffer from several quirks and performance problems. The latest updates are in pre-release stage after long hiatus in its project activity.
+At present, the ``pipenv`` project team is `staging multiple bug fixes and features <https://github.com/pypa/pipenv/issues/3369>`_, so the tool continues to suffer from several quirks and performance problems. The latest updates are in pre-release stage after long hiatus.
 
-Because of these issues, you may find you need to troubleshoot the tool itself. While this tutorial covers ``pipenv`` project as a tool for Python *application* development, the abovementioned troubleshooting may necessitate thinking of ``pipenv`` itself as a *library* in development. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_. In such a case, you may want to install the pre-release by specifying the version string in `pip` as follows:
+Because of these issues, you may find you need to troubleshoot the tool itself. While this tutorial covers ``pipenv`` for Python *application* development, troubleshooting necessitates thinking of ``pipenv`` itself as a *library* in development. If you run into a bug that `appears to be addressed <https://github.com/pypa/pipenv/releases/latest>`_ by the latest preview version, you may want to try the `latest Pipenv <https://pypi.org/project/pipenv/#history>`_. In such a case, you would install the pre-release by specifying the version string in `pip` as follows:
 
 .. code-block:: python
 


### PR DESCRIPTION
The pipenv team hit their April and May release targets, so the caveat about the seeming impasse of pipenv development no longer applies. However, it may benefit the user to know that the early access version of the package is available as pre-release in `pip`.