### PR TITLE
Update link to now-decommissioned mailing list

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -128,11 +128,14 @@ Glossary
 
     Python Packaging Authority (PyPA)
 
-        PyPA is a working group that maintains many of the relevant projects in
-        Python packaging. They maintain a site at https://www.pypa.io, host projects
-        on `github <https://github.com/pypa>`_ and `bitbucket
-        <https://bitbucket.org/pypa>`_, and discuss issues on the `pypa-dev
-        mailing list <https://groups.google.com/forum/#!forum/pypa-dev>`_.
+        PyPA is a working group that maintains many of the relevant
+        projects in Python packaging. They maintain a site at
+        https://www.pypa.io, host projects on `GitHub
+        <https://github.com/pypa>`_ and `Bitbucket
+        <https://bitbucket.org/pypa>`_, and discuss issues on the
+        `distutils-sig mailing list
+        <https://mail.python.org/mailman3/lists/distutils-sig.python.org/>`_
+	and `the Python Discourse forum <https://discuss.python.org/c/packaging>`__.
 
 
     Python Package Index (PyPI)

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -122,8 +122,8 @@ Glossary
 
     Pure Module
 
-        A :term:`module` written in Python and contained in a single .py file (and
-        possibly associated .pyc and/or .pyo files).
+        A :term:`module` written in Python and contained in a single `.py` file (and
+        possibly associated `.pyc` and/or `.pyo` files).
 
 
     Python Packaging Authority (PyPA)


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ , pointing to distutils-sig and Discourse instead.