### PR TITLE
Improve sample author email and name in guide

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -251,8 +251,8 @@ author
 
 ::
 
-  author='The Python Packaging Authority',
-  author_email='pypa-dev@googlegroups.com',
+  author='A. Random Developer',
+  author_email='author@example.com',
 
 Provide details about the author.
 


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ
the pypa-dev Google Group is now decommissioned.
Using this opportunity to, as in
pypa/sampleproject#118, improve the example
author name and email address.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>