### PR TITLE
Update Packaging Python Project Tutorial

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -36,8 +36,8 @@ Creating the package files
 --------------------------
 
 You will now create a handful of files to package up this project and prepare it
-for distribution. Create the new files listed below - you will add content to
-them in the following steps.
+for distribution. Create the new files listed below and place them in the project's root directory
+- you will add content to them in the following steps.
 
 .. code-block:: text
 


### PR DESCRIPTION
Update the `Packaging Python Project` tutorial to specify the target location of the newly added package files (`tests/`, `setup.py`, `README` and `LICENSE`) to the project's root directory to remove confusion of the folder structure.