### PR TITLE
Add trove-classifiers to key projects

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -209,18 +209,18 @@ trove-classifiers
 
 trove-classifiers is the canonical source for `classifiers on PyPI
 <https://pypi.org/classifiers/>`_, which project maintainers use to
-`sytematically describe there projects
+`systematically describe their projects
 <https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`_
 so that users can better find projects that match their needs on the PyPI.
 
 The trove-classifiers package contains a list of valid classifiers and
-deprecated classifiers(which are paired with the classifiers that replace
+deprecated classifiers (which are paired with the classifiers that replace
 them).  Use this package to validate classifiers used in packages intended for
-uploading to the PyPI. As this list of classifiers is published as code, you
-can script using it, providing you with a more convenient workflow compared to
+uploading to PyPI. As this list of classifiers is published as code, you
+can install and import it, giving you a more convenient workflow compared to
 referring to the `list published on PyPI <https://pypi.org/classifiers/>`_. The
 `issue tracker <https://github.com/pypa/trove-classifiers/issues>`_ for the
-project hosts discussions on classifiers such as requests for adding new
+project hosts discussions on proposed classifiers and requests for new
 classifiers.
 
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -198,6 +198,32 @@ Package>`, especially ones that have dependencies on other packages.
 v0.7), thereby making setuptools the primary choice for Python packaging.
 
 
+.. _trove-classifiers:
+
+trove-classifiers
+=================
+
+`Issues <https://github.com/pypa/trove-classifiers/issues>`__ | `GitHub
+<https://github.com/pypa/trove-classifiers>`__ | `PyPI
+<https://pypi.org/project/trove-classifiers/>`__
+
+trove-classifiers is the canonical source for `classifiers on PyPI
+<https://pypi.org/classifiers/>`_, which project maintainers use to
+`sytematically describe there projects
+<https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`_
+so that users can better find projects that match their needs on the PyPI.
+
+The trove-classifiers package contains a list of valid classifiers and
+deprecated classifiers(which are paired with the classifiers that replace
+them).  Use this package to validate classifiers used in packages intended for
+uploading to the PyPI. As this list of classifiers is published as code, you
+can script using it, providing you with a more convenient workflow compared to
+referring to the `list published on PyPI <https://pypi.org/classifiers/>`_. The
+`issue tracker <https://github.com/pypa/trove-classifiers/issues>`_ for the
+project hosts discussions on classifiers such as requests for adding new
+classifiers.
+
+
 .. _twine:
 
 twine


### PR DESCRIPTION
Add a description of the trove-classifiers package to the list of key projects. Closes #714.

I've made an assumption in writing the description: that readers wont know what classifiers are, and that it wont be immediately obvious(without reading the trove-classfier README) to them why you'd have a package for it instead of using the list of classifiers published on the PyPI. I copied a line off of #714 to explain what a classifier is, and suggested why you'd want to use troves-classifier(its python code, and a repo gets you an issue tracker). Do these make sense?

Any feedback (on style too)?