### PR TITLE
Mention enhanced attr: directive in single-sourcing option #1

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -42,12 +42,13 @@ number of your project:
        .. code-block:: ini
 
            [metadata]
-           version = attr:package.__version__
+           version = attr: package.__version__
 
        Earlier versions of setuptools implemented the ``attr:`` directive by
        importing the module, but setuptools 46.4.0 added rudimentary AST
        analysis so that ``attr:`` can function without having to import any of
        the package's dependencies.
+
 
 #.  Use an external build tool that either manages updating both locations, or
     offers an API that both locations can use.

--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -33,6 +33,21 @@ number of your project:
            ...
         )
 
+    .. note::
+
+       As of the release of setuptools 46.4.0, one can accomplish the same
+       thing by instead placing the following in the project's ``setup.cfg``
+       file (replacing "package" with the import name of the package):
+
+       .. code-block:: ini
+
+           [metadata]
+           version = attr:package.__version__
+
+       Earlier versions of setuptools implemented the ``attr:`` directive by
+       importing the module, but setuptools 46.4.0 added rudimentary AST
+       analysis so that ``attr:`` can function without having to import any of
+       the package's dependencies.
 
 #.  Use an external build tool that either manages updating both locations, or
     offers an API that both locations can use.


### PR DESCRIPTION
This PR adds a note to the `setup.py`-parsing option for single-sourcing project versions that setuptools' `attr:` directive does the same thing (without importing dependencies) starting in version 46.4.0.