### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Code of Conduct
 
 Everyone interacting in the Python Packaging User Guide project's codebases,
 issue trackers, chat rooms, and mailing lists are expected to follow the
-`PyPA Code of Conduct`_.
+`PSF Code of Conduct`_.
 
-.. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. _PSF Code of Conduct: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
 
 Contributing
 ------------

--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -21,11 +21,11 @@ the guide, please read the :ref:`style guide <contributing_style_guide>`.
 .. __: https://github.com/pypa/python-packaging-user-guide/issues
 .. __: https://github.com/pypa/python-packaging-user-guide/pulls
 
-By contributing to the |PyPUG|, you're expected to follow the Python Packaging
-Authority's `Contributor Code of Conduct`__. Harassment, personal attacks, and
+By contributing to the |PyPUG|, you're expected to follow the PSF's
+`Code of Conduct`__. Harassment, personal attacks, and
 other unprofessional conduct are not acceptable.
 
-.. __: https://www.pypa.io/en/latest/code-of-conduct/
+.. __: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
 
 
 Documentation types

--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -22,8 +22,7 @@ the guide, please read the :ref:`style guide <contributing_style_guide>`.
 .. __: https://github.com/pypa/python-packaging-user-guide/pulls
 
 By contributing to the |PyPUG|, you're expected to follow the PSF's
-`Code of Conduct`__. Harassment, personal attacks, and
-other unprofessional conduct are not acceptable.
+`Code of Conduct`__.
 
 .. __: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
 


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745