### PR TITLE
specifications: Requires-Python doesn't accept an environment marker

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -477,14 +477,13 @@ picking which version of a project to install.
 
 The value must be in the format specified in :doc:`version-specifiers`.
 
-This field may be followed by an environment marker after a semicolon.
+This field cannot be followed by an environment marker.
 
 Examples::
 
     Requires-Python: >=3
     Requires-Python: >2.6,!=3.0.*,!=3.1.*
     Requires-Python: ~=2.6
-    Requires-Python: >=3; sys_platform == 'win32'
 
 
 Requires-External (multiple use)


### PR DESCRIPTION
Cf https://github.com/pypa/setuptools/issues/1876 for context and https://github.com/pypa/setuptools/issues/1876#issuecomment-545642504 specifically for the reasoning.

TLDR: PEP-0345 currently allows environment markers for `Requires-Python` but most tools do not expect environment markers to be present in this field: let's update the specification/PEP to match the reality.

This would also require (?) an update to PEP-0345 (simply remove https://github.com/python/peps/blob/5a0ab0c2b71441f839914df6e7b996bfc4850cab/pep-0345.txt#L499).