### PR TITLE
Remove Requires-Python warning from piwheels project description

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -517,15 +517,8 @@ piwheels
 piwheels is a website, and software underpinning it, that fetches
 source code distribution packages from PyPI and compiles them into
 binary wheels that are optimized for installation onto Raspberry Pi
-computers. pip in Raspbian is pre-configured to use piwheels.org as
+computers. Raspberry Pi OS pre-configures pip to use piwheels.org as
 an additional index to PyPI.
-
-  .. warning::
-
-    Note that piwheels `does not yet fully support
-    <https://github.com/piwheels/piwheels/issues/208>`__ :pep:`503` and
-    thus some users have trouble installing certain wheels; this is in
-    progress.
 
 .. _poetry:
 


### PR DESCRIPTION
piwheels now honours the Requires-Python attribute on files, so I've removed the warning from the key projects page. 🚀 

https://blog.piwheels.org/requires-python-support-new-project-page-layout-and-a-new-json-api/

I also changed "Raspbian" to "Raspberry Pi OS" as the project name has [changed](https://www.raspberrypi.org/downloads/raspberry-pi-os/).