### PR TITLE
Fix references with wrong link text

### DIFF
--- a/source/discussions/pip-vs-easy-install.rst
+++ b/source/discussions/pip-vs-easy-install.rst
@@ -6,12 +6,12 @@ pip vs easy_install
 ===================
 
 
-`easy_install` was released in 2004, as part of :ref:`setuptools`.  It was
+:ref:`easy_install <easy_install>` was released in 2004, as part of :ref:`setuptools`.  It was
 notable at the time for installing :term:`packages <Distribution Package>` from
 :term:`PyPI <Python Package Index (PyPI)>` using requirement specifiers, and
 automatically installing dependencies.
 
-:ref:`pip` came later in 2008, as alternative to `easy_install`, although still
+:ref:`pip` came later in 2008, as alternative to :ref:`easy_install <easy_install>`, although still
 largely built on top of :ref:`setuptools` components.  It was notable at the
 time for *not* installing packages as :term:`Eggs <Egg>` or from :term:`Eggs <Egg>` (but
 rather simply as 'flat' packages from :term:`sdists <Source Distribution (or


### PR DESCRIPTION
The "easy_install" references links to a section with "setuptools" as
the title. This title is then used as the link text, making the section
incomprehensible for people not familiar with the relationship between
pip, easy_install, and setuptools.
