### PR TITLE
Refer to PyPI API tokens as such in GitHub secret names, spell in uppercase

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.test_pypi_password }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -37,11 +37,11 @@ Let's begin! 🚀
 2. In a separate browser tab or window, go to the ``Settings``
    tab of your target repository and then click on `Secrets`_
    in the left sidebar.
-3. Create a new secret called ``pypi_password`` and copy-paste
+3. Create a new secret called ``PYPI_API_TOKEN`` and copy-paste
    the token from the fist step.
 4. Now, go to https://test.pypi.org/manage/account/#api-tokens
    and repeat the steps. Save that TestPyPI token on GitHub
-   as ``test_pypi_password``.
+   as ``TEST_PYPI_API_TOKEN``.
 
    .. attention::
 


### PR DESCRIPTION
GitHub seems to default to uppercase nowadays, and in PyPI terms
this is about API tokens instead of passwords as such.

Refs https://github.com/pypa/gh-action-pypi-publish/pull/52#pullrequestreview-550969422