### PR TITLE
Tweak opening "important note" in installing-packages tutorial

### DIFF
--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -7,14 +7,15 @@ Installing Packages
 This section covers the basics of how to install Python :term:`packages
 <Distribution Package>`.
 
-It's important to note that the term "package" in this context is being used as
-a synonym for a :term:`distribution <Distribution Package>` (i.e. a bundle of
-software to be installed), not to refer to the kind of :term:`package <Import
-Package>` that you import in your Python source code (i.e. a container of
-modules). It is common in the Python community to refer to a :term:`distribution
-<Distribution Package>` using the term "package".  Using the term "distribution"
-is often not preferred, because it can easily be confused with a Linux
-distribution, or another larger software distribution like Python itself.
+It's important to note that the term "package" in this context is being used to
+describe a bundle of software to be installed (i.e. as a synonym for a
+:term:`distribution <Distribution Package>`). It does not to refer to the kind
+of :term:`package <Import Package>` that you import in your Python source code
+(i.e. a container of modules). It is common in the Python community to refer to
+a :term:`distribution <Distribution Package>` using the term "package".  Using
+the term "distribution" is often not preferred, because it can easily be
+confused with a Linux distribution, or another larger software distribution
+like Python itself.
 
 
 .. contents:: Contents


### PR DESCRIPTION
This flips the order of "synonym" vs "meaning", to convey the meaning before using
a loaded term that'll link to the glossary. This should help make it less intimidating to
first-time readers as well as generally make it easier to follow the sentence.

PS: It's likely easier to review this PR in "rich diff" mode, since I've had to re-wrap the entire passage.