### PR TITLE
Fix typos

### DIFF
--- a/source/overview.rst
+++ b/source/overview.rst
@@ -450,7 +450,7 @@ ride. This impression is mostly a byproduct of Python's
 versatility. Once you understand the natural boundaries between each
 packaging solution, you begin to realize that the varied landscape is
 a small price Python programmers pay for using one of the most
-balanced, flexible language available.
+balanced, flexible languages available.
 
 
 .. Editing notes:
@@ -503,7 +503,7 @@ balanced, flexible language available.
 
    - Avoid words that trivialize using JupyterLab
    such as “simply” or “just.” Tasks that developers find simple or
-   easy may not be for users."
+   easy may not be for users.
 
    Among other useful points. Read more here:
    https://jupyterlab.readthedocs.io/en/latest/developer/documentation.html


### PR DESCRIPTION
Fixes https://github.com/pypa/packaging.python.org/issues/787 and removes an unnecessary, unbalanced quote mark. 