### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('noxfile.py') }}
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.python-version }}-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install --upgrade nox virtualenv
 
       - name: Nox build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade nox virtualenv
+
+      - name: Nox build
+        run: |
+          python -m nox -s build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-sudo: false
-python:
-- 3.6
-install: python3 -m pip install --upgrade nox virtualenv
-script: python3 -m nox -s build


### PR DESCRIPTION
Travis CI has a new pricing model which places limits on open source.

* https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
* https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Travis support has also become unresponsive to developers who have run out of free credits, and many projects are moving to GitHub Actions instead. 

And https://github.com/pypa builds can not longer build:

> Builds have been temporarily disabled for public repositories due to a negative credit balance. Please go to the Plan page to replenish your credit balance or alter your Consume paid credits for OSS setting.

![image](https://user-images.githubusercontent.com/1324225/106754832-1c0fd980-6636-11eb-84a9-7680c7ad405e.png)

> Owner pypa does not have enough credits.

![image](https://user-images.githubusercontent.com/1324225/106755015-4eb9d200-6636-11eb-8b3e-751c11d96aa7.png)

---

This GHA config does much the same as the deleted Travis one. Two differences: tests with current newest Python 3.9 instead of 3.6; and adds caching of pip downloads, to try and help ease the load on PyPI, and speed up builds a bit.

Sample build:

* https://github.com/hugovk/packaging.python.org/runs/1822833000?check_suite_focus=true