### PR TITLE
feat: add project_urls example

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -171,7 +171,7 @@ an escape hatch when absolutely necessary.
     - ``url`` is the URL for the homepage of the project. For many projects, this
       will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
       service.
-    - ``project_urls`` lets you list any number of extra links to show in PyPI.
+    - ``project_urls`` lets you list any number of extra links to show on PyPI.
       Generally this could be to documentation, issue trackers, etc.
     - ``classifiers`` gives the index and :ref:`pip` some additional metadata
       about your package. In this case, the package is only compatible with Python
@@ -273,7 +273,7 @@ an escape hatch when absolutely necessary.
     - ``url`` is the URL for the homepage of the project. For many projects, this
       will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
       service.
-    - ``project_urls`` lets you list any number of extra links to show in PyPI.
+    - ``project_urls`` lets you list any number of extra links to show on PyPI.
       Generally this could be to documentation, issue trackers, etc.
     - ``classifiers`` gives the index and :ref:`pip` some additional metadata
       about your package. In this case, the package is only compatible with Python

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -134,6 +134,8 @@ an escape hatch when absolutely necessary.
         long_description = file: README.md
         long_description_content_type = text/markdown
         url = https://github.com/pypa/sampleproject
+        project_urls =
+            Bug Tracker = https://github.com/pypa/sampleproject/issues
         classifiers =
             Programming Language :: Python :: 3
             License :: OSI Approved :: MIT License
@@ -169,6 +171,8 @@ an escape hatch when absolutely necessary.
     - ``url`` is the URL for the homepage of the project. For many projects, this
       will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
       service.
+    - ``project_urls`` lets you list any number of extra links to show in PyPI.
+      Generally this could be to documentation, issue trackers, etc.
     - ``classifiers`` gives the index and :ref:`pip` some additional metadata
       about your package. In this case, the package is only compatible with Python
       3, is licensed under the MIT license, and is OS-independent. You should
@@ -234,6 +238,9 @@ an escape hatch when absolutely necessary.
             long_description=long_description,
             long_description_content_type="text/markdown",
             url="https://github.com/pypa/sampleproject",
+            project_urls={
+                "Bug Tracker": https://github.com/pypa/sampleproject/issues",
+            }
             classifiers=[
                 "Programming Language :: Python :: 3",
                 "License :: OSI Approved :: MIT License",
@@ -266,6 +273,8 @@ an escape hatch when absolutely necessary.
     - ``url`` is the URL for the homepage of the project. For many projects, this
       will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
       service.
+    - ``project_urls`` lets you list any number of extra links to show in PyPI.
+      Generally this could be to documentation, issue trackers, etc.
     - ``classifiers`` gives the index and :ref:`pip` some additional metadata
       about your package. In this case, the package is only compatible with Python
       3, is licensed under the MIT license, and is OS-independent. You should


### PR DESCRIPTION
In https://github.com/pypa/packaging.python.org/pull/823, it was mentioned that `project_urls` might be a good thing to show. This adds that example.

Happy to change this as needed, or if it's seen as "too much", that's fine too, it's just a followup to https://github.com/pypa/packaging.python.org/pull/823#discussion_r571482624 as promised in https://github.com/pypa/packaging.python.org/pull/823#discussion_r571484257 . I don't think I've used it in setup.py, I think I got the setup.py version right...
