### PR TITLE
Mention manylinux_x_y in platform tags specification

### DIFF
--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -51,7 +51,10 @@ representing the common subset of Linux platforms at a given point in time:
   and ``s390x``) and updates the base platform to a compatible Linux platform
   from 2014.
 
-``manylinux_x_y`` (:pep:`600`) supersedes all previous PEPs to define a future-proof standard. It defines ``x`` and ``y`` as glibc major an minor versions supported (e.g. ``manylinux_2_24`` should work on any distro using glibc 2.24+). Previous tags are still supported for backward compatibility.
+``manylinux_x_y`` (:pep:`600`) supersedes all previous PEPs to define a
+future-proof standard. It defines ``x`` and ``y`` as glibc major an minor
+versions supported (e.g. ``manylinux_2_24`` should work on any distro using
+glibc 2.24+). Previous tags are still supported for backward compatibility.
 
 In general, distributions built for older versions of the specification are
 forwards-compatible (meaning that ``manylinux1`` distributions should continue

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -69,9 +69,9 @@ Manylinux compatibility support
 
 .. Note::
   * The ``manylinux2014`` specification is relatively new and is not yet widely
-   recognised by install tools.
+    recognised by install tools.
   * The ``manylinux_x_y`` specification is relatively new and is not yet widely
-   recognised by install tools.
+    recognised by install tools.
 
 The following table shows the minimum versions of relevant projects to support
 the various ``manylinux`` standards:

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -33,12 +33,12 @@ The scheme defined in :pep:`425` is insufficient for public distribution of
 wheel files (and \*nix wheel files in general) to Linux platforms, due to the
 large ecosystem of Linux platforms and subtle differences between them.
 
-Instead, :pep:`513` defines the ``manylinux`` standard, which represents a
+Instead, :pep:`600` defines the ``manylinux`` standard, which represents a
 common subset of Linux platforms, and allows building wheels tagged with the
 ``manylinux`` platform tag which can be used across most common Linux
 distributions.
 
-There are multiple iterations of the ``manylinux`` specification, each
+There were multiple iterations of the ``manylinux`` specification, each
 representing the common subset of Linux platforms at a given point in time:
 
 * ``manylinux1`` (:pep:`513`) supports ``x86_64`` and ``i686``
@@ -51,6 +51,8 @@ representing the common subset of Linux platforms at a given point in time:
   and ``s390x``) and updates the base platform to a compatible Linux platform
   from 2014.
 
+``manylinux_x_y`` (:pep:`600`) supersedes all previous PEPs to define a future-proof standard. It defines ``x`` and ``y`` as glibc major an minor versions supported (e.g. ``manylinux_2_24`` should work on any distro using glibc 2.24+). Previous tags are still supported for backward compatibility.
+
 In general, distributions built for older versions of the specification are
 forwards-compatible (meaning that ``manylinux1`` distributions should continue
 to work on modern systems) but not backwards-compatible (meaning that
@@ -59,26 +61,27 @@ existed before 2010).
 
 Package maintainers should attempt to target the most compatible specification
 possible, with the caveat that the provided build environment for
-``manylinux1`` has reached end-of-life, and the build environment for
-``manylinux2010`` will reach end-of-life in November 2020 [#]_, meaning that
+``manylinux1`` and ``manylinux2010`` have reached end-of-life meaning that
 these images will no longer receive security updates.
 
 Manylinux compatibility support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. Note::
-   The ``manylinux2014`` specification is relatively new and is not yet widely
+  * The ``manylinux2014`` specification is relatively new and is not yet widely
+   recognised by install tools.
+  * The ``manylinux_x_y`` specification is relatively new and is not yet widely
    recognised by install tools.
 
 The following table shows the minimum versions of relevant projects to support
 the various ``manylinux`` standards:
 
-==========  ==============  =================  =================
-Tool        ``manylinux1``  ``manylinux2010``  ``manylinux2014``
-==========  ==============  =================  =================
-pip         ``>=8.1.0``     ``>=19.0``         ``>=19.3``
-auditwheel  ``>=1.0.0``     ``>=2.0.0``        ``>=3.0.0``
-==========  ==============  =================  =================
+==========  ==============  =================  =================  =================
+Tool        ``manylinux1``  ``manylinux2010``  ``manylinux2014``  ``manylinux_x_y``
+==========  ==============  =================  =================  =================
+pip         ``>=8.1.0``     ``>=19.0``         ``>=19.3``         ``>=20.3``
+auditwheel  ``>=1.0.0``     ``>=2.0.0``        ``>=3.0.0``        ``>=3.3.0`` [#]_
+==========  ==============  =================  =================  =================
 
 Platform tags for other \*nix platforms
 ---------------------------------------
@@ -89,4 +92,4 @@ distribution of wheel files to other \*nix platforms. Efforts are currently
 schemes for AIX and for Alpine Linux.
 
 
-.. [#] https://wiki.centos.org/About/Product
+.. [#] Only support for ``manylinux_2_24`` has been added in auditwheel 3.3.0


### PR DESCRIPTION
PEP600 now supersedes all previous PEPs to define a future-proof manylinux standard.