### PR TITLE
fix: Remove '<4' from python_requires in packaging guide

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -397,15 +397,10 @@ versions.  For example, if your package is for Python 3+ only, write::
 
     python_requires='>=3',
 
-If your package is for Python 3.3 and up but you're not willing to commit to
-Python 4 support yet, write::
-
-    python_requires='~=3.3',
-
 If your package is for Python 2.6, 2.7, and all versions of Python 3 starting
 with 3.3, write::
 
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4',
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
 
 And so on.
 


### PR DESCRIPTION
As discussed in the discuss.python topic ["Use of “less-than next-major-version” (e.g., `<4`) in `python_requires` (setup.py)"](https://discuss.python.org/t/use-of-less-than-next-major-version-e-g-4-in-python-requires-setup-py/1066) and other places there can be some side effects of adding `<4` to a library's `python_requires`. This PR removes it, as requested by @njsmith in the discuss.python topic.

The section above the lines discussed in the topic that uses compatible release syntax is also removed given that `~=3.3` also enforces `<4`.

My apologies in advance if this was already discussed in an Issue and decided against (I didn't see any when I scrolled through) or in a previously closed PR. Please let me know if you'd like me to open an Issue to discuss this PR topic instead.

Tagging @pfmoore and @njsmith as they were the devs in the discuss.python topic and @NickleDave and @henryiii as they might be interested in this as well.