### PR TITLE
Describe the file format of core metadata

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -13,6 +13,20 @@ complete and not subject to change. The required fields are:
 
 All the other fields are optional.
 
+The standard file format for metadata (including in :doc:`wheels
+<binary-distribution-format>` and :doc:`installed projects
+<recording-installed-packages>`) is based on the format of email headers.
+However, email formats have been revised several times, and exactly which email
+RFC applies to packaging metadata is not specified. In the absence of a precise
+definition, the practical standard is set by what the standard library
+:mod:`python:email.parser` module can parse using the
+:data:`~.python:email.policy.compat32` policy.
+
+Although :pep:`566` defined a way to transform metadata into a JSON-compatible
+dictionary, this is not yet used as a standard interchange format. The need for
+tools to work with years worth of existing packages makes it difficult to shift
+to a new format.
+
 .. note:: *Interpreting old metadata:* In :pep:`566`, the version specifier
    field format specification was relaxed to accept the syntax used by popular
    publishing tools (namely to remove the requirement that version specifiers


### PR DESCRIPTION
Following [this discussion on discourse](https://discuss.python.org/t/core-metadata-email-fields-unicode/7421). The file format of core metadata is not precisely defined (PEP 241 said RFC 822, but that's outdated in practice), but there is a practical standard: the major tools consuming metadata use the `email.parser` module with the (default) `compat32` policy. I think it's better to describe the situation than to leave it completely unspecified.

Hopefully this is an interim measure until someone gets around to describing the format properly. But that's a much bigger job, and so far no-one is volunteering.