### PR TITLE
fix: Apply formatting corrections for packaging tutorial

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -20,9 +20,9 @@ To create this project locally, create the following file structure:
 
 .. code-block:: text
 
-    packaging_tutorial
-    └── src
-        └── example_pkg
+    packaging_tutorial/
+    └── src/
+        └── example_pkg/
             └── __init__.py
 
 Once you create this structure, you'll want to run all of the commands in this
@@ -44,16 +44,16 @@ project's root directory - you will add content to them in the following steps.
 
 .. code-block:: text
 
-    packaging_tutorial
+    packaging_tutorial/
     ├── LICENSE
     ├── pyproject.toml
     ├── README.md
     ├── setup.cfg
     ├── setup.py  # optional, needed to make editable pip installs work
-    ├── src
-    │   └── example_pkg
+    ├── src/
+    │   └── example_pkg/
     │       └── __init__.py
-    └── tests
+    └── tests/
 
 
 Creating a test folder
@@ -188,9 +188,10 @@ an escape hatch when absolutely necessary.
 
     In the options category, we have controls for setuptools itself:
 
-    - ``package_dir`` is a collection of package names and directories.
-      An empty package name represents the "root package", so in this
-      case the root package is in the ``src`` directory.
+    - ``package_dir`` is a mapping of package names and directories.
+      An empty package name represents the "root package" --- the directory in
+      the project that contains all Python source files for the package --- so
+      in this case the ``src`` directory is designated the root package.
     - ``packages`` is a list of all Python :term:`import packages <Import
       Package>` that should be included in the :term:`Distribution Package`.
       Instead of listing each package manually, we can use the ``find:`` directive
@@ -300,8 +301,10 @@ an escape hatch when absolutely necessary.
       your package will work on. For a complete list of classifiers, see
       https://pypi.org/classifiers/.
     - ``package_dir`` is a dictionary with package names for keys and directories
-      for values. An empty package name represents the "root package", so in this
-      case the root package is in the ``src`` directory.
+      for values. An empty package name represents the "root package" --- the
+      directory in the project that contains all Python source files for the
+      package --- so in this case the ``src`` directory is designated the root
+      package.
     - ``packages`` is a list of all Python :term:`import packages <Import
       Package>` that should be included in the :term:`Distribution Package`.
       Instead of listing each package manually, we can use :func:`find_packages`


### PR DESCRIPTION
This PR is a follow up to PR #859 to apply suggested revisions and formatting (cc @webknjaz).

* Adds directory trailing slashes to indicate dir structure for clarity, so abandons `tree` behavior for `ls -F` behavior :+1: 
* Revise phrasing for `package_dir` description: "collection" -> "mapping"
* Attempts to clarify the definition of "root package"

In PR #859 it was also [suggested that](https://github.com/pypa/packaging.python.org/pull/859/files#r592172904)

> An empty package name represents the "root package", so in this case the root package is in the ``src`` directory.

might get rephrased to "flat", but the links provided to the discussion at the PyCon 2019 - PyPA Sprints + Summit notes seem to indicate that this is referring to terminology related to a **non**-src directory structure. Here the phrase "root package" is referring to the directory in the project directory structure that contains all Python source files for the package and is taken from the [old Distutils Examples docs](https://docs.python.org/3/distutils/examples.html#pure-python-distribution-by-package) where this pattern still applies in `setuptools` today.

![distutils](https://user-images.githubusercontent.com/5142394/110896726-c7f5b600-82c1-11eb-9f64-9939b1976a3f.png)

As "the directory in the project that contains all Python source files for the package" is perhaps unwieldy for someone totally new to packaging reading the tutorial I welcome suggestions for revision here!