### PR TITLE
Add `--keep-going` to the Sphinx invocation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,9 +19,11 @@ def build(session, autobuild=False):
         command = "sphinx-autobuild"
         extra_args = "-H", "0.0.0.0"
     else:
+        # NOTE: This branch adds options that are unsupported by autobuild
         command = "sphinx-build"
         extra_args = (
-            "--color",  # colorize the output, unsupported by autobuild
+            "--color",  # colorize the output
+            "--keep-going",  # don't interrupt the build on the first warning
         )
 
     session.run(


### PR DESCRIPTION
In nitpicky mode, Sphinx will error out on the first warning met. This change makes it collect all the warnings before returning with an error.