### PR TITLE
fix: Note that easy_install is deprecated

### DIFF
--- a/source/discussions/pip-vs-easy-install.rst
+++ b/source/discussions/pip-vs-easy-install.rst
@@ -6,8 +6,8 @@ pip vs easy_install
 ===================
 
 
-:ref:`easy_install <easy_install>` was released in 2004, as part of :ref:`setuptools`.  It was
-notable at the time for installing :term:`packages <Distribution Package>` from
+:ref:`easy_install <easy_install>`, now `deprecated`_, was released in 2004 as part of :ref:`setuptools`.
+It was notable at the time for installing :term:`packages <Distribution Package>` from
 :term:`PyPI <Python Package Index (PyPI)>` using requirement specifiers, and
 automatically installing dependencies.
 
@@ -19,7 +19,7 @@ rather simply as 'flat' packages from :term:`sdists <Source Distribution (or
 <pip:Requirements Files>`, which gave users the power to easily replicate
 environments.
 
-Here's a breakdown of the important differences between pip and easy_install now:
+Here's a breakdown of the important differences between pip and the deprecated easy_install:
 
 +------------------------------+--------------------------------------+-------------------------------+
 |                              | **pip**                              | **easy_install**              |
@@ -62,6 +62,8 @@ Here's a breakdown of the important differences between pip and easy_install now
 +------------------------------+--------------------------------------+-------------------------------+
 
 ----
+
+.. _deprecated: https://setuptools.readthedocs.io/en/latest/history.html#v42-0-0
 
 .. [1] https://setuptools.readthedocs.io/en/latest/easy_install.html#natural-script-launcher
 


### PR DESCRIPTION
Resolves #830 

Note in the ["pip vs easy_install" discussions](https://packaging.python.org/discussions/pip-vs-easy-install/) that `easy_install` is deprecated. Additionally add a link to the [release notes for `setuptools` `v42.0.0`](https://setuptools.readthedocs.io/en/latest/history.html#v42-0-0) in which in the Breaking Changes it is noted that

> Mark the easy_install script and setuptools command as deprecated

cc @qsqa for comments as they opened up the Issue. Also tagging @webknjaz as they requested a PR from the Issue.

RTD build of the page in question: https://python-packaging-user-guide--872.org.readthedocs.build/discussions/pip-vs-easy-install/