### PR TITLE
fix: use sys.version_info over try/except

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -98,10 +98,11 @@ number of your project:
     older versions as the ``importlib-metadata`` project.)  An installed
     project's version can be fetched with the API as follows::
 
-        try:
+        import sys
+
+        if sys.version_info >= (3, 8):
             from importlib import metadata
-        except ImportError:
-            # Running on pre-3.8 Python; use importlib-metadata package
+        else:
             import importlib_metadata as metadata
 
         assert metadata.version('pip') == '1.2.0'


### PR DESCRIPTION
This changes a try/except to a version check. Not only is this statically typable in MyPy, but it literally states exactly what the comment below states, but in code. :)
