### PR TITLE
Fix description of entry points mechanism

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -395,7 +395,7 @@ nitpick_ignore = [
     ('py:func', 'find_packages'),
     ('py:func', 'setup'),
     ('py:func', 'importlib.metadata.entry_points'),  # remove when 3.10 is released
-    ('py:class', 'importlib.metadata.EntryPoints'),  # remove when 3.10 is released
+    ('py:class', 'importlib.metadata.EntryPoint'),  # remove when 3.10 is released
     ('py:func', 'setuptools.find_namespace_packages'),
     ('py:func', 'setuptools.find_packages'),
     ('py:func', 'setuptools.setup'),

--- a/source/conf.py
+++ b/source/conf.py
@@ -395,6 +395,7 @@ nitpick_ignore = [
     ('py:func', 'find_packages'),
     ('py:func', 'setup'),
     ('py:func', 'importlib.metadata.entry_points'),  # remove when 3.10 is released
+    ('py:class', 'importlib.metadata.EntryPoints'),  # remove when 3.10 is released
     ('py:func', 'setuptools.find_namespace_packages'),
     ('py:func', 'setuptools.find_packages'),
     ('py:func', 'setuptools.setup'),

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,10 +120,10 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-`Setuptools`_ provides :setuptools:doc:`special support
-<userguide/entry_point>` for plugins. By providing the ``entry_points``
-argument to :func:`setup` in :file:`setup.py` plugins can register themselves
-for discovery.
+`Setuptools`_ provides :doc:`special support
+<setuptools:userguide/entry_point>` for plugins. By providing the
+``entry_points`` argument to :func:`setup` in :file:`setup.py` plugins can
+register themselves for discovery.
 
 For example if you have a package named ``myapp-plugin-a`` and it includes
 in its :file:`setup.py`:
@@ -165,10 +165,10 @@ Now the module of your choice can be imported by executing
 
 .. note:: The ``entry_point`` specification in :file:`setup.py` is fairly
     flexible and has a lot of options. It's recommended to read over the entire
-    section on :setuptools:doc:`entry points <userguide/entry_point>` .
+    section on :doc:`entry points <setuptools:userguide/entry_point>` .
 
-.. note:: Since this specification is part of the :python:doc:`standard library
-   <library/importlib.metadata>`, most packaging tools other than setuptools
+.. note:: Since this specification is part of the :doc:`standard library
+   <python:library/importlib.metadata>`, most packaging tools other than setuptools
    provide support for defining entry points.
 
 .. _Setuptools: https://setuptools.readthedocs.io

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -150,21 +150,30 @@ Then you can discover and load all of the registered entry points by using
     discovered_plugins = entry_points(group='myapp.plugins')
 
 
-In this example, ``discovered_plugins`` would be:
+In this example, ``discovered_plugins`` would be a collection of type :class:`importlib.metadata.EntryPoints`:
 
 .. code-block:: python
 
-    {
-        'a': <module: 'myapp_plugin_a'>,
-    }
+    (
+        EntryPoint(name='a', value='myapp_plugin_a', group='myapp.plugins'),
+        ...
+    )
+
+Now the module of your choice can be imported by executing
+``discovered_plugins['a'].load()``.
 
 .. note:: The ``entry_point`` specification in :file:`setup.py` is fairly
     flexible and has a lot of options. It's recommended to read over the entire
     section on `entry points`_.
 
+.. note:: Since this specification is part of the `standard library`_, most
+   packaging tools other than setuptools provide support for defining entry
+   points.
+
 .. _Setuptools: https://setuptools.readthedocs.io
 .. _special support:
 .. _entry points:
-    https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
+   https://setuptools.readthedocs.io/en/stable/userguide/entry_point.html
+.. _standard library: https://docs.python.org/3/library/importlib.metadata.html#entry-points
 .. _backport: https://importlib-metadata.readthedocs.io/en/latest/
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,9 +120,10 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-`Setuptools`_ provides `special support`_ for plugins. By
-providing the ``entry_points`` argument to :func:`setup` in :file:`setup.py`
-plugins can register themselves for discovery.
+`Setuptools`_ provides :setuptools:doc:`special support
+<userguide/entry_point>` for plugins. By providing the ``entry_points``
+argument to :func:`setup` in :file:`setup.py` plugins can register themselves
+for discovery.
 
 For example if you have a package named ``myapp-plugin-a`` and it includes
 in its :file:`setup.py`:
@@ -164,16 +165,12 @@ Now the module of your choice can be imported by executing
 
 .. note:: The ``entry_point`` specification in :file:`setup.py` is fairly
     flexible and has a lot of options. It's recommended to read over the entire
-    section on `entry points`_.
+    section on :setuptools:doc:`entry points <userguide/entry_point>` .
 
-.. note:: Since this specification is part of the `standard library`_, most
-   packaging tools other than setuptools provide support for defining entry
-   points.
+.. note:: Since this specification is part of the :python:doc:`standard library
+   <library/importlib.metadata>`, most packaging tools other than setuptools
+   provide support for defining entry points.
 
 .. _Setuptools: https://setuptools.readthedocs.io
-.. _special support:
-.. _entry points:
-   https://setuptools.readthedocs.io/en/stable/userguide/entry_point.html
-.. _standard library: https://docs.python.org/3/library/importlib.metadata.html#entry-points
 .. _backport: https://importlib-metadata.readthedocs.io/en/latest/
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -151,7 +151,7 @@ Then you can discover and load all of the registered entry points by using
     discovered_plugins = entry_points(group='myapp.plugins')
 
 
-In this example, ``discovered_plugins`` would be a collection of type :class:`importlib.metadata.EntryPoints`:
+In this example, ``discovered_plugins`` would be a collection of type :class:`importlib.metadata.EntryPoint`:
 
 .. code-block:: python
 
@@ -173,4 +173,3 @@ Now the module of your choice can be imported by executing
 
 .. _Setuptools: https://setuptools.readthedocs.io
 .. _backport: https://importlib-metadata.readthedocs.io/en/latest/
-


### PR DESCRIPTION
- Show how a module would be loaded. A dictionary of modules will not be loaded, unless created by the user. The example code was corrected.
- Update links to external documentation
- Hint that specifying entry points is not limited to setuptools. For  example [flit](https://flit.readthedocs.io/en/latest/pyproject_toml.html#entry-points-sections)  and [poetry](https://python-poetry.org/docs/pyproject/#plugins) support it too.

Following up on #870 and #879 