### PR TITLE
binary-extensions: add cibuildwheel and multibuild

### DIFF
--- a/source/guides/packaging-binary-extensions.rst
+++ b/source/guides/packaging-binary-extensions.rst
@@ -232,16 +232,15 @@ guide includes an introduction to writing a
 Building binary extensions
 ==========================
 
-Building extensions in CI
+Building extensions for multiple platforms
 -------------------------
 
-If you plan to distribute your modules, you should provide builds for all the
+If you plan to distribute your extension, you should provide :term:`wheels <Wheel>` for all the
 platforms you intend to support. For most extensions, this is at least one
-module per Python version times the number of OS and archetectures you support.
+package per Python version times the number of OS and architectures you support.
 These are usually built on continous integration (CI) systems. There are tools
 to help you build highly redistributable binaries from CI; these include
-`cibuildwheel <https://cibuildwheel.readthedocs.io>`__ and
-`multibuild <https://github.com/matthew-brett/multibuild>`__.
+:ref:`cibuildwheel` and :ref:`multibuild`.
 
 
 Binary extensions for Windows

--- a/source/guides/packaging-binary-extensions.rst
+++ b/source/guides/packaging-binary-extensions.rst
@@ -233,14 +233,15 @@ Building binary extensions
 ==========================
 
 Building extensions for multiple platforms
--------------------------
+------------------------------------------
 
-If you plan to distribute your extension, you should provide :term:`wheels <Wheel>` for all the
-platforms you intend to support. For most extensions, this is at least one
-package per Python version times the number of OS and architectures you support.
-These are usually built on continous integration (CI) systems. There are tools
-to help you build highly redistributable binaries from CI; these include
-:ref:`cibuildwheel` and :ref:`multibuild`.
+If you plan to distribute your extension, you should provide
+:term:`wheels <Wheel>` for all the platforms you intend to support. For most
+extensions, this is at least one package per Python version times the number of
+OS and architectures you support.  These are usually built on continuous
+integration (CI) systems. There are tools to help you build highly
+redistributable binaries from CI; these include :ref:`cibuildwheel` and
+:ref:`multibuild`.
 
 
 Binary extensions for Windows

--- a/source/guides/packaging-binary-extensions.rst
+++ b/source/guides/packaging-binary-extensions.rst
@@ -232,6 +232,18 @@ guide includes an introduction to writing a
 Building binary extensions
 ==========================
 
+Building extensions in CI
+-------------------------
+
+If you plan to distribute your modules, you should provide builds for all the
+platforms you intend to support. For most extensions, this is at least one
+module per Python version times the number of OS and archetectures you support.
+These are usually built on continous integration (CI) systems. There are tools
+to help you build highly redistributable binaries from CI; these include
+`cibuildwheel <https://cibuildwheel.readthedocs.io>`__ and
+`multibuild <https://github.com/matthew-brett/multibuild>`__.
+
+
 Binary extensions for Windows
 -----------------------------
 


### PR DESCRIPTION
This adds a mention of pypa's cibuildwheel and multibuild here before going into the (highly outdated, currently) specifics of building wheels. For most users, this likely is the correct place to go, rather than trying to set things up themselves. For those who might want to do things themselves, the following sections still need updating.