### PR TITLE
Suggest restricting to main in GHA publishing guide

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build-n-publish:

--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -1,9 +1,6 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   build-n-publish:
@@ -32,6 +29,11 @@ jobs:
         .
     # Actually publish to PyPI/TestPyPI
     - name: Publish distribution 📦 to Test PyPI
+      if: >-
+        github.event_name == 'push' &&
+        github.ref == format(
+          'refs/heads/{0}', github.event.repository.default_branch
+        )
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -65,6 +65,11 @@ should make GitHub run this workflow:
    :language: yaml
    :end-before: jobs:
 
+The workflow only runs on push events for the ``main`` branch to avoid
+unnecessary publishes, like on a feature branch. If your primary
+branch is named something else, like ``master``, please replace ``main`` with
+the correct branch.
+
 
 Defining a workflow job environment
 ===================================
@@ -75,7 +80,7 @@ In this guide, we'll use Ubuntu 18.04:
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
-   :start-after: on:
+   :start-after: - main
    :end-before: steps:
 
 

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -65,11 +65,6 @@ should make GitHub run this workflow:
    :language: yaml
    :end-before: jobs:
 
-The workflow only runs on push events for the ``main`` branch to avoid
-unnecessary publishes, like on a feature branch. If your primary
-branch is named something else, like ``master``, please replace ``main`` with
-the correct branch.
-
 
 Defining a workflow job environment
 ===================================
@@ -80,7 +75,7 @@ In this guide, we'll use Ubuntu 18.04:
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
-   :start-after: - main
+   :start-after: on:
    :end-before: steps:
 
 
@@ -130,6 +125,14 @@ Action: the first one uploads contents of the ``dist/`` folder
 into TestPyPI unconditionally and the second does that to
 PyPI, but only if the current commit is tagged.
 
+.. tip::
+
+   The conditional for TestPyPI is necessary because other branches may
+   trigger this. Without it, multiple pushes (say merges to main) would
+   attempt publishing the same version which would fail since updates to
+   pre-existing versions are blocked server side. Producing unique
+   versions for every commit would require more work that isn't covered
+   in this guide.
 
 That's all, folks!
 ==================


### PR DESCRIPTION
Previously the guide suggested workflow would run on every push which
isn't ideal (eg. a push on for an in-development feature branch doesn't need
a release).

Fixes #744.