### PR TITLE
chore: move pipx to pypa

### DIFF
--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -4,7 +4,7 @@ Installing stand alone command line tools
 Many packages have command line entry points. Examples of this type of application are
 `mypy <https://github.com/python/mypy>`_,
 `flake8 <https://github.com/PyCQA/flake8>`_,
-`pipenv <https://github.com/pypa/pipenv>`_,and
+:ref:`pipenv`,and
 `black <https://github.com/ambv/black>`_.
 
 Usually you want to be able to access these from anywhere,
@@ -12,13 +12,13 @@ but installing packages and their dependencies to the same global environment
 can cause version conflicts and break dependencies the operating system has
 on Python packages.
 
-`pipx <https://github.com/pipxproject/pipx>`_ solves this by creating a virtual
+:ref:`pipx` solves this by creating a virtual
 environment for each package, while also ensuring that package's applications
 are accessible through a directory that is on your ``$PATH``. This allows each
 package to be upgraded or uninstalled without causing conflicts with other
 packages, and allows you to safely run the program from anywhere.
 
-.. Note:: pipx only works with Python 3.6+.
+.. note:: pipx only works with Python 3.6+.
 
 ``pipx`` is installed with ``pip``:
 
@@ -110,4 +110,4 @@ To see the full list of commands ``pipx`` offers, run
   $ pipx --help
 
 You can learn more about ``pipx`` at its homepage,
-https://github.com/pipxproject/pipx.
+https://github.com/pypa/pipx.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -174,8 +174,8 @@ pipx
 `GitHub <https://github.com/pypa/pipx>`__ |
 `PyPI <https://pypi.org/project/pipx/>`__
 
-pipx is a tool to safely install and run Python CLI applications globally
-or even install and run them directly in a single line.
+pipx is a tool to install and run Python command-line applications without
+causing dependency conflicts with other packages installed on the system.
 
 
 Python Packaging User Guide

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -165,6 +165,18 @@ Pipfile
 application-centric alternative to :ref:`pip`'s lower-level
 :file:`requirements.txt` file.
 
+.. _pipx:
+
+pipx
+====
+
+`Docs <https://pypa.github.io/pipx/>`__ |
+`GitHub <https://github.com/pypa/pipx>`__ |
+`PyPI <https://pypi.org/project/pipx/>`__
+
+pipx is a tool to safely install and run Python CLI applications globally
+or even install and run them directly in a single line.
+
 
 Python Packaging User Guide
 ===========================
@@ -472,17 +484,6 @@ files, standalone Python environments in the spirit of :ref:`virtualenv`.
 :file:`.pex` files are just carefully constructed zip files with a
 ``#!/usr/bin/env python`` and special :file:`__main__.py`, and are designed to
 make deployment of Python applications as simple as ``cp``.
-
-.. _pipx:
-
-pipx
-====
-
-`Docs <https://pipxproject.github.io/pipx/>`__ |
-`GitHub <https://github.com/pipxproject/pipx>`__ |
-`PyPI <https://pypi.org/project/pipx/>`__
-
-pipx is a tool to safely install and run Python CLI applications globally.
 
 .. _pip-tools:
 


### PR DESCRIPTION
This updates for the new location of pipx.
