### PR TITLE
fix: easy_install URL now includes /deprecated/

### DIFF
--- a/source/discussions/pip-vs-easy-install.rst
+++ b/source/discussions/pip-vs-easy-install.rst
@@ -65,7 +65,7 @@ Here's a breakdown of the important differences between pip and the deprecated e
 
 .. _deprecated: https://setuptools.readthedocs.io/en/latest/history.html#v42-0-0
 
-.. [1] https://setuptools.readthedocs.io/en/latest/easy_install.html#natural-script-launcher
+.. [1] https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html#natural-script-launcher
 
 
 .. _pylauncher support: https://bitbucket.org/vinay.sajip/pylauncher


### PR DESCRIPTION
Tiny fix for the homepage of the deprecated easy_install. Without `/deprecated/` it ends in the 404 Not Found page of rtd.