### PR TITLE
Adjust nox config for building the translated site versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -43,6 +43,7 @@ def build(session, autobuild=False):
         "-b", "html",  # use HTML builder
         "-n",  # nitpicky warn about all missing references
         "-W",  # Treat warnings as errors.
+        *session.posargs,
         "source",  # where the rst files are located
         target_build_dir,  # where to put the html output
     )

--- a/source/conf.py
+++ b/source/conf.py
@@ -89,6 +89,8 @@ release = ''
 # Usually you set "language" from the command line for these cases.
 language = None
 
+locale_dirs = ['../locales']
+
 # making all documents use single text domain
 gettext_compact = "messages"
 


### PR DESCRIPTION
I was playing with building the localized sites on RTD and noticed that the `*.po` files are not being picked up. So I dug deeper and now realized that Sphinx looks for the `locales/` dir relative to `conf.py` and fixed that.

Additionally, since there was no way to invoke `nox` locally for building the docs in other languages, I've adjusted the nox file to bypass any posargs to the underlying invocation of `sphinx-build` and now it's possible to do this. For example:
```console
$ python -m nox -s build -- -D language=uk
nox > Running session build
nox > Creating virtual environment (virtualenv) using python3 in .nox/build
nox > python -m pip install -r requirements.txt
nox > sphinx-build --color --keep-going -j auto -b html -n -W -D language=uk source build
Running Sphinx v4.0.3
loading translations [uk]... done
...
```