### PR TITLE
Clarify how MANIFEST.in's "include" and "exclude" work

### DIFF
--- a/source/guides/using-manifest-in.rst
+++ b/source/guides/using-manifest-in.rst
@@ -67,7 +67,9 @@ are:
 Command                                                    Description
 =========================================================  ==================================================================================================
 :samp:`include {pat1} {pat2} ...`                          Add all files matching any of the listed patterns
+                                                           (Files must be given as paths relative to the root of the project)
 :samp:`exclude {pat1} {pat2} ...`                          Remove all files matching any of the listed patterns
+                                                           (Files must be given as paths relative to the root of the project)
 :samp:`recursive-include {dir-pattern} {pat1} {pat2} ...`  Add all files under directories matching ``dir-pattern`` that match any of the listed patterns
 :samp:`recursive-exclude {dir-pattern} {pat1} {pat2} ...`  Remove all files under directories matching ``dir-pattern`` that match any of the listed patterns
 :samp:`global-include {pat1} {pat2} ...`                   Add all files anywhere in the source tree matching any of the listed patterns


### PR DESCRIPTION
I recently found out the hard way that, if you have a file `src/foobar/stuff.txt` in your project, writing just `include stuff.txt` in your `MANIFEST.in` won't do anything; you need to write `include src/foobar/stuff.txt` instead.  This PR tries to make that clearer to readers.