### PR TITLE
WIP Enable build translated docs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,9 +32,9 @@ def build(session, language='en', autobuild=False):
     """
     session.install("-r", "requirements.txt")
 
-    target_build_dir = "build"
+    target_build_dir = "build/" + language
 
-    #shutil.rmtree(target_build_dir, ignore_errors=True)
+    shutil.rmtree(target_build_dir, ignore_errors=True)
 
     if autobuild:
         command = "sphinx-autobuild"
@@ -47,25 +47,21 @@ def build(session, language='en', autobuild=False):
             "--keep-going",  # don't interrupt the build on the first warning
         )
 
-    if language:
-        # add language parameter; if empty do not add because it is English
-        extra_args = extra_args + ( "-D", "language=" + language)
-        target_build_dir = target_build_dir + '/' + language
     session.run(
         command, *extra_args,
         "-j", "auto",  # parallelize the build
         "-b", "html",  # use HTML builder
         "-n",  # nitpicky warn about all missing references
         "-W",  # Treat warnings as errors.
+        "-D", "language=" + language, # build in the give language
         *session.posargs,
         "source",  # where the rst files are located
         target_build_dir,  # where to put the html output
     )
 
 @nox.session()
-@nox.parametrize("language", language_list)
-def l10n(session, language):
-    build(session, language=language)
+def l10n(session):
+    build(session, language=session.posargs.pop(0))
 
 @nox.session()
 def preview(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ def translation(session):
     )
 
 @nox.session()
-def build(session, autobuild=False):
+def build(session, language='en', autobuild=False):
     """
     Make the website.
     """
@@ -34,7 +34,7 @@ def build(session, autobuild=False):
 
     target_build_dir = "build"
 
-    shutil.rmtree(target_build_dir, ignore_errors=True)
+    #shutil.rmtree(target_build_dir, ignore_errors=True)
 
     if autobuild:
         command = "sphinx-autobuild"
@@ -47,6 +47,10 @@ def build(session, autobuild=False):
             "--keep-going",  # don't interrupt the build on the first warning
         )
 
+    if language:
+        # add language parameter; if empty do not add because it is English
+        extra_args = extra_args + ( "-D", "language=" + language)
+        target_build_dir = target_build_dir + '/' + language
     session.run(
         command, *extra_args,
         "-j", "auto",  # parallelize the build
@@ -58,6 +62,10 @@ def build(session, autobuild=False):
         target_build_dir,  # where to put the html output
     )
 
+@nox.session()
+@nox.parametrize("language", language_list)
+def l10n(session, language):
+    build(session, language=language)
 
 @nox.session()
 def preview(session):


### PR DESCRIPTION
## Description

Currently there is no option in nox config file for building translated version of packaging.python.org. `nox -s build` builds English-only docs. One can run e.g. `nox -s build -- -D language=pt_BR` to build Brazilian Portuguese translated version of the docs. The idea with this PR is to implement a nox's session (`--session`/`-s`) to build translated docs.

See https://github.com/pypa/packaging.python.org/issues/927#issuecomment-968310133.

/cc @meowmeowmeowcat @webknjaz 

## Initial solution

While I don't feel this is perfect, let's use it to start discussion.

This commit added a new session named 'l10n' that receives the list of languages available as parameters. This new session relies on 'build' session to build the docs.

Build docs in only English (source language):
```
nox -s build
```

Build docs in all translated languages (English excluded):
```
nox -s l10n
```

Build docs in only Brazilian Portuguese:
```
nox -s "l10n(language='pt_BR')"
```

NOTE: I had to comment the line that removes target_build_dir because it was cleaning up the directory on every run, causing it to losing all previous builds.