### PR TITLE
Advise against using distutils directly, take 2

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -4,9 +4,11 @@
 Packaging and distributing projects
 ===================================
 
-This section covers the basics of how to configure, package and distribute your
-own Python projects.  It assumes that you are already familiar with the contents
-of the :doc:`/tutorials/installing-packages` page.
+This section covers some additional details on configuring, packaging and
+distributing Python projects with ``setuptools`` that aren't covered by the
+introductory tutorial in :doc:`/tutorials/packaging-projects`.  It still assumes
+that you are already familiar with the contents of the
+:doc:`/tutorials/installing-packages` page.
 
 The section does *not* aim to cover best practices for Python project
 development as a whole.  For example, it does not provide guidance or tool

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -333,13 +333,11 @@ be required, but can be omitted with newer versions of setuptools and pip.
 
       You may see some existing projects or other Python packaging tutorials that
       import their ``setup`` function from ``distutils.core`` rather than
-      ``setuptools``. This is a `legacy approach`_ that installers support
+      ``setuptools``. This is a legacy approach that installers support
       for backwards compatibility purposes [1]_, but using the legacy ``distutils`` API
       directly in new projects is strongly discouraged, since ``distutils`` is
       deprecated as per :pep:`632` and will be removed from the standard library
       in Python 3.12.
-
-    .. _legacy approach: https://docs.python.org/3.10/library/distutils.html
 
 Creating README.md
 ------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -329,17 +329,17 @@ be required, but can be omitted with newer versions of setuptools and pip.
     There are many more than the ones mentioned here. See
     :doc:`/guides/distributing-packages-using-setuptools` for more details.
 
-.. warning::
+    .. warning::
 
-   You may see some existing projects or other Python packaging tutorials that
-   import their ``setup`` function from ``distutils.core`` rather than
-   ``setuptools``. This is a `legacy approach`_ that installers support
-   for backwards compatibility purposes [1]_, but using the legacy ``distutils`` API
-   directly in new projects is strongly discouraged, since ``distutils`` is
-   deprecated as per :pep:`632` and will be removed from the standard library
-   in Python 3.12.
+      You may see some existing projects or other Python packaging tutorials that
+      import their ``setup`` function from ``distutils.core`` rather than
+      ``setuptools``. This is a `legacy approach`_ that installers support
+      for backwards compatibility purposes [1]_, but using the legacy ``distutils`` API
+      directly in new projects is strongly discouraged, since ``distutils`` is
+      deprecated as per :pep:`632` and will be removed from the standard library
+      in Python 3.12.
 
-.. _legacy approach: https://docs.python.org/3.10/library/distutils.html
+    .. _legacy approach: https://docs.python.org/3.10/library/distutils.html
 
 Creating README.md
 ------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -642,7 +642,7 @@ some things you can do:
        pre-installed, and the operators of those environments may still be
        requiring users to install packages by running ``setup.py install``
        commands, rather than providing an installer like ``pip`` that
-       automatically installes required build dependendencies. These
+       automatically installs required build dependendencies. These
        environments will not be able to use many published packages until the
        environment is updated to provide an up to date Python package
        installation client (e.g. by running ``python -m ensurepip``).

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -329,6 +329,15 @@ be required, but can be omitted with newer versions of setuptools and pip.
     There are many more than the ones mentioned here. See
     :doc:`/guides/distributing-packages-using-setuptools` for more details.
 
+.. note::
+
+   You may see some existing projects or other Python packaging tutorials that
+   import their ``setup`` function from ``distutils.core`` rather than
+   ``setuptools``. This is a legacy approach that installers [1]_ still support
+   for backwards compatibility purposes, but using the legacy ``distutils`` API
+   directly in new projects is strongly discouraged, as it means that newer
+   build commands, like ``setup.py bdist_wheel``, won't work.
+
 Creating README.md
 ------------------
 
@@ -624,3 +633,14 @@ some things you can do:
 * Read about :doc:`/guides/packaging-binary-extensions`.
 * Consider alternatives to :ref:`setuptools` such as :ref:`flit`, :ref:`hatch`,
   and :ref:`poetry`.
+
+----
+
+.. [1] Some legacy Python environments may not have ``setuptools``
+       pre-installed, and the operators of those environments may still be
+       requiring users to install packages by running ``setup.py install``
+       commands, rather than providing an installer like ``pip`` that
+       automatically installes required build dependendencies. These
+       environments will not be able to use many published packages until the
+       environment is updated to provide an up to date Python package
+       installation client (e.g. by running ``python -m ensurepip``).

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -333,8 +333,8 @@ be required, but can be omitted with newer versions of setuptools and pip.
 
    You may see some existing projects or other Python packaging tutorials that
    import their ``setup`` function from ``distutils.core`` rather than
-   ``setuptools``. This is a `legacy approach`_ that installers [1]_ support
-   for backwards compatibility purposes, but using the legacy ``distutils`` API
+   ``setuptools``. This is a `legacy approach`_ that installers support
+   for backwards compatibility purposes [1]_, but using the legacy ``distutils`` API
    directly in new projects is strongly discouraged, since ``distutils`` is
    deprecated as per :pep:`632` and will be removed from the standard library
    in Python 3.12.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -329,16 +329,17 @@ be required, but can be omitted with newer versions of setuptools and pip.
     There are many more than the ones mentioned here. See
     :doc:`/guides/distributing-packages-using-setuptools` for more details.
 
-.. note::
+.. warning::
 
    You may see some existing projects or other Python packaging tutorials that
    import their ``setup`` function from ``distutils.core`` rather than
    ``setuptools``. This is a `legacy approach`_ that installers [1]_ support
    for backwards compatibility purposes, but using the legacy ``distutils`` API
-   directly in new projects is strongly discouraged, as it means that newer
-   build commands, like ``setup.py bdist_wheel``, won't work.
+   directly in new projects is strongly discouraged, since ``distutils`` is
+   deprecated as per :pep:`632` and will be removed from the standard library
+   in Python 3.12.
 
-.. _legacy approach: https://docs.python.org/3/library/distutils.html
+.. _legacy approach: https://docs.python.org/3.10/library/distutils.html
 
 Creating README.md
 ------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -333,10 +333,12 @@ be required, but can be omitted with newer versions of setuptools and pip.
 
    You may see some existing projects or other Python packaging tutorials that
    import their ``setup`` function from ``distutils.core`` rather than
-   ``setuptools``. This is a legacy approach that installers [1]_ still support
+   ``setuptools``. This is a `legacy approach`_ that installers [1]_ support
    for backwards compatibility purposes, but using the legacy ``distutils`` API
    directly in new projects is strongly discouraged, as it means that newer
    build commands, like ``setup.py bdist_wheel``, won't work.
+
+.. _legacy approach: https://docs.python.org/3/library/distutils.html
 
 Creating README.md
 ------------------


### PR DESCRIPTION
Closes #667. Continuation of #672, closes #672.

I tried to respect the original spirit of #672, even if that meant _not_ updating the rest of the page (i.e. noting the deprecation of direct `setup.py` invokations and encouragement for `pyproject.toml` for static metadata), as this would require a bit more work. I prefer to defer that to a future PR.