### PR TITLE
feat: add PEP 621 config only

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -394,6 +394,8 @@ linkcheck_ignore = [
     # Ignoring it as it will redirect to login page if reader hasn't logged in.
     "https://pypi.org/manage/*",
     "https://test.pypi.org/manage/*",
+    # This is a placeholder
+    "https://test.pypi.org/project/example_package_your_username_here",
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/source/conf.py
+++ b/source/conf.py
@@ -394,8 +394,6 @@ linkcheck_ignore = [
     # Ignoring it as it will redirect to login page if reader hasn't logged in.
     "https://pypi.org/manage/*",
     "https://test.pypi.org/manage/*",
-    # This is a placeholder
-    "https://test.pypi.org/project/example_package_your_username_here",
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -108,7 +108,8 @@ should contain one of these build-system blocks:
 
 .. tab:: Setuptools
 
-    This is the classic backend for building projects; large, slow, complex.
+    This is the original backend for building projects, with C extension
+    support and many plugins, like :ref:`setuptools_scm`.
 
     .. code-block:: toml
 
@@ -129,7 +130,7 @@ should contain one of these build-system blocks:
 
 .. tab:: Hatchling
 
-    :ref:`hatch` has a more feature-rich build backend than flit, supporting
+    :ref:`hatch` has a more feature-rich build backend than Flit, supporting
     SCM versioning and plugins.
 
     .. code-block:: toml

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -176,7 +176,7 @@ people following this tutorial.
     ]
     description = "A small example package"
     readme = "README.md"
-    requires-python = ">=3.6"
+    requires-python = ">=3.7"
     classifiers = [
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -188,10 +188,10 @@ people following this tutorial.
     "Bug Tracker" = "https://github.com/pypa/sampleproject/issues"
 
 - ``name`` is the *distribution name* of your package. This can be any name as
-  long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
-  already be taken on PyPI. **Be sure to update this with your username,**
-  as this ensures you won't try to upload a package with the same name as one
-  which already exists.
+  long as it only contains letters, numbers, ``.``, ``_`` , and ``-``. It also
+  must not already be taken on PyPI. **Be sure to update this with your
+  username** for this tutorial, as this ensures you won't try to upload a
+  package with the same name as one which already exists.
 - ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>`
   for more details on versions. Some build backends allow it to be specified
   another way, such as from a file or a git tag.
@@ -402,7 +402,7 @@ After the command completes, you should see output similar to this:
 
 
 Once uploaded your package should be viewable on TestPyPI, for example,
-https://test.pypi.org/project/example_package_YOUR_USERNAME_HERE
+https://test.pypi.org/project/example_package_your_username_here.
 
 
 Installing your newly uploaded package

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -108,8 +108,7 @@ should contain one of these build-system blocks:
 
 .. tab:: Setuptools
 
-    This is the classic backend for building projects; large, slow, but
-    powerful with many options.
+    This is the classic backend for building projects; large, slow, complex.
 
     .. code-block:: toml
 
@@ -120,7 +119,7 @@ should contain one of these build-system blocks:
 .. tab:: Flit
 
     :ref:`Flit` is a very lightweight, simple, and fast backend for pure Python
-    projects. It is 10x faster than setuptools, and has no dependencies at all.
+    projects. It has no dependencies at all.
 
     .. code-block:: toml
 
@@ -130,9 +129,8 @@ should contain one of these build-system blocks:
 
 .. tab:: PDM
 
-    If you want to use use :ref:`pdm`'s backend (not required to use PDM for
-    package management, any PEP 621 backend works), it also has a standalone
-    backend for builds. It has some features not present in Flit.
+    :ref:`pdm` has a build backend as well (not required to use PDM for package
+    management, any PEP 621 backend works).
 
     .. code-block:: toml
 
@@ -154,8 +152,7 @@ See :pep:`517` and :pep:`518` for background and details.
 Configuring metadata
 --------------------
 
-:pep:`621` provides a standard way to define metadata.  :file:`pyproject.toml`
-configuration is stored in the ``[project]`` table.
+:pep:`621` provides a standard way to define metadata in :file:`pyproject.toml`.
 
 Open :file:`pyproject.toml` and enter the following content. Change the ``name``
 to include your username; this ensures that you have a unique package name
@@ -178,6 +175,7 @@ people following this tutorial.
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ]
+    license = {file = "LICENSE"}
 
     [project.urls]
     Homepage = "https://github.com/pypa/sampleproject"
@@ -209,40 +207,25 @@ The options allowed here are defined in :pep:`621`. In short, they are:
   which license your package is available under, and which operating systems
   your package will work on. For a complete list of classifiers, see
   https://pypi.org/classifiers/.
+- ``license`` is a table with either ``file=`` or ``text=``. Backends will often be
+  happy with a trove classifier too.
 - ``urls`` lets you list any number of extra links to show on PyPI.
   Generally this could be to the source, documentation, issue trackers, etc.
 
 Besides the entries shown above, there are a few more:
 
-- ``license`` is a table with either ``file=`` or ``text=``. Backends will often be
-  happy with a trove classifier too.
 - ``maintainers`` is list of inline tables, with name and emails, just like ``authors``.
-- ``keywords`` are a list of project keywords.
+- ``keywords`` is a list of project keywords.
 - ``scripts`` are the command-line scripts exported by the proejct as a table.
 - ``gui-scripts`` are the graphical scripts exported by the project as a table.
 - ``entry-points`` are non-script entry points as a table.
-- ``dependencies`` are a list of required dependencies at install time. :pep:404 syntax.
+- ``dependencies`` are a list of required dependencies at install time. :pep:`404` syntax.
 - ``optional-dependencies`` is a table of extras.
 
-There is also one special entry: ``dynamic``. This is a list of fields
-(from the above) tha are specified dynamically during the building of your project instead of being listed in
-the static :file:`pyproject.toml`. For example, Flit allows ``version`` and
-``description`` to be dynamic.
-
-:pep:`621` does not refer to package structure at all, only metadata, so
-structure will depend on backend. Both :ref:`Flit` and :ref:`pdm`
-automatically detect ``<package>`` and ``src/<package>`` structure, but other
-backends might have other expectations or settings.
-
-    .. warning::
-
-      You may see some existing projects or other Python packaging tutorials that
-      import their ``setup`` function from ``distutils.core`` rather than
-      ``setuptools``. This is a legacy approach that installers support
-      for backwards compatibility purposes [1]_, but using the legacy ``distutils`` API
-      directly in new projects is strongly discouraged, since ``distutils`` is
-      deprecated as per :pep:`632` and will be removed from the standard library
-      in Python 3.12.
+There is also one special entry: ``dynamic``. This is a list of fields (from
+the above) tha are specified dynamically during the building of your project
+instead of being listed in the static :file:`pyproject.toml`. For example, Flit
+allows ``version`` and ``description`` to be dynamic.
 
 Creating README.md
 ------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -103,7 +103,7 @@ Creating pyproject.toml
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
 what is required to build your project. You can select a variety of backends
 here; the tutorial will work identically on Hatchling, Flit, PDM, and
-Setuptools; most backends that support :pep:`621` should work. Your
+Setuptools; most backends that support the ``project`` table should work. Your
 :file:`pyproject.toml` file should contain one of these build-system blocks:
 
 .. tab:: Hatchling
@@ -132,7 +132,7 @@ Setuptools; most backends that support :pep:`621` should work. Your
 .. tab:: PDM
 
     :ref:`pdm` has a build backend as well (not required to use PDM for package
-    management, any PEP 621 backend works).
+    management, any standards-compliant backend works).
 
     .. code-block:: toml
 
@@ -165,7 +165,7 @@ See :pep:`517` and :pep:`518` for background and details.
 Configuring metadata
 ^^^^^^^^^^^^^^^^^^^^
 
-:pep:`621` provides a standard way to define metadata in :file:`pyproject.toml`.
+There is a standard way to define metadata in :file:`pyproject.toml`.
 
 Open :file:`pyproject.toml` and enter the following content. Change the ``name``
 to include your username; this ensures that you have a unique package name
@@ -178,7 +178,7 @@ people following this tutorial.
     name = "example-pkg-YOUR-USERNAME-HERE"
     version = "0.0.1"
     authors = [
-      {name="Example Author", email="author@example.com"},
+      { name="Example Author", email="author@example.com" },
     ]
     description = "A small example package"
     readme = "README.md"
@@ -188,7 +188,6 @@ people following this tutorial.
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ]
-    license = {file = "LICENSE"}
 
     [project.urls]
     Homepage = "https://github.com/pypa/sampleproject"
@@ -204,7 +203,9 @@ The options allowed here are defined in the :ref:`project metadata specification
 - ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>` for more details on
   versions. Some build backends allow it to be specified another way, such
   as from a file or a git tag.
-- ``authors`` is used to identify the author of the package.
+- ``authors`` is used to identify the author of the package; you specify a name
+  and an email for each author. You can also list ``maintainers`` in the same
+  format.
 - ``description`` is a short, one-sentence summary of the package.
 - ``readme`` is a detailed description of the package. This is
   shown on the package detail page on the Python Package Index. The long
@@ -220,25 +221,20 @@ The options allowed here are defined in the :ref:`project metadata specification
   which license your package is available under, and which operating systems
   your package will work on. For a complete list of classifiers, see
   https://pypi.org/classifiers/.
-- ``license`` is a table with either ``file=`` or ``text=``. Backends will often be
-  happy with a trove classifier too.
 - ``urls`` lets you list any number of extra links to show on PyPI.
   Generally this could be to the source, documentation, issue trackers, etc.
 
-Besides the entries shown above, there are a few more:
-
-- ``maintainers`` is list of inline tables, with name and emails, just like ``authors``.
-- ``keywords`` is a list of project keywords.
-- ``scripts`` are the command-line scripts exported by the proejct as a table.
-- ``gui-scripts`` are the graphical scripts exported by the project as a table.
-- ``entry-points`` are non-script entry points as a table.
-- ``dependencies`` are a list of required dependencies at install time. :pep:`404` syntax.
-- ``optional-dependencies`` is a table of extras.
+Besides the entries shown above, there are a few more. You can use ``keywords``
+to list keywords to improve discoverability.  You can make a list of
+``dependencies`` that are required to install your package.  You can list
+``scripts``/``gui-scripts`` or general plugin-like ``entry-points``; see
+:ref:`project metadata specification <declaring-project-metadata>` for details
+on these and a little more.
 
 There is also one special entry: ``dynamic``. This is a list of fields (from
 the above) that are specified dynamically during the building of your project
-instead of being listed in the static :file:`pyproject.toml`. For example, Flit
-allows ``version`` and ``description`` to be dynamic.
+instead of being listed in the static :file:`pyproject.toml`. Some backends allow
+``version`` to be dynamic, and pull it from a file or your Version Control System.
 
 Creating README.md
 ------------------
@@ -300,7 +296,7 @@ Including other files
 The files listed above will be included automatically in your
 :term:`source distribution <Source Distribution (or "sdist")>`. If you want to
 control what goes in this explicitly, see :ref:`Using MANIFEST.in` for setuptools.
-Other backends like Flit have methods to control this - :pep:`621` only covers
+Other backends like Flit have methods to control this - the ``project`` table covers
 metadata, not package structure.
 
 The final :term:`built distribution <Built Distribution>` will have the Python

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -109,12 +109,12 @@ should contain one of these build-system blocks:
 .. tab:: Setuptools
 
     This is the original backend for building projects, with C extension
-    support and many plugins, like :ref:`setuptools_scm`.
+    support and many plugins, like :ref:`setuptools_scm`. EXPERIMENTAL.
 
     .. code-block:: toml
 
         [build-system]
-        requires = ["setuptools @ git+https://github.com/pypa/setuptools@experimental/support-pyproject"]
+        requires = ["setuptools >=61.0"]
         build-backend = "setuptools.build_meta"
 
 .. tab:: Flit

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -102,20 +102,20 @@ Creating pyproject.toml
 
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
 what is required to build your project. You can select a variety of backends
-here; the tutorial will work identically on Setuptools, Flit, and PDM; most
-backends that support :pep:`621` should work. Your :file:`pyproject.toml` file
-should contain one of these build-system blocks:
+here; the tutorial will work identically on Hatchling, Flit, PDM, and
+Setuptools; most backends that support :pep:`621` should work. Your
+:file:`pyproject.toml` file should contain one of these build-system blocks:
 
-.. tab:: Setuptools
+.. tab:: Hatchling
 
-    This is the original backend for building projects, with C extension
-    support and many plugins, like :ref:`setuptools_scm`. EXPERIMENTAL.
+    :ref:`hatch` has a feature-rich build backend, supporting
+    SCM versioning and plugins.
 
     .. code-block:: toml
 
         [build-system]
-        requires = ["setuptools >=61.0"]
-        build-backend = "setuptools.build_meta"
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
 
 .. tab:: Flit
 
@@ -125,19 +125,9 @@ should contain one of these build-system blocks:
     .. code-block:: toml
 
         [build-system]
-        requires = ["flit_core >=3.2"]
+        requires = ["flit_core>=3.2"]
         build-backend = "flit_core.buildapi"
 
-.. tab:: Hatchling
-
-    :ref:`hatch` has a more feature-rich build backend than Flit, supporting
-    SCM versioning and plugins.
-
-    .. code-block:: toml
-
-        [build-system]
-        requires = ["hatchling>=0.7"]
-        build-backend = "hatchling.build"
 
 .. tab:: PDM
 
@@ -149,6 +139,17 @@ should contain one of these build-system blocks:
         [build-system]
         requires = ["pdm-pep517"]
         build-backend = "pdm.pep517.api"
+
+.. tab:: Setuptools
+
+    This is the original backend for building projects, with C extension
+    support and many plugins, like :ref:`setuptools_scm`. EXPERIMENTAL.
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["setuptools>=61.0"]
+        build-backend = "setuptools.build_meta"
 
 
 ``build-system.requires`` gives a list of packages that are needed to build your

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -113,7 +113,7 @@ should contain one of these build-system blocks:
     .. code-block:: toml
 
         [build-system]
-        requires = ["setuptools >=TBD", "wheel>=TBD"]
+        requires = ["setuptools @ git+https://github.com/pypa/setuptools@experimental/support-pyproject"]
         build-backend = "setuptools.build_meta"
 
 .. tab:: Flit
@@ -126,6 +126,17 @@ should contain one of these build-system blocks:
         [build-system]
         requires = ["flit_core >=3.2"]
         build-backend = "flit_core.buildapi"
+
+.. tab:: Hatchling
+
+    :ref:`hatch` has a more feature-rich build backend than flit, supporting
+    SCM versioning and plugins.
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["hatchling>=0.7"]
+        build-backend = "hatchling.build"
 
 .. tab:: PDM
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -214,9 +214,9 @@ Besides the entries shown above, there are a few more:
 - ``optional-dependencies`` is a table of extras.
 
 There is also one special entry: ``dynamic``. This is a list of fields
-(from the above) tha are specified dynamically instead of being listed in
-the static :file:`pyproject.toml`. For example, Flit allows version and
-description to be dynamic.
+(from the above) tha are specified dynamically during the building of your project instead of being listed in
+the static :file:`pyproject.toml`. For example, Flit allows ``version`` and
+``description`` to be dynamic.
 
 :pep:`621` does not refer to package structure at all, only metadata, so
 structure will depend on backend. Both :ref:`Flit` and :ref:`pdm`

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -104,6 +104,7 @@ Creating pyproject.toml
 .. TODO: Clarify ``project`` table (described in "Configuring metadata")
 .. TODO: Refine backend copy
 .. TODO: Add/update links to backends
+.. TODO: Add a note to check the tools' documentation for the current snippet
 
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
 what is required to build your project. You can select a variety of backends
@@ -514,6 +515,6 @@ some things you can do:
 .. TODO: Add links to other guides
 
 * Read about :doc:`/guides/packaging-binary-extensions`.
-* Consider packaging tools that with project management features, such as
+* Consider packaging tools with project management features, such as
   :ref:`hatch`, :ref:`flit`, :ref:`pdm`, and :ref:`poetry`.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -143,7 +143,7 @@ Setuptools; most backends that support :pep:`621` should work. Your
 .. tab:: Setuptools
 
     This is the original backend for building projects, with C extension
-    support and many plugins, like :ref:`setuptools_scm`. EXPERIMENTAL.
+    support and many plugins, like :ref:`setuptools_scm`.
 
     .. code-block:: toml
 
@@ -194,14 +194,14 @@ people following this tutorial.
     Homepage = "https://github.com/pypa/sampleproject"
     Bug Tracker = "https://github.com/pypa/sampleproject/issues"
 
-The options allowed here are defined in :pep:`621`. In short, they are:
+The options allowed here are defined in the :ref:`project metadata specification <declaring-project-metadata>`. In short, they are:
 
 - ``name`` is the *distribution name* of your package. This can be any name as
   long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
   already be taken on pypi.org. **Be sure to update this with your username,**
   as this ensures you won't try to upload a package with the same name as one
   which already exists.
-- ``version`` is the package version. See :pep:`440` for more details on
+- ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>` for more details on
   versions. Some build backends allow it to be specified another way, such
   as from a file or a git tag.
 - ``authors`` is used to identify the author of the package.
@@ -209,7 +209,7 @@ The options allowed here are defined in :pep:`621`. In short, they are:
 - ``readme`` is a detailed description of the package. This is
   shown on the package detail page on the Python Package Index. The long
   description is loaded from :file:`README.md` (which is a common pattern).
-  There also is a more advanced table form described in :pep:`621`.
+  There also is a more advanced table form described in the :ref:`project metadata specification <declaring-project-metadata>`.
 - ``requires-python`` gives the versions of Python supported by your
   project. Installers like :ref:`pip` will look back through older versions of
   packages until it finds one that has a matching Python version.
@@ -236,7 +236,7 @@ Besides the entries shown above, there are a few more:
 - ``optional-dependencies`` is a table of extras.
 
 There is also one special entry: ``dynamic``. This is a list of fields (from
-the above) tha are specified dynamically during the building of your project
+the above) that are specified dynamically during the building of your project
 instead of being listed in the static :file:`pyproject.toml`. For example, Flit
 allows ``version`` and ``description`` to be dynamic.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -293,8 +293,8 @@ include additional files, see the documentation for your build backend.
 Generating distribution archives
 --------------------------------
 
-The next step is to generate :term:`distribution packages <Distribution
-Package>` for the package. These are archives that are uploaded to the Python
+The next step is to generate :term:`distribution packages <Distribution Package>`
+for the package. These are archives that are uploaded to the Python
 Package Index and can be installed by :ref:`pip`.
 
 Make sure you have the latest version of PyPA's :ref:`build` installed:
@@ -338,13 +338,13 @@ files in the :file:`dist` directory:
       example-package-YOUR-USERNAME-HERE-0.0.1.tar.gz
 
 
-The ``tar.gz`` file is a :term:`source archive <Source Archive>` whereas the
-``.whl`` file is a :term:`built distribution <Built Distribution>`. Newer
-:ref:`pip` versions preferentially install built distributions, but will fall
-back to source archives if needed. You should always upload a source archive and
-provide built archives for the platforms your project is compatible with. In
-this case, our example package is compatible with Python on any platform so only
-one built distribution is needed.
+The ``tar.gz`` file is a :term:`source distribution <Source Distribution (or "sdist")>`
+whereas the ``.whl`` file is a :term:`built distribution <Built Distribution>`.
+Newer :ref:`pip` versions preferentially install built distributions, but will
+fall back to source distributions if needed. You should always upload a source
+distribution and provide built distributions for the platforms your project is
+compatible with. In this case, our example package is compatible with Python on
+any platform so only one built distribution is needed.
 
 Uploading the distribution archives
 -----------------------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -3,7 +3,7 @@ Packaging Python Projects
 
 This tutorial walks you through how to package a simple Python project. It will
 show you how to add the necessary files and structure to create the package, how
-to build the package, and how to upload it to the Python Package Index.
+to build the package, and how to upload it to the Python Package Index (PyPI).
 
 .. tip::
 
@@ -100,11 +100,16 @@ Creating a test directory
 Creating pyproject.toml
 -----------------------
 
+.. TODO: Define "backend" (first reference)
+.. TODO: Clarify ``project`` table (described in "Configuring metadata")
+.. TODO: Refine backend copy
+.. TODO: Add/update links to backends
+
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
 what is required to build your project. You can select a variety of backends
 here; the tutorial will work identically on Hatchling, Flit, PDM, and
 Setuptools; most backends that support the ``project`` table should work. Your
-:file:`pyproject.toml` file should contain one of these build-system blocks:
+:file:`pyproject.toml` file should contain one of these ``build-system`` blocks:
 
 .. tab:: Hatchling
 
@@ -152,12 +157,9 @@ Setuptools; most backends that support the ``project`` table should work. Your
         build-backend = "pdm.pep517.api"
 
 
-``build-system.requires`` gives a list of packages that are needed to build your
-package. Listing something here will *only* make it available during the build,
-not after it is installed.
-
-``build-system.build-backend`` is the name of Python object that will be used to
-perform the build. 
+``build-system.requires`` is a list of packages that are needed to build your
+package. ``build-system.build-backend`` is the name of Python object that will
+be used to perform the build.
 
 See :pep:`517` and :pep:`518` for background and details.
 
@@ -193,24 +195,26 @@ people following this tutorial.
     Homepage = "https://github.com/pypa/sampleproject"
     Bug Tracker = "https://github.com/pypa/sampleproject/issues"
 
-The options allowed here are defined in the :ref:`project metadata specification <declaring-project-metadata>`. In short, they are:
+The fields allowed here are defined in the :ref:`project metadata specification <declaring-project-metadata>`.
+In short, they are:
 
 - ``name`` is the *distribution name* of your package. This can be any name as
   long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
-  already be taken on pypi.org. **Be sure to update this with your username,**
+  already be taken on PyPI. **Be sure to update this with your username,**
   as this ensures you won't try to upload a package with the same name as one
   which already exists.
-- ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>` for more details on
-  versions. Some build backends allow it to be specified another way, such
-  as from a file or a git tag.
+- ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>`
+  for more details on versions. Some build backends allow it to be specified
+  another way, such as from a file or a git tag.
 - ``authors`` is used to identify the author of the package; you specify a name
   and an email for each author. You can also list ``maintainers`` in the same
   format.
 - ``description`` is a short, one-sentence summary of the package.
-- ``readme`` is a detailed description of the package. This is
-  shown on the package detail page on the Python Package Index. The long
-  description is loaded from :file:`README.md` (which is a common pattern).
-  There also is a more advanced table form described in the :ref:`project metadata specification <declaring-project-metadata>`.
+- ``readme`` is a path to a file containing a detailed description of the
+  package. This is shown on the package detail page on PyPI.
+  In this case, the description is loaded from :file:`README.md` (which is a
+  common pattern). There also is a more advanced table form described in the
+  :ref:`project metadata specification <declaring-project-metadata>`.
 - ``requires-python`` gives the versions of Python supported by your
   project. Installers like :ref:`pip` will look back through older versions of
   packages until it finds one that has a matching Python version.
@@ -224,17 +228,10 @@ The options allowed here are defined in the :ref:`project metadata specification
 - ``urls`` lets you list any number of extra links to show on PyPI.
   Generally this could be to the source, documentation, issue trackers, etc.
 
-Besides the entries shown above, there are a few more. You can use ``keywords``
-to list keywords to improve discoverability.  You can make a list of
-``dependencies`` that are required to install your package.  You can list
-``scripts``/``gui-scripts`` or general plugin-like ``entry-points``; see
-:ref:`project metadata specification <declaring-project-metadata>` for details
-on these and a little more.
-
-There is also one special entry: ``dynamic``. This is a list of fields (from
-the above) that are specified dynamically during the building of your project
-instead of being listed in the static :file:`pyproject.toml`. Some backends allow
-``version`` to be dynamic, and pull it from a file or your Version Control System.
+See the :ref:`project metadata specification <declaring-project-metadata>` for
+details on all of the fields that can be defined in the ``project`` table. Some
+other common ones are ``keywords`` to improve discoverability and the
+``dependencies`` that are required to install your package.
 
 Creating README.md
 ------------------
@@ -249,12 +246,6 @@ if you'd like.
     This is a simple example package. You can use
     [Github-flavored Markdown](https://guides.github.com/features/mastering-markdown/)
     to write your content.
-
-
-Because our configuration loads :file:`README.md` to provide a
-``long_description``, :file:`README.md` must be included along with your
-code when you :ref:`generate a source distribution <generating archives>`.
-Newer versions of :ref:`setuptools` will do this automatically.
 
 
 Creating a LICENSE
@@ -295,15 +286,7 @@ Including other files
 
 The files listed above will be included automatically in your
 :term:`source distribution <Source Distribution (or "sdist")>`. If you want to
-control what goes in this explicitly, see :ref:`Using MANIFEST.in` for setuptools.
-Other backends like Flit have methods to control this - the ``project`` table covers
-metadata, not package structure.
-
-The final :term:`built distribution <Built Distribution>` will have the Python
-files in the discovered or listed Python packages. If you want to control what
-goes here, such as to add data files, see
-:doc:`Including Data Files <setuptools:userguide/datafiles>`
-from the :doc:`setuptools docs <setuptools:index>`.
+include additional files, see the documentation for your build backend.
 
 .. _generating archives:
 
@@ -528,9 +511,9 @@ differences:
 At this point if you want to read more on packaging Python libraries here are
 some things you can do:
 
-* Read more about using :ref:`setuptools` to package libraries in
-  :doc:`/guides/distributing-packages-using-setuptools`.
+.. TODO: Add links to other guides
+
 * Read about :doc:`/guides/packaging-binary-extensions`.
-* Consider alternatives to :ref:`setuptools` such as :ref:`hatch`, :ref:`flit`,
-  :ref:`pdm`, and :ref:`poetry`.
+* Consider packaging tools that with project management features, such as
+  :ref:`hatch`, :ref:`flit`, :ref:`pdm`, and :ref:`poetry`.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -535,6 +535,6 @@ some things you can do:
 * Read more about using :ref:`setuptools` to package libraries in
   :doc:`/guides/distributing-packages-using-setuptools`.
 * Read about :doc:`/guides/packaging-binary-extensions`.
-* Consider alternatives to :ref:`setuptools` such as :ref:`flit`, :ref:`pdm`,
-  :ref:`hatch`, and :ref:`poetry`.
+* Consider alternatives to :ref:`setuptools` such as :ref:`hatch`, :ref:`flit`,
+  :ref:`pdm`, and :ref:`poetry`.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -483,7 +483,7 @@ do much the same as you did in this tutorial, but with these important
 differences:
 
 * Choose a memorable and unique name for your package. You don't have to append
-  your username as you did in the tutorial. But you can't take an existing name.
+  your username as you did in the tutorial, but you can't take an existing name.
 * Register an account on https://pypi.org - note that these are two separate
   servers and the login details from the test server are not shared with the
   main server.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -100,22 +100,17 @@ Creating a test directory
 Creating pyproject.toml
 -----------------------
 
-.. TODO: Define "backend" (first reference)
-.. TODO: Clarify ``project`` table (described in "Configuring metadata")
-.. TODO: Refine backend copy
-.. TODO: Add/update links to backends
-.. TODO: Add a note to check the tools' documentation for the current snippet
+:file:`pyproject.toml` tells tools like :ref:`pip` and :ref:`build` what 
+"build backend" to use to create :term:`distribution packages <Distribution Package>`
+for your project. You can choose from a number of backends; this tutorial
+recommends :ref:`Hatchling <hatch>` for its simplicity and speed, but it will
+work identically with :ref:`setuptools`, :ref:`Flit <flit>`, :ref:`PDM <pdm>`,
+and others that support the ``[project]`` table for :ref:`metadata <configuring
+metadata>`.
 
-:file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
-what is required to build your project. You can select a variety of backends
-here; the tutorial will work identically on Hatchling, Flit, PDM, and
-Setuptools; most backends that support the ``project`` table should work. Your
-:file:`pyproject.toml` file should contain one of these ``build-system`` blocks:
+Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
 
 .. tab:: Hatchling
-
-    :ref:`hatch` has a feature-rich build backend, supporting
-    SCM versioning and plugins. Recommended for beginners.
 
     .. code-block:: toml
 
@@ -123,10 +118,7 @@ Setuptools; most backends that support the ``project`` table should work. Your
         requires = ["hatchling"]
         build-backend = "hatchling.build"
 
-.. tab:: Setuptools
-
-    This is the original backend for building projects, with C extension
-    support and many plugins, like :ref:`setuptools_scm`.
+.. tab:: setuptools
 
     .. code-block:: toml
 
@@ -135,9 +127,6 @@ Setuptools; most backends that support the ``project`` table should work. Your
         build-backend = "setuptools.build_meta"
 
 .. tab:: Flit
-
-    :ref:`Flit` is a very lightweight, simple, and fast backend for pure Python
-    projects. It has no dependencies at all.
 
     .. code-block:: toml
 
@@ -148,9 +137,6 @@ Setuptools; most backends that support the ``project`` table should work. Your
 
 .. tab:: PDM
 
-    :ref:`pdm` has a build backend as well (not required to use PDM for package
-    management, any standards-compliant backend works).
-
     .. code-block:: toml
 
         [build-system]
@@ -158,12 +144,13 @@ Setuptools; most backends that support the ``project`` table should work. Your
         build-backend = "pdm.pep517.api"
 
 
-``build-system.requires`` is a list of packages that are needed to build your
-package. ``build-system.build-backend`` is the name of Python object that will
-be used to perform the build.
+``requires`` is a list of packages that are needed to build your package.
+``build-backend`` is the name of Python object that will be used to perform the
+build. See :pep:`517` and :pep:`518` for background and details.
 
-See :pep:`517` and :pep:`518` for background and details.
+.. TODO: Add note to check the tools' documentation for the current snippet?
 
+.. _configuring metadata:
 
 Configuring metadata
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -119,8 +119,9 @@ that supports :pep:`621` will work.
 
 .. tab:: PDM
 
-    If you use  :ref:`pdm`, open :file:`pyproject.toml` and enter the following
-    content:
+    If you want to use use :ref:`pdm`'s backend (not required to use PDM for
+    package management, any PEP 621 backend works), open :file:`pyproject.toml`
+    and enter the following content:
 
     .. code-block:: toml
 
@@ -220,7 +221,7 @@ the static :file:`pyproject.toml`. For example, Flit allows ``version`` and
 
 :pep:`621` does not refer to package structure at all, only metadata, so
 structure will depend on backend. Both :ref:`Flit` and :ref:`pdm`
-automatically detect `<package>` and `src/<package>` structure, but other
+automatically detect ``<package>`` and ``src/<package>`` structure, but other
 backends might have other expectations or settings.
 
     .. warning::

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -35,10 +35,11 @@ A simple project
 ----------------
 
 This tutorial uses a simple project named
-``example_package_YOUR_USERNAME_HERE``; if your username is ``me``, then the
-package would be ``example_package_me``; this ensures a unique name for
-uploading to TestPyPI at the end. We recommend following this tutorial as-is
-using this project, before packaging your own project.
+``example_package_YOUR_USERNAME_HERE``. If your username is ``me``, then the
+package would be ``example_package_me``; this ensures that you have a unique
+package name that doesn't conflict with packages uploaded by other people
+following this tutorial. We recommend following this tutorial as-is using this
+project, before packaging your own project.
 
 Create the following file structure locally:
 
@@ -50,9 +51,8 @@ Create the following file structure locally:
             ├── __init__.py
             └── example.py
 
-The folder containing the Python module should match the package name, both
-to avoid extra configuration and to avoid confusing users who expect the pip
-install name to match the importable name.
+The directory containing the Python files should match the project name. This
+simplifies the configuration and is more obvious to users who install the package.
 
 :file:`__init__.py` is required to import the directory as a package, and
 should be empty.
@@ -91,9 +91,9 @@ When you're done, the project structure will look like this:
     ├── pyproject.toml
     ├── README.md
     ├── src/
-    │   └── example_package_YOUR_USERNAME_HERE/
-    │       ├── __init__.py
-    │       └── example.py
+    │   └── example_package_YOUR_USERNAME_HERE/
+    │       ├── __init__.py
+    │       └── example.py
     └── tests/
 
 
@@ -106,13 +106,23 @@ Creating a test directory
 Creating pyproject.toml
 -----------------------
 
-:file:`pyproject.toml` tells tools like :ref:`pip` and :ref:`build` what 
-"build backend" to use to create :term:`distribution packages <Distribution Package>`
-for your project. You can choose from a number of backends; this tutorial
-recommends :ref:`Hatchling <hatch>` for its simplicity and speed, but it will
-work identically with :ref:`setuptools`, :ref:`Flit <flit>`, :ref:`PDM <pdm>`,
-and others that support the ``[project]`` table for :ref:`metadata <configuring
-metadata>`.
+.. TODO: Add an intro sentence about pyproject.toml, and a sub-heading for
+   "Configuring build tools"
+
+:file:`pyproject.toml` tells tools "frontend" build tools like :ref:`pip` and
+:ref:`build` what "backend" tool to use to create
+:term:`distribution packages <Distribution Package>` for your project.
+You can choose from a number of backends; this tutorial uses :ref:`Hatchling
+<hatch>` by default, but it will work identically with :ref:`setuptools`,
+:ref:`Flit <flit>`, :ref:`PDM <pdm>`, and others that support the ``[project]``
+table for :ref:`metadata <configuring metadata>`.
+
+.. note::
+
+   Some build backends are part of larger tools that provide a command-line
+   interface with additional features like project initialization and version
+   management, as well as building, uploading, and installing packages. This
+   tutorial uses single-purpose tools that work independently.
 
 Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
 
@@ -140,7 +150,6 @@ Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
         requires = ["flit_core>=3.2"]
         build-backend = "flit_core.buildapi"
 
-
 .. tab:: PDM
 
     .. code-block:: toml
@@ -150,9 +159,11 @@ Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
         build-backend = "pdm.pep517.api"
 
 
-``requires`` is a list of packages that are needed to build your package.
-``build-backend`` is the name of Python object that will be used to perform the
-build. See :pep:`517` and :pep:`518` for background and details.
+- ``requires`` is a list of packages that are needed to build your package. You
+  don't need to install them; build frontends like :ref:`pip` will install them
+  automatically in a temporary, isolated virtual environment.
+- ``build-backend`` is the name of the Python object that frontends will use to
+  perform the build.
 
 .. TODO: Add note to check the tools' documentation for the current snippet?
 
@@ -162,9 +173,9 @@ Configuring metadata
 ^^^^^^^^^^^^^^^^^^^^
 
 Open :file:`pyproject.toml` and enter the following content. Change the ``name``
-to include your username; this ensures that you have a unique package name
-and that your package doesn't conflict with packages uploaded by other
-people following this tutorial.
+to include your username; this ensures that you have a unique
+package name that doesn't conflict with packages uploaded by other people
+following this tutorial.
 
 .. code-block:: toml
 
@@ -497,8 +508,10 @@ At this point if you want to read more on packaging Python libraries here are
 some things you can do:
 
 .. TODO: Add links to other guides
+.. TODO: Add links to backend configuration docs
 
-* Read about :doc:`/guides/packaging-binary-extensions`.
 * Consider packaging tools with project management features, such as
   :ref:`hatch`, :ref:`flit`, :ref:`pdm`, and :ref:`poetry`.
+* See :pep:`517` and :pep:`518` for background and details on build tool configuration.
+* Read about :doc:`/guides/packaging-binary-extensions`.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -168,8 +168,6 @@ See :pep:`517` and :pep:`518` for background and details.
 Configuring metadata
 ^^^^^^^^^^^^^^^^^^^^
 
-There is a standard way to define metadata in :file:`pyproject.toml`.
-
 Open :file:`pyproject.toml` and enter the following content. Change the ``name``
 to include your username; this ensures that you have a unique package name
 and that your package doesn't conflict with packages uploaded by other
@@ -178,7 +176,7 @@ people following this tutorial.
 .. code-block:: toml
 
     [project]
-    name = "example-pkg-YOUR-USERNAME-HERE"
+    name = "example-package-YOUR-USERNAME-HERE"
     version = "0.0.1"
     authors = [
       { name="Example Author", email="author@example.com" },
@@ -193,11 +191,8 @@ people following this tutorial.
     ]
 
     [project.urls]
-    Homepage = "https://github.com/pypa/sampleproject"
-    Bug Tracker = "https://github.com/pypa/sampleproject/issues"
-
-The fields allowed here are defined in the :ref:`project metadata specification <declaring-project-metadata>`.
-In short, they are:
+    "Homepage" = "https://github.com/pypa/sampleproject"
+    "Bug Tracker" = "https://github.com/pypa/sampleproject/issues"
 
 - ``name`` is the *distribution name* of your package. This can be any name as
   long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
@@ -230,8 +225,8 @@ In short, they are:
   Generally this could be to the source, documentation, issue trackers, etc.
 
 See the :ref:`project metadata specification <declaring-project-metadata>` for
-details on all of the fields that can be defined in the ``project`` table. Some
-other common ones are ``keywords`` to improve discoverability and the
+details on these and other fields that can be defined in the ``[project]``
+table. Other common fields are ``keywords`` to improve discoverability and the
 ``dependencies`` that are required to install your package.
 
 Creating README.md

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -77,13 +77,13 @@ Creating the package files
 You will now add files that are used to prepare the project for distribution.
 When you're done, the project structure will look like this:
 
+
 .. code-block:: text
 
     packaging_tutorial/
     ├── LICENSE
     ├── pyproject.toml
     ├── README.md
-    ├── setup.cfg
     ├── src/
     │   └── example_package/
     │       ├── __init__.py
@@ -101,14 +101,32 @@ Creating pyproject.toml
 -----------------------
 
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
-what is required to build your project. This tutorial uses :ref:`setuptools`,
-so open :file:`pyproject.toml` and enter the following content:
+what is required to build your project. You can select a variety of backends
+here; the tutorial will assume you are using :ref:`Flit`, though any backend
+that supports :pep:`621` will work.
 
-.. code-block:: toml
 
-    [build-system]
-    requires = ["setuptools>=42"]
-    build-backend = "setuptools.build_meta"
+.. tab:: Flit
+
+    If you use  :ref:`Flit`, open :file:`pyproject.toml` and enter the
+    following content:
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["flit_core >=3.2"]
+        build-backend = "flit_core.buildapi"
+
+.. tab:: PDM
+
+    If you use  :ref:`pdm`, open :file:`pyproject.toml` and enter the following
+    content:
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["pdm-pep517"]
+        build-backend = "pdm.pep517.api"
 
 
 ``build-system.requires`` gives a list of packages that are needed to build your
@@ -116,10 +134,7 @@ package. Listing something here will *only* make it available during the build,
 not after it is installed.
 
 ``build-system.build-backend`` is the name of Python object that will be used to
-perform the build. If you were to use a different build system, such as
-:ref:`flit` or :ref:`poetry`, those would go here, and the configuration details
-would be completely different than the :ref:`setuptools` configuration described
-below.
+perform the build. 
 
 See :pep:`517` and :pep:`518` for background and details.
 
@@ -127,204 +142,86 @@ See :pep:`517` and :pep:`518` for background and details.
 Configuring metadata
 --------------------
 
-There are two types of metadata: static and dynamic.
+:pep:`621`: provides a standard way to define metadata. Flit is used below, but
+you can instead use any build system that follows :pep:`621`, like :ref:`PDM`.
+:file:`pyproject.toml` configuration is stored in the ``[project]`` table.
 
-* Static metadata (:file:`setup.cfg`): guaranteed to be the same every time. This is
-  simpler, easier to read, and avoids many common errors, like encoding errors.
-* Dynamic metadata (:file:`setup.py`): possibly non-deterministic. Any items that are
-  dynamic or determined at install-time, as well as extension modules or
-  extensions to setuptools, need to go into :file:`setup.py`.
+Open :file:`pyproject.toml` and enter the following content. Change the ``name``
+to include your username; this ensures that you have a unique package name
+and that your package doesn't conflict with packages uploaded by other
+people following this tutorial.
 
-Static metadata (:file:`setup.cfg`) should be preferred. Dynamic metadata (:file:`setup.py`)
-should be used only as an escape hatch when absolutely necessary. :file:`setup.py` used to
-be required, but can be omitted with newer versions of setuptools and pip.
+.. code-block:: toml
 
+    [project]
+    name = "example-pkg-YOUR-USERNAME-HERE"
+    version = "0.0.1"
+    authors = [
+      {name="Example Author", email="author@example.com"},
+    ]
+    description = "A small example package"
+    readme = "README.md"
+    requires-python = ">=3.6"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ]
 
-.. tab:: :file:`setup.cfg` (static)
+    [project.urls]
+    Homepage = "https://github.com/pypa/sampleproject"
+    Bug Tracker = "https://github.com/pypa/sampleproject/issues"
 
-    :file:`setup.cfg` is the configuration file for :ref:`setuptools`. It tells
-    setuptools about your package (such as the name and version) as well as which
-    code files to include. Eventually much of this configuration may be able to move
-    to :file:`pyproject.toml`.
+The options allowed here are defined in :pep:`621`. In short, they are:
 
-    Open :file:`setup.cfg` and enter the following content. Change the ``name``
-    to include your username; this ensures that you have a unique package name
-    and that your package doesn't conflict with packages uploaded by other
-    people following this tutorial.
+- ``name`` is the *distribution name* of your package. This can be any name as
+  long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
+  already be taken on pypi.org. **Be sure to update this with your username,**
+  as this ensures you won't try to upload a package with the same name as one
+  which already exists.
+- ``version`` is the package version. See :pep:`440` for more details on
+  versions. Some build backends allow it to be specified another way, such
+  as from a file or a git tag.
+- ``authors`` is used to identify the author of the package.
+- ``description`` is a short, one-sentence summary of the package.
+- ``readme`` is a detailed description of the package. This is
+  shown on the package detail page on the Python Package Index. The long
+  description is loaded from :file:`README.md` (which is a common pattern).
+  There also is a more advanced table form described in :pep:`621`.
+- ``requires-python`` gives the versions of Python supported by your
+  project. Installers like :ref:`pip` will look back through older versions of
+  packages until it finds one that has a matching Python version.
+- ``classifiers`` gives the index and :ref:`pip` some additional metadata
+  about your package. In this case, the package is only compatible with Python
+  3, is licensed under the MIT license, and is OS-independent. You should
+  always include at least which version(s) of Python your package works on,
+  which license your package is available under, and which operating systems
+  your package will work on. For a complete list of classifiers, see
+  https://pypi.org/classifiers/.
+- ``urls`` lets you list any number of extra links to show on PyPI.
+  Generally this could be to the source, documentation, issue trackers, etc.
 
-    .. code-block:: python
+Besides the entries shown above, there are a few more:
 
-        [metadata]
-        name = example-package-YOUR-USERNAME-HERE
-        version = 0.0.1
-        author = Example Author
-        author_email = author@example.com
-        description = A small example package
-        long_description = file: README.md
-        long_description_content_type = text/markdown
-        url = https://github.com/pypa/sampleproject
-        project_urls =
-            Bug Tracker = https://github.com/pypa/sampleproject/issues
-        classifiers =
-            Programming Language :: Python :: 3
-            License :: OSI Approved :: MIT License
-            Operating System :: OS Independent
+- ``license`` is a table with either ``file=`` or ``text=``. Backends will often be
+  happy with a trove classifier too.
+- ``maintainers`` is list of inline tables, with name and emails, just like ``authors``.
+- ``keywords`` are a list of project keywords.
+- ``scripts`` are the command-line scripts exported by the proejct as a table.
+- ``gui-scripts`` are the graphical scripts exported by the project as a table.
+- ``entry-points`` are non-script entry points as a table.
+- ``dependencies`` are a list of required dependencies at install time. :pep:404 syntax.
+- ``optional-dependencies`` is a table of extras.
 
-        [options]
-        package_dir =
-            = src
-        packages = find:
-        python_requires = >=3.6
+There is also one special entry: ``dynamic``. This is a list of fields
+(from the above) tha are specified dynamically instead of being listed in
+the static :file:`pyproject.toml`. For example, Flit allows version and
+description to be dynamic.
 
-        [options.packages.find]
-        where = src
-
-    There are a `variety of metadata and options
-    <https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html>`_
-    supported here. This is in :doc:`configparser <python:library/configparser>`
-    format; do not place quotes around values. This example package uses a
-    relatively minimal set of ``metadata``:
-
-    - ``name`` is the *distribution name* of your package. This can be any name as
-      long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
-      already be taken on pypi.org. **Be sure to update this with your username,**
-      as this ensures you won't try to upload a package with the same name as one
-      which already exists.
-    - ``version`` is the package version. See :pep:`440` for more details on
-      versions. You can use ``file:`` or ``attr:`` directives to read from a file or
-      package attribute.
-    - ``author`` and ``author_email`` are used to identify the author of the
-      package.
-    - ``description`` is a short, one-sentence summary of the package.
-    - ``long_description`` is a detailed description of the package. This is
-      shown on the package detail page on the Python Package Index. In
-      this case, the long description is loaded from :file:`README.md` (which is
-      a common pattern) using the ``file:`` directive.
-    - ``long_description_content_type`` tells the index what type of markup is
-      used for the long description. In this case, it's Markdown.
-    - ``url`` is the URL for the homepage of the project. For many projects, this
-      will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
-      service.
-    - ``project_urls`` lets you list any number of extra links to show on PyPI.
-      Generally this could be to documentation, issue trackers, etc.
-    - ``classifiers`` gives the index and :ref:`pip` some additional metadata
-      about your package. In this case, the package is only compatible with Python
-      3, is licensed under the MIT license, and is OS-independent. You should
-      always include at least which version(s) of Python your package works on,
-      which license your package is available under, and which operating systems
-      your package will work on. For a complete list of classifiers, see
-      https://pypi.org/classifiers/.
-
-    In the ``options`` category, we have controls for setuptools itself:
-
-    - ``package_dir`` is a mapping of package names and directories.
-      An empty package name represents the "root package" --- the directory in
-      the project that contains all Python source files for the package --- so
-      in this case the ``src`` directory is designated the root package.
-    - ``packages`` is a list of all Python :term:`import packages <Import
-      Package>` that should be included in the :term:`distribution package
-      <Distribution Package>`. Instead of listing each package manually, we can
-      use the ``find:`` directive to automatically discover all packages and
-      subpackages and ``options.packages.find`` to specify the ``package_dir``
-      to use. In this case, the list of packages will be ``example_package`` as
-      that's the only package present.
-    - ``python_requires`` gives the versions of Python supported by your
-      project. Installers like :ref:`pip` will look back through older versions of
-      packages until it finds one that has a matching Python version.
-
-    There are many more than the ones mentioned here. See
-    :doc:`/guides/distributing-packages-using-setuptools` for more details.
-
-
-.. tab:: :file:`setup.py` (dynamic)
-
-    :file:`setup.py` is the build script for :ref:`setuptools`. It tells setuptools
-    about your package (such as the name and version) as well as which code files
-    to include.
-
-    Open :file:`setup.py` and enter the following content.  Change the ``name``
-    to include your username; this ensures that you have a unique package name
-    and that your package doesn't conflict with packages uploaded by other
-    people following this tutorial.
-
-    .. code-block:: python
-
-        import setuptools
-
-        with open("README.md", "r", encoding="utf-8") as fh:
-            long_description = fh.read()
-
-        setuptools.setup(
-            name="example-package-YOUR-USERNAME-HERE",
-            version="0.0.1",
-            author="Example Author",
-            author_email="author@example.com",
-            description="A small example package",
-            long_description=long_description,
-            long_description_content_type="text/markdown",
-            url="https://github.com/pypa/sampleproject",
-            project_urls={
-                "Bug Tracker": "https://github.com/pypa/sampleproject/issues",
-            },
-            classifiers=[
-                "Programming Language :: Python :: 3",
-                "License :: OSI Approved :: MIT License",
-                "Operating System :: OS Independent",
-            ],
-            package_dir={"": "src"},
-            packages=setuptools.find_packages(where="src"),
-            python_requires=">=3.6",
-        )
-
-
-    :func:`setup` takes several arguments. This example package uses a relatively
-    minimal set:
-
-    - ``name`` is the *distribution name* of your package. This can be any name as
-      long as it only contains letters, numbers, ``_`` , and ``-``. It also must not
-      already be taken on pypi.org. **Be sure to update this with your username,**
-      as this ensures you won't try to upload a package with the same name as one
-      which already exists.
-    - ``version`` is the package version. See :pep:`440` for more details on
-      versions.
-    - ``author`` and ``author_email`` are used to identify the author of the
-      package.
-    - ``description`` is a short, one-sentence summary of the package.
-    - ``long_description`` is a detailed description of the package. This is
-      shown on the package detail page on the Python Package Index. In
-      this case, the long description is loaded from :file:`README.md`, which is
-      a common pattern.
-    - ``long_description_content_type`` tells the index what type of markup is
-      used for the long description. In this case, it's Markdown.
-    - ``url`` is the URL for the homepage of the project. For many projects, this
-      will just be a link to GitHub, GitLab, Bitbucket, or similar code hosting
-      service.
-    - ``project_urls`` lets you list any number of extra links to show on PyPI.
-      Generally this could be to documentation, issue trackers, etc.
-    - ``classifiers`` gives the index and :ref:`pip` some additional metadata
-      about your package. In this case, the package is only compatible with Python
-      3, is licensed under the MIT license, and is OS-independent. You should
-      always include at least which version(s) of Python your package works on,
-      which license your package is available under, and which operating systems
-      your package will work on. For a complete list of classifiers, see
-      https://pypi.org/classifiers/.
-    - ``package_dir`` is a dictionary with package names for keys and directories
-      for values. An empty package name represents the "root package" --- the
-      directory in the project that contains all Python source files for the
-      package --- so in this case the ``src`` directory is designated the root
-      package.
-    - ``packages`` is a list of all Python :term:`import packages <Import
-      Package>` that should be included in the :term:`distribution package
-      <Distribution Package>`. Instead of listing each package manually, we can
-      use :func:`find_packages` to automatically discover all packages and
-      subpackages under ``package_dir``. In this case, the list of packages will
-      be ``example_package`` as that's the only package present.
-    - ``python_requires`` gives the versions of Python supported by your
-      project. Installers like :ref:`pip` will look back though older versions of
-      packages until it finds one that has a matching Python version.
-
-    There are many more than the ones mentioned here. See
-    :doc:`/guides/distributing-packages-using-setuptools` for more details.
+:pep:`621` does not refer to package structure at all, only metadata, so
+structure will depend on backend. Both :ref:`Flit` and :ref:`pdm`
+automatically detect `<package>` and `src/<package>` structure, but other
+backends might have other expectations or settings.
 
     .. warning::
 
@@ -395,7 +292,9 @@ Including other files
 
 The files listed above will be included automatically in your
 :term:`source distribution <Source Distribution (or "sdist")>`. If you want to
-control what goes in this explicitly, see :ref:`Using MANIFEST.in`.
+control what goes in this explicitly, see :ref:`Using MANIFEST.in` for setuptools.
+Other backends like Flit have methods to control this - :pep:`621` only covers
+metadata, not package structure.
 
 The final :term:`built distribution <Built Distribution>` will have the Python
 files in the discovered or listed Python packages. If you want to control what

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -102,14 +102,25 @@ Creating pyproject.toml
 
 :file:`pyproject.toml` tells build tools (like :ref:`pip` and :ref:`build`)
 what is required to build your project. You can select a variety of backends
-here; the tutorial will assume you are using :ref:`Flit`, though any backend
-that supports :pep:`621` will work.
+here; the tutorial will work identically on Setuptools, Flit, and PDM; most
+backends that support :pep:`621` should work. Your :file:`pyproject.toml` file
+should contain one of these build-system blocks:
 
+.. tab:: Setuptools
+
+    This is the classic backend for building projects; large, slow, but
+    powerful with many options.
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["setuptools >=TBD", "wheel>=TBD"]
+        build-backend = "setuptools.build_meta"
 
 .. tab:: Flit
 
-    If you use  :ref:`Flit`, open :file:`pyproject.toml` and enter the
-    following content:
+    :ref:`Flit` is a very lightweight, simple, and fast backend for pure Python
+    projects. It is 10x faster than setuptools, and has no dependencies at all.
 
     .. code-block:: toml
 
@@ -120,8 +131,8 @@ that supports :pep:`621` will work.
 .. tab:: PDM
 
     If you want to use use :ref:`pdm`'s backend (not required to use PDM for
-    package management, any PEP 621 backend works), open :file:`pyproject.toml`
-    and enter the following content:
+    package management, any PEP 621 backend works), it also has a standalone
+    backend for builds. It has some features not present in Flit.
 
     .. code-block:: toml
 
@@ -143,9 +154,8 @@ See :pep:`517` and :pep:`518` for background and details.
 Configuring metadata
 --------------------
 
-:pep:`621`: provides a standard way to define metadata. Flit is used below, but
-you can instead use any build system that follows :pep:`621`, like :ref:`PDM`.
-:file:`pyproject.toml` configuration is stored in the ``[project]`` table.
+:pep:`621` provides a standard way to define metadata.  :file:`pyproject.toml`
+configuration is stored in the ``[project]`` table.
 
 Open :file:`pyproject.toml` and enter the following content. Change the ``name``
 to include your username; this ensures that you have a unique package name
@@ -529,8 +539,8 @@ some things you can do:
 * Read more about using :ref:`setuptools` to package libraries in
   :doc:`/guides/distributing-packages-using-setuptools`.
 * Read about :doc:`/guides/packaging-binary-extensions`.
-* Consider alternatives to :ref:`setuptools` such as :ref:`flit`, :ref:`hatch`,
-  and :ref:`poetry`.
+* Consider alternatives to :ref:`setuptools` such as :ref:`flit`, :ref:`pdm`,
+  :ref:`hatch`, and :ref:`poetry`.
 
 ----
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -34,9 +34,11 @@ sure you have the latest version installed:
 A simple project
 ----------------
 
-This tutorial uses a simple project named ``example_package``.  We recommend
-following this tutorial as-is using this project, before packaging your own
-project.
+This tutorial uses a simple project named
+``example_package_YOUR_USERNAME_HERE``; if your username is ``me``, then the
+package would be ``example_package_me``; this ensures a unique name for
+uploading to TestPyPI at the end. We recommend following this tutorial as-is
+using this project, before packaging your own project.
 
 Create the following file structure locally:
 
@@ -44,9 +46,13 @@ Create the following file structure locally:
 
     packaging_tutorial/
     └── src/
-        └── example_package/
+        └── example_package_YOUR_USERNAME_HERE/
             ├── __init__.py
             └── example.py
+
+The folder containing the Python module should match the package name, both
+to avoid extra configuration and to avoid confusing users who expect the pip
+install name to match the importable name.
 
 :file:`__init__.py` is required to import the directory as a package, and
 should be empty.
@@ -85,7 +91,7 @@ When you're done, the project structure will look like this:
     ├── pyproject.toml
     ├── README.md
     ├── src/
-    │   └── example_package/
+    │   └── example_package_YOUR_USERNAME_HERE/
     │       ├── __init__.py
     │       └── example.py
     └── tests/
@@ -163,7 +169,7 @@ people following this tutorial.
 .. code-block:: toml
 
     [project]
-    name = "example-package-YOUR-USERNAME-HERE"
+    name = "example_package_YOUR_USERNAME_HERE"
     version = "0.0.1"
     authors = [
       { name="Example Author", email="author@example.com" },
@@ -317,8 +323,8 @@ files in the :file:`dist` directory:
 .. code-block:: text
 
     dist/
-      example-package-YOUR-USERNAME-HERE-0.0.1-py3-none-any.whl
-      example-package-YOUR-USERNAME-HERE-0.0.1.tar.gz
+      example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
+      example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
 
 
 The ``tar.gz`` file is a :term:`source distribution <Source Distribution (or "sdist")>`
@@ -389,14 +395,14 @@ After the command completes, you should see output similar to this:
     Uploading distributions to https://test.pypi.org/legacy/
     Enter your username: [your username]
     Enter your password:
-    Uploading example-package-YOUR-USERNAME-HERE-0.0.1-py3-none-any.whl
+    Uploading example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
     100%|█████████████████████| 4.65k/4.65k [00:01<00:00, 2.88kB/s]
-    Uploading example-package-YOUR-USERNAME-HERE-0.0.1.tar.gz
+    Uploading example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
     100%|█████████████████████| 4.25k/4.25k [00:01<00:00, 3.05kB/s]
 
 
 Once uploaded your package should be viewable on TestPyPI, for example,
-https://test.pypi.org/project/example-package-YOUR-USERNAME-HERE
+https://test.pypi.org/project/example_package_YOUR_USERNAME_HERE
 
 
 Installing your newly uploaded package
@@ -426,9 +432,9 @@ something like this:
 .. code-block:: text
 
     Collecting example-package-YOUR-USERNAME-HERE
-      Downloading https://test-files.pythonhosted.org/packages/.../example-package-YOUR-USERNAME-HERE-0.0.1-py3-none-any.whl
-    Installing collected packages: example-package-YOUR-USERNAME-HERE
-    Successfully installed example-package-YOUR-USERNAME-HERE-0.0.1
+      Downloading https://test-files.pythonhosted.org/packages/.../example_package_YOUR_USERNAME_HERE_0.0.1-py3-none-any.whl
+    Installing collected packages: example_package_YOUR_USERNAME_HERE
+    Successfully installed example_package_YOUR_USERNAME_HERE-0.0.1
 
 .. note:: This example uses ``--index-url`` flag to specify TestPyPI instead of
    live PyPI. Additionally, it specifies ``--no-deps``. Since TestPyPI doesn't
@@ -456,14 +462,10 @@ and import the package:
 
 .. code-block:: python
 
-    >>> from example_package import example
+    >>> from example_package_YOUR_USERNAME_HERE import example
     >>> example.add_one(2)
     3
 
-Note that the :term:`import package <Import Package>` is ``example_package``
-regardless of what ``name`` you gave your :term:`distribution package <Distribution
-Package>` in :file:`setup.cfg` or :file:`setup.py` (in this case,
-``example-package-YOUR-USERNAME-HERE``).
 
 Next steps
 ----------
@@ -481,7 +483,7 @@ do much the same as you did in this tutorial, but with these important
 differences:
 
 * Choose a memorable and unique name for your package. You don't have to append
-  your username as you did in the tutorial.
+  your username as you did in the tutorial. But you can't take an existing name.
 * Register an account on https://pypi.org - note that these are two separate
   servers and the login details from the test server are not shared with the
   main server.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -109,13 +109,24 @@ Setuptools; most backends that support the ``project`` table should work. Your
 .. tab:: Hatchling
 
     :ref:`hatch` has a feature-rich build backend, supporting
-    SCM versioning and plugins.
+    SCM versioning and plugins. Recommended for beginners.
 
     .. code-block:: toml
 
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
+
+.. tab:: Setuptools
+
+    This is the original backend for building projects, with C extension
+    support and many plugins, like :ref:`setuptools_scm`.
+
+    .. code-block:: toml
+
+        [build-system]
+        requires = ["setuptools>=61.0"]
+        build-backend = "setuptools.build_meta"
 
 .. tab:: Flit
 
@@ -139,17 +150,6 @@ Setuptools; most backends that support the ``project`` table should work. Your
         [build-system]
         requires = ["pdm-pep517"]
         build-backend = "pdm.pep517.api"
-
-.. tab:: Setuptools
-
-    This is the original backend for building projects, with C extension
-    support and many plugins, like :ref:`setuptools_scm`.
-
-    .. code-block:: toml
-
-        [build-system]
-        requires = ["setuptools>=61.0"]
-        build-backend = "setuptools.build_meta"
 
 
 ``build-system.requires`` gives a list of packages that are needed to build your

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -161,7 +161,8 @@ Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
 
 - ``requires`` is a list of packages that are needed to build your package. You
   don't need to install them; build frontends like :ref:`pip` will install them
-  automatically in a temporary, isolated virtual environment.
+  automatically in a temporary, isolated virtual environment for use during the
+  build process.
 - ``build-backend`` is the name of the Python object that frontends will use to
   perform the build.
 
@@ -494,7 +495,7 @@ do much the same as you did in this tutorial, but with these important
 differences:
 
 * Choose a memorable and unique name for your package. You don't have to append
-  your username as you did in the tutorial, but you can't take an existing name.
+  your username as you did in the tutorial, but you can't use an existing name.
 * Register an account on https://pypi.org - note that these are two separate
   servers and the login details from the test server are not shared with the
   main server.
@@ -510,8 +511,9 @@ some things you can do:
 .. TODO: Add links to other guides
 .. TODO: Add links to backend configuration docs
 
-* Consider packaging tools with project management features, such as
-  :ref:`hatch`, :ref:`flit`, :ref:`pdm`, and :ref:`poetry`.
-* See :pep:`517` and :pep:`518` for background and details on build tool configuration.
+* Consider packaging tools that provide a single command-line interface for
+  project management and packaging, such as :ref:`hatch`, :ref:`flit`,
+  :ref:`pdm`, and :ref:`poetry`.
+* Read :pep:`517` and :pep:`518` for background and details on build tool configuration.
 * Read about :doc:`/guides/packaging-binary-extensions`.
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -150,7 +150,7 @@ See :pep:`517` and :pep:`518` for background and details.
 
 
 Configuring metadata
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 :pep:`621` provides a standard way to define metadata in :file:`pyproject.toml`.
 
@@ -525,13 +525,3 @@ some things you can do:
 * Consider alternatives to :ref:`setuptools` such as :ref:`flit`, :ref:`pdm`,
   :ref:`hatch`, and :ref:`poetry`.
 
-----
-
-.. [1] Some legacy Python environments may not have ``setuptools``
-       pre-installed, and the operators of those environments may still be
-       requiring users to install packages by running ``setup.py install``
-       commands, rather than providing an installer like ``pip`` that
-       automatically installs required build dependendencies. These
-       environments will not be able to use many published packages until the
-       environment is updated to provide an up to date Python package
-       installation client (e.g. by running ``python -m ensurepip``).

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -412,8 +412,8 @@ After the command completes, you should see output similar to this:
     100%|█████████████████████| 4.25k/4.25k [00:01<00:00, 3.05kB/s]
 
 
-Once uploaded your package should be viewable on TestPyPI, for example,
-https://test.pypi.org/project/example_package_your_username_here.
+Once uploaded your package should be viewable on TestPyPI; for example:
+``https://test.pypi.org/project/example_package_YOUR_USERNAME_HERE``.
 
 
 Installing your newly uploaded package


### PR DESCRIPTION
This is a simpler, PEP 621 _only_ version of #1030. Might not be ready to go this route, but this would be what I think we could do.

Also, I'd love to move this over to using pipx. That would really simplify the ending commands (building and publishing), and would remove the unix/windows split from everything except the first line, where pipx would be installed.

_Update from @bhrutledge_:

Merging is currently blocked on changing the example package name to support backend discovery; see discussion in https://github.com/pypa/packaging.python.org/pull/1031#discussion_r891096802. Until that's fixed, the tutorial is broken. Further content improvements can be made in future PRs. Closes #1085.