### PR TITLE
Say that distribution names should be lowercase in wheel filenames

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -159,8 +159,9 @@ As the components of the filename are separated by a dash (``-``, HYPHEN-MINUS),
 this character cannot appear within any component. This is handled as follows:
 
 - In distribution names, any run of ``-_.`` characters (HYPHEN-MINUS, LOW LINE
-  and FULL STOP) should be replaced with ``_`` (LOW LINE). This is equivalent
-  to :pep:`503` normalisation followed by replacing ``-`` with ``_``.
+  and FULL STOP) should be replaced with ``_`` (LOW LINE), and uppercase
+  characters should be replaced with corresponding lowercase ones. This is
+  equivalent to :pep:`503` normalisation followed by replacing ``-`` with ``_``.
 - Version numbers should be normalised according to :pep:`440`. Normalised
   version numbers cannot contain ``-``.
 - The remaining components may not contain ``-`` characters, so no escaping

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -162,6 +162,9 @@ this character cannot appear within any component. This is handled as follows:
   and FULL STOP) should be replaced with ``_`` (LOW LINE), and uppercase
   characters should be replaced with corresponding lowercase ones. This is
   equivalent to :pep:`503` normalisation followed by replacing ``-`` with ``_``.
+  Tools consuming wheels must be prepared to accept ``.`` (FULL STOP) and
+  uppercase letters, however, as these were allowed by an earlier version of
+  this specification.
 - Version numbers should be normalised according to :pep:`440`. Normalised
   version numbers cannot contain ``-``.
 - The remaining components may not contain ``-`` characters, so no escaping


### PR DESCRIPTION
This should wait on the resolution of [this Discourse thread](https://discuss.python.org/t/revisiting-distribution-name-normalization/12348) about normalisation rules. I'm presuming it will come out in favour of keeping PEP 503 normalisation for wheel filenames.

This was an oversight on my part - I wanted the spec to directly describe the normalisation rule, not only refer to another spec, because I think this is clearer for people reading it. But I missed out the lower-casing step from PEP 503 in my description. The specs [for `.dist-info`](https://packaging.python.org/en/latest/specifications/recording-installed-packages/) and [for sdists](https://packaging.python.org/en/latest/specifications/source-distribution-format/) both refer to PEP 503 without trying to copy the relevant details, so they don't have this issue.

Given that name normalisation here is relatively new, we might want a note saying that tools consuming packages should be prepared to accept capital letters and dots in wheel filenames, because we can't really change names for existing packages.