### PR TITLE
Upgrade expected Python version

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -131,9 +131,9 @@ need:
 
       python -m pip install --user nox
 
-2. Python 3.6. Our build scripts are designed to work with Python 3.6 only.
+2. Python 3.8. Our build scripts are usually tested with Python 3.8 only.
    See the :doc:`Hitchhiker's Guide to Python installation instructions <python-guide:starting/installation>`
-   to install Python 3.6 on your operating system.
+   to install Python 3.8 on your operating system.
 
 To build the guide, run the following bash command in the source folder:
 


### PR DESCRIPTION
At the moment the documentation doesn't run on Python 3.6 because sphinx-inline-tabs is incompatible to it, so I upgraded Python to a more recent version. I was still a bit conservative, so happy to bring it up to 3.9 :) not sure if all the dependencies run on 3.10 already.