### PR TITLE
Add PDM to the list of alternatives to Pipenv

### DIFF
--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -162,8 +162,8 @@ working well for you or your use case, you may want to explore these other tools
 and techniques, listed in alphabetical order, to see if one of them is a better fit:
 
 * `hatch <https://github.com/ofek/hatch>`_ for opinionated coverage of even
-  more steps in the project management workflow (such as incrementing versions,
-  tagging releases, and creating new skeleton projects from project templates)
+  more steps in the project management workflow, such as incrementing versions,
+  tagging releases, and creating new skeleton projects from project templates.
 * `micropipenv <https://github.com/thoth-station/micropipenv>`_ is a lightweight
   wrapper for pip to support requirements.txt, Pipenv and Poetry lock files or
   converting them to pip-tools compatible output. Designed for containerized

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -168,12 +168,10 @@ and techniques, listed in alphabetical order, to see if one of them is a better 
   wrapper for pip to support requirements.txt, Pipenv and Poetry lock files or
   converting them to pip-tools compatible output. Designed for containerized
   Python applications but not limited to them.
-* `pdm <https://github.com/pdm-project/pdm>`_ for a modern Python package management
-  tool supporting `PEP 582 <https://www.python.org/dev/peps/pep-0582/>`_
-  (no virtualenvs: installation of packages in a ``__pypackages__`` folder,
-  *à la* ``node_modules``) and relying on standards such as
-  `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ and
-  `PEP 621 <https://www.python.org/dev/peps/pep-0621/>`_.
+* `PDM <https://github.com/pdm-project/pdm>`_ for a modern Python package management
+  tool supporting :pep:`582` (replacing virtual environments with ``__pypackages__``
+  directory for package installation) and relying on standards such as :pep:`517` and
+  :pep:`621`.
 * `pip-tools <https://github.com/jazzband/pip-tools>`_ to build your own
   custom workflow from lower level pieces like ``pip-compile`` and ``pip-sync``
 * `poetry <https://github.com/python-poetry/poetry>`__ for a tool comparable in scope

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -163,10 +163,10 @@ and techniques, listed in alphabetical order, to see if one of them is a better 
 * `hatch <https://github.com/ofek/hatch>`_ for opinionated coverage of even
   more steps in the project management workflow, such as incrementing versions,
   tagging releases, and creating new skeleton projects from project templates.
-* `micropipenv <https://github.com/thoth-station/micropipenv>`_ is a lightweight
-  wrapper for pip to support requirements.txt, Pipenv and Poetry lock files or
-  converting them to pip-tools compatible output. Designed for containerized
-  Python applications but not limited to them.
+* `micropipenv <https://github.com/thoth-station/micropipenv>`_ for a lightweight
+  wrapper around pip that supports ``requirements.txt``, Pipenv and Poetry lock files,
+  or converting them to pip-tools compatible output. Designed for containerized
+  Python applications, but not limited to them.
 * `PDM <https://github.com/pdm-project/pdm>`_ for a modern Python package management
   tool supporting :pep:`582` (replacing virtual environments with ``__pypackages__``
   directory for package installation) and relying on standards such as :pep:`517` and
@@ -174,9 +174,8 @@ and techniques, listed in alphabetical order, to see if one of them is a better 
 * `pip-tools <https://github.com/jazzband/pip-tools>`_ for creating a lock file of all
   dependencies from a list of packages directly used in a project, and ensuring that
   only those dependencies are installed.
-* `poetry <https://github.com/python-poetry/poetry>`__ for a tool comparable in scope
-  to ``pipenv`` that focuses more directly on use cases where the repository being
-  managed is structured as a Python project with a valid ``pyproject.toml`` file
-  (by contrast, ``pipenv`` explicitly avoids making the assumption that the
-  application being worked on that's depending on components from PyPI will
-  itself support distribution as a ``pip``-installable Python package).
+* `Poetry <https://github.com/python-poetry/poetry>`__ for a tool comparable in scope
+  to Pipenv that focuses more directly on use cases where the project being managed is
+  structured as a distributable Python package with a valid ``pyproject.toml`` file.
+  By contrast, Pipenv explicitly avoids making the assumption that the application
+  being worked on will support distribution as a ``pip``-installable Python package.

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -21,8 +21,7 @@ applicable to the development and deployment of network services (including
 web applications), but is also very well suited to managing development and
 testing environments for any kind of project.
 
-Alternative dependency management solutions can be found in a non-exhaustive list
-at the bottom of the page.
+For alternatives, see `Other Tools for Application Dependency Management`_.
 
 Installing Pipenv
 -----------------

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -172,8 +172,9 @@ and techniques, listed in alphabetical order, to see if one of them is a better 
   tool supporting :pep:`582` (replacing virtual environments with ``__pypackages__``
   directory for package installation) and relying on standards such as :pep:`517` and
   :pep:`621`.
-* `pip-tools <https://github.com/jazzband/pip-tools>`_ to build your own
-  custom workflow from lower level pieces like ``pip-compile`` and ``pip-sync``
+* `pip-tools <https://github.com/jazzband/pip-tools>`_ for creating a lock file of all
+  dependencies from a list of packages directly used in a project, and ensuring that
+  only those dependencies are installed.
 * `poetry <https://github.com/python-poetry/poetry>`__ for a tool comparable in scope
   to ``pipenv`` that focuses more directly on use cases where the repository being
   managed is structured as a Python project with a valid ``pyproject.toml`` file

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -21,10 +21,8 @@ applicable to the development and deployment of network services (including
 web applications), but is also very well suited to managing development and
 testing environments for any kind of project.
 
-Developers of Python libraries, or of applications that support distribution
-as Python libraries, should also consider the
-`poetry <https://github.com/python-poetry/poetry>`_ project as an alternative dependency
-management solution.
+Alternative dependency management solutions can be found in a non-exhaustive list
+at the bottom of the page.
 
 Installing Pipenv
 -----------------
@@ -161,20 +159,26 @@ Other Tools for Application Dependency Management
 
 If you find this particular approach to managing application dependencies isn't
 working well for you or your use case, you may want to explore these other tools
-and techniques to see if one of them is a better fit:
+and techniques, listed in alphabetical order, to see if one of them is a better fit:
 
+* `hatch <https://github.com/ofek/hatch>`_ for opinionated coverage of even
+  more steps in the project management workflow (such as incrementing versions,
+  tagging releases, and creating new skeleton projects from project templates)
+* `micropipenv <https://github.com/thoth-station/micropipenv>`_ is a lightweight
+  wrapper for pip to support requirements.txt, Pipenv and Poetry lock files or
+  converting them to pip-tools compatible output. Designed for containerized
+  Python applications but not limited to them.
+* `pdm <https://github.com/pdm-project/pdm>`_ for a modern Python package management
+  tool supporting `PEP 582 <https://www.python.org/dev/peps/pep-0582/>`_
+  (no virtualenvs: installation of packages in a ``__pypackages__`` folder,
+  *à la* ``node_modules``) and relying on standards such as
+  `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ and
+  `PEP 621 <https://www.python.org/dev/peps/pep-0621/>`_.
+* `pip-tools <https://github.com/jazzband/pip-tools>`_ to build your own
+  custom workflow from lower level pieces like ``pip-compile`` and ``pip-sync``
 * `poetry <https://github.com/python-poetry/poetry>`__ for a tool comparable in scope
   to ``pipenv`` that focuses more directly on use cases where the repository being
   managed is structured as a Python project with a valid ``pyproject.toml`` file
   (by contrast, ``pipenv`` explicitly avoids making the assumption that the
   application being worked on that's depending on components from PyPI will
   itself support distribution as a ``pip``-installable Python package).
-* `hatch <https://github.com/ofek/hatch>`_ for opinionated coverage of even
-  more steps in the project management workflow (such as incrementing versions,
-  tagging releases, and creating new skeleton projects from project templates)
-* `pip-tools <https://github.com/jazzband/pip-tools>`_ to build your own
-  custom workflow from lower level pieces like ``pip-compile`` and ``pip-sync``
-* `micropipenv <https://github.com/thoth-station/micropipenv>`_ is a lightweight
-  wrapper for pip to support requirements.txt, Pipenv and Poetry lock files or
-  converting them to pip-tools compatible output. Designed for containerized
-  Python applications but not limited to them.


### PR DESCRIPTION
We could also add https://github.com/FFY00/trampolim, but I wanted to see what you think first (and if we add more, all descriptions should probably be made either as comparisons to pipenv, or as pipenv-unrelated descriptions).
I believe these alternatives deserve an entry on this page :slightly_smiling_face: 