### PR TITLE
No longer suggest `wheel` in build-requires for PEP 517 builds

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -107,10 +107,7 @@ so open :file:`pyproject.toml` and enter the following content:
 .. code-block:: toml
 
     [build-system]
-    requires = [
-        "setuptools>=42",
-        "wheel"
-    ]
+    requires = ["setuptools>=42"]
     build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
`"wheel"` is included with proper version by `get_requires_for_build_wheel` from PEP 517, and isn't required for making an sdist, and might not be required in the future at all (in which case setuptools will modify `get_requires_for_build_wheel`). [It's available even in 40.8](https://github.com/pypa/setuptools/blob/c1243e96f05d3b13392a792144c97d9471581550/setuptools/build_meta.py#L130).

This was probably my fault (actually, yes it was, git blame's to me). It is very common, so maybe we should mention wheel is not required? I'd go for simple, I think, but it's possible someone will try to add it again in a PR.