### PR TITLE
Update the "Application dependency management" recommendations

### DIFF
--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -14,8 +14,8 @@ Application dependency management
 * Use :ref:`pip` in a `secure manner`_ to install a Python application and its
   dependencies during deployment.
 
-* Use :ref:`virtualenv`, or :doc:`venv <python:library/venv>` to isolate application
-  specific dependencies from a shared Python installation. [4]_
+* Use :ref:`virtualenv` or :doc:`venv <python:library/venv>` to isolate
+  application-specific dependencies from a shared Python installation. [4]_
 
 * Use `pip-tools`_, :ref:`pipenv`, or `poetry`_ to generate the fully-specified
   application-specific dependencies, when developing Python applications.
@@ -32,8 +32,8 @@ Installation tool recommendations
   is installed, you may need to also install :ref:`wheel` to get the benefit
   of wheel caching. [3]_
 
-* Use :ref:`virtualenv`, or :doc:`venv <python:library/venv>` to isolate application
-  specific dependencies from a shared Python installation. [4]_
+* Use :ref:`virtualenv` or :doc:`venv <python:library/venv>` to isolate
+  application-specific dependencies from a shared Python installation. [4]_
 
 * If you're looking for management of fully integrated cross-platform software
   stacks, consider:

--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -11,17 +11,18 @@ what tools are currently recommended, then here it is.
 Application dependency management
 =================================
 
-Use :ref:`pipenv` to manage library dependencies when developing Python
-applications. See :doc:`../tutorials/managing-dependencies` for more details
-on using ``pipenv``.
+* Use :ref:`pip` in a `secure manner`_ to install a Python application and its
+  dependencies during deployment.
 
-When ``pipenv`` does not meet your use case, consider other tools like:
+* Use :ref:`virtualenv`, or :doc:`venv <python:library/venv>` to isolate application
+  specific dependencies from a shared Python installation. [4]_
 
-* :ref:`pip`
+* Use `pip-tools`_, :ref:`pipenv`, or `poetry`_ to generate the fully-specified
+  application-specific dependencies, when developing Python applications.
 
-* `pip-tools <https://github.com/jazzband/pip-tools>`_
-
-* `Poetry <https://python-poetry.org/>`_
+.. _secure manner: https://pip.pypa.io/en/latest/topics/secure-installs/
+.. _pip-tools: https://github.com/jazzband/pip-tools
+.. _Poetry: https://python-poetry.org/
 
 Installation tool recommendations
 =================================


### PR DESCRIPTION
This is a more detailed recommendation that breaks up the recommendation
into multiple parts, to reflect that multiple tools need to be used in
workflows today to maximise compatibility with existing platforms.

It also recommends that deployed applications be isolated from the
system packages, as was implied but not explicitly noted.

The move away from Pipenv as the primary recommendation is a reflection
of the change that application development workflows have a greater
diversity in mature tooling available for them.

Toward #912