### PR TITLE
Document the 'Private ::' classifier prefix

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -325,6 +325,10 @@ projects on PyPI, not for installing projects.  To actually restrict what
 Python versions a project can be installed on, use the :ref:`python_requires`
 argument.
 
+To prevent a package from being uploaded to PyPI, use the special
+``'Private :: Do Not Upload'`` classifier. PyPI will always reject packages with
+classifiers beginning with ``"Private ::'``.
+
 
 ``keywords``
 ~~~~~~~~~~~~


### PR DESCRIPTION
Fixes https://github.com/pypa/packaging.python.org/issues/643.

Same wording as https://github.com/pypa/warehouse/pull/10872.

Preview: https://python-packaging-user-guide--1056.org.readthedocs.build/en/1056/guides/distributing-packages-using-setuptools/#classifiers