### PR TITLE
Including pep658 in the simple API description

### DIFF
--- a/source/specifications/simple-repository-api.rst
+++ b/source/specifications/simple-repository-api.rst
@@ -8,5 +8,6 @@ Simple repository API
 The current interface for querying available package versions and
 retrieving packages from an index server is defined in :pep:`503`,
 with the addition of "yank" support (allowing a kind of file deletion)
-as defined in :pep:`592` and specifying the interface version provided
-by an index server in :pep:`629`.
+as defined in :pep:`592`, specifying the interface version provided
+by an index server in :pep:`629` and optionally providing metadata 
+separated from the distrobution package as stated in :pep:`658`.


### PR DESCRIPTION
The relevant PEP's to the Simple Repository API are listed, but I'm under the impression that pep658 should also be included.

I'm not too proud about the phrasing, so happy for it to be changed