### PR TITLE
Core Metadata: Rm line allowing metadata producers to use lower versions

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -40,6 +40,7 @@ to a new format.
 .. contents:: Contents
    :local:
 
+
 Metadata-Version
 ================
 
@@ -53,10 +54,6 @@ greater than the highest version they support, and MUST fail if
 ``metadata_version`` has a greater major version than the highest
 version they support (as described in :pep:`440`, the major version is the
 value before the first dot).
-
-For broader compatibility, build tools MAY choose to produce
-distribution metadata using the lowest metadata version that includes
-all of the needed fields.
 
 Example::
 


### PR DESCRIPTION
Presently, the [Metadata-Version ](https://packaging.python.org/en/latest/specifications/core-metadata/#metadata-version) section of the core metadata spec states:

> For broader compatibility, build tools MAY choose to produce distribution metadata using the lowest metadata version that includes all of the needed fields.

Following [discussion on PEP 685's thread](https://discuss.python.org/t/pep-685-comparison-of-extra-names-for-optional-distribution-dependencies/14141/32?u=cam-gerlach) and [related conversations on metadata-version](https://discuss.python.org/t/non-sequential-acceptance-and-implementation-of-new-core-metadata-features-and-changes/14233/3), it seemed prudent to simply remove this; per @pfmoore 

> I would prefer to drop the quoted statement, and let the whole thing come under the “be strict in what you produce and lenient in what you consume” principle, so that metadata producers should always produce the latest version that they can, and consumers should be capable of dealing with older versions.

[PEP 609](https://peps.python.org/pep-0609/) in turn delegates to the the [PyPA Specifications document](https://www.pypa.io/en/latest/specifications/#handling-fixes-and-other-minor-updates), which states:

> All enhancements proposed this way must be discussed on the Packaging category of the [Python.org Discourse](https://discuss.python.org/c/packaging) prior to amending the PEP

@pfmoore is the standing PEP-Delegate for this metadata specification, so it is his call on merging this as-is after the limited discussion thus far, waiting for additional discussion, opening a dedicated thread on Discourse for additional visibility, or taking another action. Thus, I've marked this as a draft until then.