### PR TITLE
Change "application" to "project" in installer recommendation

### DIFF
--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -33,7 +33,7 @@ Installation tool recommendations
   of wheel caching. [3]_
 
 * Use :ref:`virtualenv` or :doc:`venv <python:library/venv>` to isolate
-  application-specific dependencies from a shared Python installation. [4]_
+  project-specific dependencies from a shared Python installation. [4]_
 
 * If you're looking for management of fully integrated cross-platform software
   stacks, consider:


### PR DESCRIPTION
Not all projects that need to be installed are applications. Libraries
should also fall into this recommendation, of what installer tools
should be used when working on them.

Closes https://github.com/pypa/packaging.python.org/issues/865