### PR TITLE
In wheel spec, 'include' should be 'headers'

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -196,7 +196,7 @@ its version, e.g. ``1.0.0``, consist of:
 #. ``{distribution}-{version}.data/`` contains one subdirectory
    for each non-empty install scheme key not already covered, where
    the subdirectory name is an index into a dictionary of install paths
-   (e.g. ``data``, ``scripts``, ``include``, ``purelib``, ``platlib``).
+   (e.g. ``data``, ``scripts``, ``headers``, ``purelib``, ``platlib``).
 #. Python scripts must appear in ``scripts`` and begin with exactly
    ``b'#!python'`` in order to enjoy script wrapper generation and
    ``#!python`` rewriting at install time.  They may have any or no


### PR DESCRIPTION
This is a typo according to https://github.com/pypa/pip/issues/9616#issuecomment-780699010

See also https://github.com/python/peps/pull/2523