### PR TITLE
GHA publish to TestPyPI guide: Update actions, environment and Python

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -5,14 +5,14 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python -m

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -71,7 +71,8 @@ Defining a workflow job environment
 
 Now, let's add initial setup for our job. It's a process that
 will execute commands that we'll define later.
-In this guide, we'll use Ubuntu 18.04:
+In this guide, we'll use the latest stable Ubuntu LTS version
+provided by GitHub Actions:
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
@@ -90,7 +91,7 @@ Then, add the following under the ``build-n-publish`` section:
    :end-before: Install pypa/build
 
 This will download your repository into the CI runner and then
-install and activate Python 3.9.
+install and activate Python 3.10.
 
 And now we can build dists from source. In this example, we'll
 use ``build`` package, assuming that your project has a
@@ -107,7 +108,7 @@ So add this to the steps list:
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
-   :start-after: version: 3.9
+   :start-after: version: "3.10"
    :end-before: Actually publish to PyPI/TestPyPI
 
 


### PR DESCRIPTION
A bit of maintenance on the [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) guide:
- Update the host OS to ubuntu-latest
- Update the actions/setup-python to v3
- Use Python 3.10