### PR TITLE
fix: pip broke a intersphinx reference

### DIFF
--- a/source/discussions/install-requires-vs-requirements.rst
+++ b/source/discussions/install-requires-vs-requirements.rst
@@ -72,7 +72,7 @@ the requirements for a complete Python environment.
 
 Whereas ``install_requires`` requirements are minimal, requirements files
 often contain an exhaustive listing of pinned versions for the purpose of
-achieving :ref:`repeatable installations <pip:Repeatability>` of a complete
+achieving :ref:`repeatable installations <pip:0-repeatability>` of a complete
 environment.
 
 Whereas ``install_requires`` requirements are "Abstract", i.e. not associated


### PR DESCRIPTION
CC @pradyunsg. Current `main` is broken because pip broke references to `pip:repeatability`. Using `pip:0-repeatability` as a fix here, as that's the only thing that seems to work.