### PR TITLE
chore: update GHA guide

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install pypa/build
       run: >-
         python -m

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -14,6 +14,8 @@ It will use the `pypa/gh-action-pypi-publish GitHub Action`_.
 
    This guide *assumes* that you already have a project that
    you know how to build distributions for and *it lives on GitHub*.
+   This guide also assumes you have a pure Python project. If you
+   have binary compoents, check out :ref:`cibuildwheel`.
 
 Saving credentials on GitHub
 ============================
@@ -94,9 +96,7 @@ This will download your repository into the CI runner and then
 install and activate Python 3.10.
 
 And now we can build dists from source. In this example, we'll
-use ``build`` package, assuming that your project has a
-``pyproject.toml`` properly set up (see
-:pep:`517`/:pep:`518`).
+use ``build`` package.
 
 .. tip::
 

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -12,10 +12,10 @@ It will use the `pypa/gh-action-pypi-publish GitHub Action`_.
 
 .. attention::
 
-   This guide *assumes* that you already have a project that
-   you know how to build distributions for and *it lives on GitHub*.
-   This guide also assumes you have a pure Python project. If you
-   have binary compoents, check out :ref:`cibuildwheel`.
+   This guide *assumes* that you already have a project that you know how to
+   build distributions for and *it lives on GitHub*.  This guide also avoids
+   details of building platform specific projects. If you have binary
+   components, check out :ref:`cibuildwheel`'s GitHub Action examples.
 
 Saving credentials on GitHub
 ============================
@@ -102,13 +102,15 @@ use ``build`` package.
 
    You can use any other method for building distributions as long as
    it produces ready-to-upload artifacts saved into the
-   ``dist/`` folder.
+   ``dist/`` folder. You can even use ``actions/upload-artifact`` and
+   ``actions/download-artifact`` to tranfer files between jobs or make them
+   accessable for download from the web CI interface.
 
 So add this to the steps list:
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
-   :start-after: version: "3.10"
+   :start-after: version: "3.x"
    :end-before: Actually publish to PyPI/TestPyPI
 
 
@@ -124,7 +126,9 @@ Finally, add the following steps at the end:
 These two steps use the `pypa/gh-action-pypi-publish`_ GitHub
 Action: the first one uploads contents of the ``dist/`` folder
 into TestPyPI unconditionally and the second does that to
-PyPI, but only if the current commit is tagged.
+PyPI, but only if the current commit is tagged. It is recommended
+you use the latest release tag; a tool like GitHub's dependabot can keep
+these updated regularly.
 
 
 That's all, folks!


### PR DESCRIPTION
This updates the GHA guide a bit with non-controversial changes (hopefully). I think using pipx instead of the current setup would be simpler and is better practice, I might do that in a followup.

Changes:
* Point out this works only for pure Python, link to cibuildwheel for binary packages
* Use Python 3.x
* Drop mention about needed pyproject.toml to use build and links to PEPs (it is backward compatible if it's missing)
* Use more recent versions of actions and the tagged versions of all actions