### PR TITLE
chore: remove obsolete pages from the ToC

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -13,7 +13,6 @@ introduction to packaging, see :doc:`/tutorials/index`.
    installing-stand-alone-command-line-tools
    installing-using-linux-tools
    installing-scientific-packages
-   multi-version-installs
    index-mirrors-and-caches
    hosting-your-own-index
 
@@ -24,13 +23,10 @@ introduction to packaging, see :doc:`/tutorials/index`.
    distributing-packages-using-setuptools
    using-manifest-in
    single-sourcing-package-version
-   supporting-multiple-python-versions
    dropping-older-python-versions
    packaging-binary-extensions
-   supporting-windows-using-appveyor
    packaging-namespace-packages
    creating-and-discovering-plugins
-   migrating-to-pypi-org
    using-testpypi
    making-a-pypi-friendly-readme
    publishing-package-distribution-releases-using-github-actions-ci-cd-workflows

--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -1,7 +1,11 @@
+:orphan:
+
 .. _`Migrating to PyPI.org`:
 
 Migrating to PyPI.org
 =====================
+
+:Page Status: Obsolete
 
 :term:`pypi.org` is the new, rewritten version of PyPI that has replaced the
 legacy PyPI code base. It is the default version of PyPI that people are

--- a/source/guides/multi-version-installs.rst
+++ b/source/guides/multi-version-installs.rst
@@ -1,8 +1,11 @@
+:orphan:
 
 .. _`Multi-version installs`:
 
 Multi-version installs
 ======================
+
+:Page Status: Obsolete
 
 
 easy_install allows simultaneous installation of different versions of the same

--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -1,10 +1,12 @@
+:orphan:
+
 .. _`Supporting multiple Python versions`:
 
 ===================================
 Supporting multiple Python versions
 ===================================
 
-:Page Status: Incomplete
+:Page Status: Obsolete
 :Last Reviewed: 2014-12-24
 
 .. contents:: Contents

--- a/source/guides/supporting-windows-using-appveyor.rst
+++ b/source/guides/supporting-windows-using-appveyor.rst
@@ -1,8 +1,10 @@
+:orphan:
+
 =================================
 Supporting Windows using Appveyor
 =================================
 
-:Page Status: Incomplete
+:Page Status: Obsolete
 :Last Reviewed: 2015-12-03
 
 This section covers how to use the free `Appveyor`_ continuous integration


### PR DESCRIPTION
Discussed at https://discuss.python.org/t/cleaning-up-packaging-python-org-guides/16717 - if everyone there and here is happy with it, then these pages can retire.

This removes four pages that don't have an obvious path forward from the navigation. The URLs stay active (and we have to keep the links alive, etc).
