### PR TITLE
Clarify the project metadata declaration spec around key requirements …

### DIFF
--- a/source/specifications/declaring-project-metadata.rst
+++ b/source/specifications/declaring-project-metadata.rst
@@ -158,7 +158,8 @@ These fields accept an array of tables with 2 keys: ``name`` and
 ``email``. Both values must be strings. The ``name`` value MUST be a
 valid email name (i.e. whatever can be put as a name, before an email,
 in :rfc:`822`) and not contain commas. The ``email`` value MUST be a
-valid email address. Both keys are optional.
+valid email address. Both keys are optional, but at least one of the
+keys must be specified in the table.
 
 Using the data to fill in :ref:`core metadata <core-metadata>` is as
 follows:


### PR DESCRIPTION
…for `authors`/`maintainers`

It's a bit ambiguous as to whether leaving out both `name` and `email` is okay, an error, etc. The original intent was that _at least_ one key would be specified, but no specific key is required.