### PR TITLE
Add PEP 621 tab for entry points docs

### DIFF
--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,8 +120,7 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-Packages have metadata for plugins described in the
-:doc:`/specifications/entry-points`.
+Packages have metadata for plugins described in the :doc:`entry-points`.
 By telling your package’s build backend,
 plugins can register themselves for discovery.
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -127,22 +127,10 @@ plugins can register themselves for discovery.
 For example if you have a package named ``myapp-plugin-a`` and it includes
 the following in its setup file:
 
-.. tab:: :file:`pyproject.toml` (PEP 621)
+.. code-block:: toml
 
-    .. code-block:: toml
-
-         [project.entry-points.'myapp.plugins']
-         a = 'myapp_plugin_a'
-
-.. tab:: :file:`setup.py` (setuptools)
-
-    .. code-block:: toml
-
-        setup(
-            ...
-            entry_points={'myapp.plugins': 'a = myapp_plugin_a'},
-            ...
-        )
+    [project.entry-points.'myapp.plugins']
+    a = 'myapp_plugin_a'
 
 Then you can discover and load all of the registered entry points by using
 :func:`importlib.metadata.entry_points` (or the `backport`_

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -127,7 +127,7 @@ plugins can register themselves for discovery.
 For example if you have a package named ``myapp-plugin-a`` and it includes
 the following in its setup file:
 
-.. tab:: :file:`pyproject.toml` (:pep:`621`)
+.. tab:: :file:`pyproject.toml` (PEP 621)
 
     .. code-block:: toml
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,7 +120,7 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-Packages can have metadata for plugins described in the :doc:`entry-points`.
+Packages can have metadata for plugins described in the :ref:`entry-points`.
 By specifying them, a package announces that it contains a specific kind of plugin.
 Another package supporting this kind of plugin can use the metadata to discover that plugin.
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,21 +120,30 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-:doc:`Setuptools <setuptools:index>` provides :doc:`special support
-<setuptools:userguide/entry_point>` for plugins. By providing the
-``entry_points`` argument to :func:`setup` in :file:`setup.py` plugins can
-register themselves for discovery.
+Packages have metadata for plugins described in the
+:doc:`/specifications/entry-points`.
+By telling your package’s build backend,
+plugins can register themselves for discovery.
 
 For example if you have a package named ``myapp-plugin-a`` and it includes
-in its :file:`setup.py`:
+the following in its setup file:
 
-.. code-block:: python
+.. tab:: :file:`pyproject.toml` (:pep:`621`)
 
-    setup(
-        ...
-        entry_points={'myapp.plugins': 'a = myapp_plugin_a'},
-        ...
-    )
+    .. code-block:: toml
+
+         [project.entry-points.'myapp.plugins']
+         a = 'myapp_plugin_a'
+
+.. tab:: :file:`setup.py` (setuptools)
+
+    .. code-block:: toml
+
+        setup(
+            ...
+            entry_points={'myapp.plugins': 'a = myapp_plugin_a'},
+            ...
+        )
 
 Then you can discover and load all of the registered entry points by using
 :func:`importlib.metadata.entry_points` (or the `backport`_

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -120,12 +120,12 @@ a list of packages to :func:`setup`'s ``packages`` argument instead of using
 Using package metadata
 ======================
 
-Packages have metadata for plugins described in the :doc:`entry-points`.
-By telling your package’s build backend,
-plugins can register themselves for discovery.
+Packages can have metadata for plugins described in the :doc:`entry-points`.
+By specifying them, a package announces that it contains a specific kind of plugin.
+Another package supporting this kind of plugin can use the metadata to discover that plugin.
 
 For example if you have a package named ``myapp-plugin-a`` and it includes
-the following in its setup file:
+the following in its ``pyproject.toml``:
 
 .. code-block:: toml
 
@@ -133,7 +133,7 @@ the following in its setup file:
     a = 'myapp_plugin_a'
 
 Then you can discover and load all of the registered entry points by using
-:func:`importlib.metadata.entry_points` (or the `backport`_
+:func:`importlib.metadata.entry_points` (or the backport_
 ``importlib_metadata >= 3.6`` for Python 3.6-3.9):
 
 .. code-block:: python


### PR DESCRIPTION
Since #1031 is merged, let’s gradually move away from a setuptools centric view.

### [Rendered](https://python-packaging-user-guide--1115.org.readthedocs.build/en/1115/guides/creating-and-discovering-plugins/#using-package-metadata)