### PR TITLE
Use latest python-docs-theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sphinx==4.3.1
 sphinx-autobuild==0.7.1
 sphinx-inline-tabs==2021.4.11b9
-python-docs-theme==2021.5
+python-docs-theme==2022.1
 sphinx-copybutton==0.4.0
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -337,8 +337,8 @@ files in the :file:`dist` directory:
 .. code-block:: text
 
     dist/
-      example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
-      example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
+    ├── example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
+    └── example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
 
 
 The ``tar.gz`` file is a :term:`source distribution <Source Distribution (or "sdist")>`


### PR DESCRIPTION
On at least Chrome and Safari on macOS, the rendering of directory trees are hard to read:

<img width="827" alt="Screen Shot 2022-07-30 at 7 29 21 AM" src="https://user-images.githubusercontent.com/1326704/181908899-abdb9680-c450-439d-ad91-2d1fa236e613.png">

Noting that the [`pypa_theme`](https://github.com/pypa/pypa-docs-theme) inherits from [`python_docs_theme`](https://github.com/python/python-docs-theme), I poked around on the Python docs and discovered that [it's not an issue there](https://docs.python.org/3/library/__main__.html#main-py-in-python-packages). That led me to https://github.com/python/python-docs-theme/pull/87, which was released in 2021.11.1. Sure enough, upgrading fixes the output:

<img width="817" alt="Screen Shot 2022-07-30 at 7 34 31 AM" src="https://user-images.githubusercontent.com/1326704/181909064-f97c788d-6513-463d-a392-5e37da1f717d.png">

This also includes "Make sidebar scrollable and sticky (on modern browsers)", which I think is a nice enhancement.