### PR TITLE
Upgrade copybutton

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ sphinx==4.3.1
 sphinx-autobuild==0.7.1
 sphinx-inline-tabs==2021.4.11b9
 python-docs-theme==2021.5
-sphinx-copybutton==0.4.0
+sphinx-copybutton==0.5.0
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/source/_static/overrides.css
+++ b/source/_static/overrides.css
@@ -1,8 +1,0 @@
-/* Overrides for theme and plugin styles */
-
-/* https://github.com/executablebooks/sphinx-copybutton/blob/v0.4.0/sphinx_copybutton/_static/copybutton.css */
-
-button.copybtn img {
-    /* Fix alignment for pypa_theme */
-    padding: 0;
-}

--- a/source/conf.py
+++ b/source/conf.py
@@ -187,9 +187,7 @@ html_title = 'Python Packaging User Guide'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-html_css_files = ['overrides.css']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
While working on #1116, I found that sphinx-copybutton has a [new release](https://github.com/executablebooks/sphinx-copybutton/blob/master/CHANGELOG.md) that changes the design, and fixes the alignment issue that previously required an [override to fix](https://github.com/pypa/packaging.python.org/pull/946/files#diff-895eee78fb3b0dce9e6556417305d5867a787b35a7ce996bd351e6ccbe8839f7).