### PR TITLE
update the linehaul link to point to https://github.com/pypa/linehaul-cloud-function/

### DIFF
--- a/source/guides/analyzing-pypi-package-downloads.rst
+++ b/source/guides/analyzing-pypi-package-downloads.rst
@@ -42,7 +42,7 @@ limited resources.
 Public dataset
 ==============
 
-As an alternative, the `Linehaul project <https://github.com/pypa/linehaul>`__
+As an alternative, the `Linehaul project <https://github.com/pypa/linehaul-cloud-function/>`__
 streams download logs from PyPI to `Google BigQuery`_ [#]_, where they are
 stored as a public dataset.
 


### PR DESCRIPTION
Noticed the existing link points to an archived repo, updates the link to point to the replacement.