### PR TITLE
Upgrade to Sphinx 4.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.3.1
+sphinx==4.5.0
 sphinx-autobuild==0.7.1
 sphinx-inline-tabs==2021.4.11b9
 python-docs-theme==2022.1


### PR DESCRIPTION
This is quick fix to address broken `:rfc:` links, which seem to have been addressed in [4.4.0](https://www.sphinx-doc.org/en/master/changes.html#release-4-4-0-released-jan-17-2022).

Not upgrading to 5.x because that should include investigation of possible breaking changes.