### PR TITLE
chore: nicer nox help text

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -6,8 +6,15 @@
 import shutil
 import nox
 
-@nox.session(py="3")
+
+nox.options.sessions = []
+
+
+@nox.session()
 def translation(session):
+    """
+    Build the gettext .pot files.
+    """
     session.install("-r", "requirements.txt")
     target_dir = "locales"
     session.run(
@@ -18,8 +25,11 @@ def translation(session):
         target_dir, # where to put the .pot file
     )
 
-@nox.session(py="3")
+@nox.session()
 def build(session, autobuild=False):
+    """
+    Make the website.
+    """
     session.install("-r", "requirements.txt")
 
     target_build_dir = "build"
@@ -49,14 +59,20 @@ def build(session, autobuild=False):
     )
 
 
-@nox.session(py="3")
+@nox.session()
 def preview(session):
+    """
+    Make and preview the website.
+    """
     session.install("sphinx-autobuild")
     build(session, autobuild=True)
 
 
-@nox.session(py="3")
+@nox.session()
 def linkcheck(session):
+    """
+    Check for broken links.
+    """
     session.install("-r", "requirements.txt")
     session.run(
         "sphinx-build", 


### PR DESCRIPTION
This improves the ergonomics and help text of nox slightly.

Here's the new help text:

```
Sessions defined in /Users/henryschreiner/git/webpages/packaging.python.org/noxfile.py:

- translation -> Build the gettext .pot files.
- build -> Make the website.
- preview -> Make and preview the website.
- linkcheck -> Check for broken links.

sessions marked with * are selected, sessions marked with - are skipped.
```

Also, now if you just type `nox`, instead of trying to build twice, and
previewing, then link checking, it will just produce the above help text.

Also removed `py="3"` since it doesn't really do anything anymore.
