### PR TITLE
Divorce the section on pip installing extras from setuptools

### DIFF
--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -641,10 +641,13 @@ default, pip only finds stable versions.
 
         py -m pip install --pre SomeProject
 
-Installing Setuptools "Extras"
-==============================
+Installing "Extras"
+===================
 
-Install `setuptools extras`_.
+Extras are optional "variants" of a package, which may include
+additional dependencies, and thereby enable additional functionality
+from the package.  If you wish to install an extra for a package which
+you know publishes one, you can include it in the pip installation command:
 
 .. tab:: Unix/macOS
 
@@ -681,5 +684,3 @@ Install `setuptools extras`_.
 .. [4] The compatible release specifier was accepted in :pep:`440`
        and support was released in :ref:`setuptools` v8.0 and
        :ref:`pip` v6.0
-
-.. _setuptools extras: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies


### PR DESCRIPTION
Per more recent PEPs (e.g. 621), extras may be produced by build tools
other than setuptools if the packager isn't using setuptools as the
build system. In this document, which is mostly about installing,
it seems simpler then to avoid mentioning that setuptools defines
the extras and to simply show the user how to do the install without
mentioning what tool is involved in defining them.

The main motivation for doing this (besides that I think it's indeed slightly simpler) was I want a page to intersphinx link to from my install documentation (telling users to install an extra), but I indeed don't use setuptools, and don't want to confuse users. It may be there's a better place for me to link to (in which case lemme know :) but figured I'd propose the change no matter what.