### PR TITLE
Revert "Declare license file in packaging tutorial"

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -281,6 +281,9 @@ MIT license:
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
+Most build backends automatically include license files in packages. See your
+backend's documentation for more details.
+
 
 Including other files
 ---------------------

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -188,7 +188,6 @@ following this tutorial.
     ]
     description = "A small example package"
     readme = "README.md"
-    license = { file="LICENSE" }
     requires-python = ">=3.7"
     classifiers = [
         "Programming Language :: Python :: 3",
@@ -217,7 +216,6 @@ following this tutorial.
   In this case, the description is loaded from :file:`README.md` (which is a
   common pattern). There also is a more advanced table form described in the
   :ref:`project metadata specification <declaring-project-metadata>`.
-- ``license`` is the path to the :file:`LICENSE` file, described below.
 - ``requires-python`` gives the versions of Python supported by your
   project. Installers like :ref:`pip` will look back through older versions of
   packages until it finds one that has a matching Python version.


### PR DESCRIPTION
Reverts pypa/packaging.python.org#1098

While investigating https://github.com/pypa/twine/issues/926, I discovered that using `license = { file="LICENSE" }` will result in the contents of `LICENSE` being displayed on PyPI in the "Meta" sidebar section. For example, see:

https://test.pypi.org/project/example-package-bhrutledge/0.0.1/

When I remove that line, I get what I think is the desired behavior, which is the name of the license:

https://test.pypi.org/project/example-package-bhrutledge/0.0.2rc1/

FYI @EpicWink 

