### PR TITLE
Document backend license inclusion behaviour

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -281,6 +281,9 @@ MIT license:
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
+Most build backends automatically include license files in packages. See your
+backend's documentation for more details.
+
 
 Including other files
 ---------------------


### PR DESCRIPTION
See [my comment](https://github.com/pypa/packaging.python.org/pull/1143#issuecomment-1251022855) on documenting how to include the license in the distribution