### PR TITLE
Update versions of github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
-
-      - name: pip cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('noxfile.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
         - linkcheck
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key:

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
     - name: Grab the repo src
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # To reach the common commit
     - name: Set up git user as [bot]
       # Refs:
       # * https://github.community/t/github-actions-bot-email-address/17204/6
       # * https://github.com/actions/checkout/issues/13#issuecomment-724415212
-      uses: fregante/setup-git-user@v1.0.1
+      uses: fregante/setup-git-user@v1.1.0
 
     - name: Switch to the translation source branch
       run: |
@@ -50,7 +50,7 @@ jobs:
         git merge '${{ github.event.repository.default_branch }}'
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: >-
           3.10


### PR DESCRIPTION
Some of them like setup-python before v4 used node.js 12, which is deprecated (see [annotations in actions log](https://github.com/pypa/packaging.python.org/actions/runs/3306153606)).