### PR TITLE
Doc: remove extra backtick in Glossary

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -42,7 +42,7 @@ Glossary
     Egg
 
         A :term:`Built Distribution` format introduced by :ref:`setuptools`,
-        which is being replaced by :term:`Wheel`.  For details, see `
+        which is being replaced by :term:`Wheel`.  For details, see 
         :doc:`The Internal Structure of Python Eggs <setuptools:deprecated/python_eggs>` and
         `Python Eggs <http://peak.telecommunity.com/DevCenter/PythonEggs>`_
 


### PR DESCRIPTION
There's an extra backtick that's not needed in the glossary entry for "egg"

Rendered at: https://packaging.python.org/en/latest/glossary/
