### PR TITLE
Update the flit_core lower bound

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -147,7 +147,7 @@ Open :file:`pyproject.toml` and enter one of these ``[build-system]`` tables:
     .. code-block:: toml
 
         [build-system]
-        requires = ["flit_core>=3.2"]
+        requires = ["flit_core>=3.4"]
         build-backend = "flit_core.buildapi"
 
 .. tab:: PDM


### PR DESCRIPTION
Version 3.4 added PEP 660 support
Version 3.3 added PEP 621 support
https://flit.pypa.io/en/stable/history.html

Feels wrong to allow a version here that doesn't support those