### PR TITLE
Use `req @ url` syntax to install from remote VCS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinx-autobuild==0.7.1
 sphinx-inline-tabs==2021.4.11b9
 python-docs-theme==2022.1
 sphinx-copybutton==0.5.0
-git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
+pypa-docs-theme @ git+https://github.com/pypa/pypa-docs-theme.git

--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -693,7 +693,7 @@ you want "bar" installed from VCS in editable mode, then you could construct a
 requirements file like so::
 
   -e .
-  -e git+https://somerepo/bar.git#egg=bar
+  -e bar @ git+https://somerepo/bar.git
 
 The first line says to install your project and any dependencies. The second
 line overrides the "bar" dependency, such that it's fulfilled from VCS, not

--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -349,7 +349,7 @@ example, you can install directly from a git repository:
 
 .. code-block:: bash
 
-    git+https://github.com/GoogleCloudPlatform/google-auth-library-python.git#egg=google-auth
+    google-auth @ git+https://github.com/GoogleCloudPlatform/google-auth-library-python.git
 
 For more information on supported version control systems and syntax, see pip's
 documentation on :ref:`VCS Support <pip:VCS Support>`.

--- a/source/specifications/direct-url.rst
+++ b/source/specifications/direct-url.rst
@@ -299,10 +299,10 @@ Commands that generate a ``direct_url.json``:
 
 * ``pip install https://example.com/app-1.0.tgz``
 * ``pip install https://example.com/app-1.0.whl``
-* ``pip install "git+https://example.com/repo/app.git#egg=app&subdirectory=setup"``
+* ``pip install "app&subdirectory=setup @ git+https://example.com/repo/app.git"``
 * ``pip install ./app``
 * ``pip install file:///home/user/app``
-* ``pip install --editable "git+https://example.com/repo/app.git#egg=app&subdirectory=setup"``
+* ``pip install --editable "app&subdirectory=setup @ git+https://example.com/repo/app.git"``
   (in which case, ``url`` will be the local directory where the git repository has been
   cloned to, and ``dir_info`` will be present with ``"editable": true`` and no
   ``vcs_info`` will be set)

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -492,19 +492,19 @@ syntax, see pip's section on :ref:`VCS Support <pip:VCS Support>`.
 
     .. code-block:: bash
 
-        python3 -m pip install -e git+https://git.repo/some_pkg.git#egg=SomeProject          # from git
-        python3 -m pip install -e hg+https://hg.repo/some_pkg#egg=SomeProject                # from mercurial
-        python3 -m pip install -e svn+svn://svn.repo/some_pkg/trunk/#egg=SomeProject         # from svn
-        python3 -m pip install -e git+https://git.repo/some_pkg.git@feature#egg=SomeProject  # from a branch
+        python3 -m pip install -e SomeProject @ git+https://git.repo/some_pkg.git          # from git
+        python3 -m pip install -e SomeProject @ hg+https://hg.repo/some_pkg                # from mercurial
+        python3 -m pip install -e SomeProject @ svn+svn://svn.repo/some_pkg/trunk/         # from svn
+        python3 -m pip install -e SomeProject @ git+https://git.repo/some_pkg.git@feature  # from a branch
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install -e git+https://git.repo/some_pkg.git#egg=SomeProject          # from git
-        py -m pip install -e hg+https://hg.repo/some_pkg#egg=SomeProject                # from mercurial
-        py -m pip install -e svn+svn://svn.repo/some_pkg/trunk/#egg=SomeProject         # from svn
-        py -m pip install -e git+https://git.repo/some_pkg.git@feature#egg=SomeProject  # from a branch
+        py -m pip install -e SomeProject @ git+https://git.repo/some_pkg.git          # from git
+        py -m pip install -e SomeProject @ hg+https://hg.repo/some_pkg                # from mercurial
+        py -m pip install -e SomeProject @ svn+svn://svn.repo/some_pkg/trunk/         # from svn
+        py -m pip install -e SomeProject @ git+https://git.repo/some_pkg.git@feature  # from a branch
 
 Installing from other Indexes
 =============================


### PR DESCRIPTION
Use 'req @ url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. pypa/pip#11617 for more details.