### PR TITLE
fix: Use proper subdirectory syntax for pip url fragments

### DIFF
--- a/source/specifications/direct-url.rst
+++ b/source/specifications/direct-url.rst
@@ -299,10 +299,10 @@ Commands that generate a ``direct_url.json``:
 
 * ``pip install https://example.com/app-1.0.tgz``
 * ``pip install https://example.com/app-1.0.whl``
-* ``pip install "app&subdirectory=setup @ git+https://example.com/repo/app.git"``
+* ``pip install "app @ git+https://example.com/repo/app.git#subdirectory=setup"``
 * ``pip install ./app``
 * ``pip install file:///home/user/app``
-* ``pip install --editable "app&subdirectory=setup @ git+https://example.com/repo/app.git"``
+* ``pip install --editable "app @ git+https://example.com/repo/app.git#subdirectory=setup"``
   (in which case, ``url`` will be the local directory where the git repository has been
   cloned to, and ``dir_info`` will be present with ``"editable": true`` and no
   ``vcs_info`` will be set)


### PR DESCRIPTION
* Use the correct syntax for [url fragments with `pip`](https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments) of the form

```
python -m pip install "pkg @ vcs+protocol://repo_url/#subdirectory=pkg_dir"
```

* Revises PR #1207