### PR TITLE
Replace refs to PEP-503 with simple repository API

### DIFF
--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -45,14 +45,13 @@ then ``discovered_plugins`` would be:
         'flask_talisman': <module: 'flask_talisman'>,
     }
 
-Using naming convention for plugins also allows you to query the
-Python Package Index's `simple API`_ for all packages that conform to your
-naming convention.
+Using naming convention for plugins also allows you to query
+the Python Package Index's :ref:`simple repository API <simple-repository-api>`
+for all packages that conform to your naming convention.
 
 .. _Flask: https://pypi.org/project/Flask/
 .. _Flask-SQLAlchemy: https://pypi.org/project/Flask-SQLAlchemy/
 .. _Flask-Talisman: https://pypi.org/project/flask-talisman
-.. _simple API: https://www.python.org/dev/peps/pep-0503/#specification
 
 
 Using namespace packages

--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -55,7 +55,7 @@ instruct users to add the URL to their installer's configuration.
 ----
 
 .. [1] For complete documentation of the simple repository protocol, see
-       :pep:`503`.
+       :ref:`simple repository API <simple-repository-api>`.
 
 
 .. _Twisted: https://twistedmatrix.com/

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -612,10 +612,10 @@ Install from a local directory containing archives (and don't check :term:`PyPI
 Installing from other sources
 =============================
 
-To install from other data sources (for example Amazon S3 storage) you can
-create a helper application that presents the data in a :pep:`503` compliant
-index format, and use the ``--extra-index-url`` flag to direct pip to use
-that index.
+To install from other data sources (for example Amazon S3 storage)
+you can create a helper application that presents the data
+in a format compliant with the :ref:`simple repository API <simple-repository-api>`:,
+and use the ``--extra-index-url`` flag to direct pip to use that index.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Preview: https://python-packaging-user-guide--1213.org.readthedocs.build/en/1213/