### PR TITLE
Quote extras to guard shells with glob qualifiers

### DIFF
--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -292,13 +292,13 @@ specifying the extra in brackets:
 
     .. code-block:: bash
 
-        python3 -m pip install requests[security]
+        python3 -m pip install 'requests[security]'
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install requests[security]
+        py -m pip install "requests[security]"
 
 .. _extras:
     https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -653,17 +653,17 @@ you know publishes one, you can include it in the pip installation command:
 
     .. code-block:: bash
 
-        python3 -m pip install SomePackage[PDF]
-        python3 -m pip install SomePackage[PDF]==3.0
-        python3 -m pip install -e .[PDF]  # editable project in current directory
+        python3 -m pip install 'SomePackage[PDF]'
+        python3 -m pip install 'SomePackage[PDF]==3.0'
+        python3 -m pip install -e '.[PDF]'  # editable project in current directory
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install SomePackage[PDF]
-        py -m pip install SomePackage[PDF]==3.0
-        py -m pip install -e .[PDF]  # editable project in current directory
+        py -m pip install "SomePackage[PDF]"
+        py -m pip install "SomePackage[PDF]==3.0"
+        py -m pip install -e ".[PDF]"  # editable project in current directory
 
 ----
 


### PR DESCRIPTION
Resolves #1209

Shells like `zsh` have glob qualifiers that will error if an extra is not quoted. While the glob qualifiers can be disabled, adding quotes guards against errors if people are copy-pasting or do not know that they can disable the behavior.