### PR TITLE
Fix: python -> pyton3 to match the python3 --version's not found error

### DIFF
--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -58,10 +58,10 @@ please install the latest 3.x version from `python.org`_ or refer to the
 
     .. code-block:: python
 
-        >>> python --version
+        >>> python3 --version
         Traceback (most recent call last):
           File "<stdin>", line 1, in <module>
-        NameError: name 'python' is not defined
+        NameError: name 'python3' is not defined
 
     It's because this command and other suggested commands in this tutorial
     are intended to be run in a *shell* (also called a *terminal* or


### PR DESCRIPTION
The wiki updated the `python3 --version` command but forgot to update the error msg.

This diff updates the error msg.