### PR TITLE
Fix linkcheck

### DIFF
--- a/source/guides/analyzing-pypi-package-downloads.rst
+++ b/source/guides/analyzing-pypi-package-downloads.rst
@@ -343,7 +343,7 @@ References
 .. _public PyPI download statistics dataset: https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=pypi&page=dataset
 .. _Google BigQuery: https://cloud.google.com/bigquery
 .. _BigQuery web UI: https://console.cloud.google.com/bigquery
-.. _pypinfo: https://github.com/ofek/pypinfo/blob/master/README.md
+.. _pypinfo: https://github.com/ofek/pypinfo
 .. _google-cloud-bigquery: https://cloud.google.com/bigquery/docs/reference/libraries
 .. _pandas-gbq: https://pandas-gbq.readthedocs.io/en/latest/
 .. _Pandas: https://pandas.pydata.org/

--- a/source/guides/analyzing-pypi-package-downloads.rst
+++ b/source/guides/analyzing-pypi-package-downloads.rst
@@ -343,7 +343,7 @@ References
 .. _public PyPI download statistics dataset: https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=pypi&page=dataset
 .. _Google BigQuery: https://cloud.google.com/bigquery
 .. _BigQuery web UI: https://console.cloud.google.com/bigquery
-.. _pypinfo: https://github.com/ofek/pypinfo/blob/master/README.rst
+.. _pypinfo: https://github.com/ofek/pypinfo/blob/master/README.md
 .. _google-cloud-bigquery: https://cloud.google.com/bigquery/docs/reference/libraries
 .. _pandas-gbq: https://pandas-gbq.readthedocs.io/en/latest/
 .. _Pandas: https://pandas.pydata.org/


### PR DESCRIPTION
The CI linkcheck is failing: for example https://github.com/pypa/packaging.python.org/actions/runs/4405998144/jobs/7717630748 in https://github.com/pypa/packaging.python.org/pull/1092.

Because `https://github.com/ofek/pypinfo/blob/master/README.rst` was converted to `https://github.com/ofek/pypinfo/blob/master/README.md` yesterday.

https://github.com/ofek/pypinfo/pull/146