### PR TITLE
Quote guard version requirements for pip installs

### DIFF
--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -245,13 +245,13 @@ a specific version of ``requests``:
 
     .. code-block:: bash
 
-        python3 -m pip install requests==2.18.4
+        python3 -m pip install 'requests==2.18.4'
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install requests==2.18.4
+        py -m pip install "requests==2.18.4"
 
 To install the latest ``2.x`` release of requests:
 
@@ -259,13 +259,13 @@ To install the latest ``2.x`` release of requests:
 
     .. code-block:: bash
 
-        python3 -m pip install requests>=2.0.0,<3.0.0
+        python3 -m pip install 'requests>=2.0.0,<3.0.0'
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install requests>=2.0.0,<3.0.0
+        py -m pip install "requests>=2.0.0,<3.0.0"
 
 To install pre-release versions of packages, use the ``--pre`` flag:
 


### PR DESCRIPTION
As pointed out by @henryiii in https://github.com/pypa/packaging.python.org/pull/1216#pullrequestreview-1342428923, adding quotes to version information on packages provides safeguards against common mistakes. Additionally this matches style with https://github.com/pypa/pip/pull/11842.