### PR TITLE
repository_url is deprecated, use repository-url

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -32,7 +32,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
repository_url is deprecated, use repository-url instead , per https://github.com/pypa/gh-action-pypi-publish/blob/a3a3bafbb3e5a75a854ae1bc53ae128cf22c4af4/action.yml#L15