### PR TITLE
Fix or replace references to PEP 427

### DIFF
--- a/source/discussions/wheel-vs-egg.rst
+++ b/source/discussions/wheel-vs-egg.rst
@@ -17,7 +17,9 @@ Distribution>` and :term:`binary <Binary Distribution>` packaging for Python.
 Here's a breakdown of the important differences between :term:`Wheel` and :term:`Egg`.
 
 
-* :term:`Wheel` has an :pep:`official PEP <427>`. :term:`Egg` did not.
+* :term:`Wheel` has an :doc:`official standard specification
+  </specifications/binary-distribution-format>`.
+  :term:`Egg` did not.
 
 * :term:`Wheel` is a :term:`distribution <Distribution Package>` format, i.e a packaging
   format. [1]_ :term:`Egg` was both a distribution format and a runtime
@@ -45,5 +47,5 @@ Here's a breakdown of the important differences between :term:`Wheel` and :term:
 ----
 
 .. [1] Circumstantially, in some cases, wheels can be used as an importable
-       runtime format, although :pep:`this is not officially supported at this time
-       <427#is-it-possible-to-import-python-code-directly-from-a-wheel-file>`.
+       runtime format, although :ref:`this is not officially supported at this time
+       <binary-distribution-format-import-wheel>`.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -237,7 +237,9 @@ Glossary
 
     Wheel
 
-        A :term:`Built Distribution` format introduced by :pep:`427`,
+        A :term:`Built Distribution` format introduced by an official
+        :doc:`standard specification
+        </specifications/binary-distribution-format/>`,
         which is intended to replace the :term:`Egg` format.  Wheel is currently
         supported by :ref:`pip`.
 

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -409,6 +409,8 @@ What's the deal with "purelib" vs. "platlib"?
     be at the root with the appropriate setting given for "Root-is-purelib".
 
 
+.. _binary-distribution-format-import-wheel:
+
 Is it possible to import Python code directly from a wheel file?
 ----------------------------------------------------------------
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -274,7 +274,7 @@ Why not use special character <X> rather than ``.`` or ``-``?
     in some contexts (for example, ``+`` must be quoted in URLs, ``~`` is
     used to denote the user's home directory in POSIX), or because the
     advantages weren't sufficiently compelling to justify changing the
-    existing reference implementation for the wheel format defined in :pep:427
+    existing reference implementation for the wheel format defined in :pep:`427`
     (for example, using ``,`` rather than ``.`` to separate components
     in a compressed tag).
 


### PR DESCRIPTION
PEP 427 is about the binary distribution format *wheel*. The full standard specification is available in the guide so we should link to it instead of the PEP. The PEP is rather a historical document, PEPs are part of the process, they are not the specification document.

Preview:
* https://python-packaging-user-guide--1229.org.readthedocs.build/en/1229/
* and more specifically:
  * https://python-packaging-user-guide--1229.org.readthedocs.build/en/1229/discussions/wheel-vs-egg/
  * https://python-packaging-user-guide--1229.org.readthedocs.build/en/1229/glossary/#term-Wheel
  * https://python-packaging-user-guide--1229.org.readthedocs.build/en/1229/specifications/platform-compatibility-tags/#faq

See also: https://github.com/pypa/packaging.python.org/pull/1213