### PR TITLE
Fix link to specifications page on `pypa.io`

### DIFF
--- a/source/specifications/index.rst
+++ b/source/specifications/index.rst
@@ -6,7 +6,7 @@ PyPA specifications
 This is a list of currently active interoperability specifications maintained
 by the Python Packaging Authority. The process for updating these standards,
 and for proposing new ones, is documented on
-`pypa.io <https://www.pypa.io/en/latest/specifications/>`__.
+`pypa.io <https://www.pypa.io/en/latest/specifications.html>`__.
 
 
 Package Distribution Metadata


### PR DESCRIPTION
GitHub: fixes https://github.com/pypa/packaging.python.org/issues/1238