### PR TITLE
Clarified pip `--upgrade` option and fixed output

### DIFF
--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -66,8 +66,10 @@ For example:
            \
              ^__^
              (oo)\_______
-             (__)\       )\/       ||----w |
+             (__)\       )\/       
                  ||     ||
+                 ||----w |
+
 
 To see a list of packages installed with pipx and which applications are
 available, use ``pipx list``:
@@ -103,14 +105,14 @@ pipx can be upgraded or uninstalled with pip:
 
   .. code-block:: bash
 
-      python3 -m pip install -U pipx
+      python3 -m pip install --upgrade pipx
       python3 -m pip uninstall pipx
 
 .. tab:: Windows
 
   .. code-block:: bat
 
-      py -m pip install -U pipx
+      py -m pip install --upgrade pipx
       py -m pip uninstall pipx
 
 pipx also allows you to install and run the latest version of an application

--- a/source/tutorials/creating-documentation.rst
+++ b/source/tutorials/creating-documentation.rst
@@ -18,13 +18,13 @@ Use ``pip`` to install Sphinx:
 
     .. code-block:: bash
 
-        python3 -m pip install -U sphinx
+        python3 -m pip install --upgrade sphinx
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install -U sphinx
+        py -m pip install --upgrade sphinx
 
 For other installation methods, see this :doc:`installation guide <sphinx:usage/installation>` by Sphinx.
 


### PR DESCRIPTION
Replaced the pip `-U` option with `--upgrade` to clarify the difference to `--user`. Also fixed some `pipx` output.