### PR TITLE
Fix broken Software Collections link

### DIFF
--- a/source/guides/installing-using-linux-tools.rst
+++ b/source/guides/installing-using-linux-tools.rst
@@ -90,7 +90,7 @@ To install pip, wheel, and setuptools, in a parallel, non-system environment
 
    * For Redhat, see here:
      https://developers.redhat.com/products/softwarecollections/overview
-   * For CentOS, see here: https://www.softwarecollections.org/en/
+   * For CentOS, see here: https://github.com/sclorg
 
    Be aware that collections may not contain the most recent versions.
 


### PR DESCRIPTION
Due to an expired security certificate: https://github.com/sclorg/softwarecollections/issues/123

I think this is a temporary swap; if that issue gets resolved, I'll change it back.