### PR TITLE
Update python runtime for RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,11 @@ sphinx:
    # https://github.com/pyca/cryptography/issues/5863#issuecomment-792343136
    builder: dirhtml
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-   version: 3.8
    install:
    - requirements: requirements.txt


### PR DESCRIPTION
The ReadTheDocs build needs a fix since [urllib3v2](https://github.com/urllib3/urllib3/releases/tag/2.0.0).

CC @bhrutledge  