### PR TITLE
Replace link to bottle project page with PyPi link

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,11 @@ sphinx:
    # https://github.com/pyca/cryptography/issues/5863#issuecomment-792343136
    builder: dirhtml
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-   version: 3.8
    install:
    - requirements: requirements.txt

--- a/source/overview.rst
+++ b/source/overview.rst
@@ -67,7 +67,7 @@ This is great for sharing simple scripts and snippets between people
 who both have compatible Python versions (such as via email,
 StackOverflow, or GitHub gists). There are even some entire Python
 libraries that offer this as an option, such as `bottle.py
-<https://bottlepy.org/docs/dev/>`_ and :doc:`boltons
+<https://pypi.org/project/bottle/>`_ and :doc:`boltons
 <boltons:architecture>`.
 
 However, this pattern won't scale for projects that consist of


### PR DESCRIPTION
The bottle project page is not reachable at the moment, so I have replaced the link temporarily with a reference to PyPi.

I'll open a ticket soon.