### PR TITLE
CI: Don't run cron for forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.noxenv }}
-    if: ${{ (github.repository_owner == 'pypa' && github.event_name == 'schedule') || github.event_name != 'schedule' }}
+    if: ${{ github.repository_owner == 'pypa' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.noxenv }}
+    if: ${{ (github.repository_owner == 'pypa' && github.event_name == 'schedule') || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The test workflow triggers on a daily cron:

```yml
on: 
  push:
  pull_request:
  schedule:
    - cron: "0 6 * * *" # daily at 6am
```

This is good for upstream, but not necessary for contributors' forks, as it sends a daily email to contributors when it fails:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/1324225/236684200-1397c9a2-bcd3-424c-98d6-423acb6c202b.png">

https://github.com/hugovk/packaging.python.org/actions

<img width="717" alt="image" src="https://user-images.githubusercontent.com/1324225/236684185-05b63ed1-a3cb-4fb7-bc87-36763756118b.png">

Let's add a condition so the `schedule` trigger only runs for upstream, and all other triggers run for both upstream and forks.
