### PR TITLE
Project URLs keys should be capitalized in pyproject.toml

### DIFF
--- a/source/specifications/declaring-project-metadata.rst
+++ b/source/specifications/declaring-project-metadata.rst
@@ -289,10 +289,10 @@ URL itself.
 .. code-block:: toml
 
     [project.urls]
-    homepage = "https://example.com"
-    documentation = "https://readthedocs.org"
-    repository = "https://github.com/me/spam.git"
-    changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
+    Homepage = "https://example.com"
+    Documentation = "https://readthedocs.org"
+    Repository = "https://github.com/me/spam.git"
+    Changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
 
 Entry points
 ------------
@@ -464,10 +464,10 @@ Example
     ]
 
     [project.urls]
-    homepage = "https://example.com"
-    documentation = "https://readthedocs.org"
-    repository = "https://github.com/me/spam.git"
-    changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
+    Homepage = "https://example.com"
+    Documentation = "https://readthedocs.org"
+    Repository = "https://github.com/me/spam.git"
+    Changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
 
     [project.scripts]
     spam-cli = "spam:main_cli"


### PR DESCRIPTION
I'm not sure whether this is controversial or not.

In pretty much all other places, the project URLs mapping keys are capitalized, including the "setuptools" guide page. Update `pyproject.toml` examples too for consistency and current practices.

Examples:
* packaging.python.org setuptools guide: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls
* PyPA's own `packaging` package: https://github.com/pypa/packaging/blob/main/pyproject.toml#L32-L34C6
* Poetry documentation: https://python-poetry.org/docs/pyproject/#urls
* Flit documentation: https://flit.pypa.io/en/latest/pyproject_toml.html#urls-table
* core-metadata spec: https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-project-url

If the keys are not capitalized, the link labels look awkward on the PyPI page, e.g. https://pypi.org/project/ruff/

> ![image](https://user-images.githubusercontent.com/137616/237053470-6613ccfb-abc0-4c7b-b3dc-97543164cf29.png)
