### PR TITLE
removed references to PEP 582 which has been rejected.

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -486,10 +486,10 @@ pdm
 `GitHub <https://github.com/pdm-project/pdm/>`__ |
 `PyPI <https://pypi.org/project/pdm>`__
 
-PDM is a modern Python package manager with :pep:`582` support. It installs and
-manages packages in a similar way to ``npm`` that doesn't need to create a
-:term:`virtual environment` at all. It also uses :term:`pyproject.toml` to store
-project metadata as defined in :pep:`621`.
+PDM is a modern Python package manager. It installs and manages packages in a
+similar way to ``npm`` that doesn't need to create a :term:`virtual
+environment` at all. It also uses :term:`pyproject.toml` to store project
+metadata as defined in :pep:`621`.
 
 .. _pex:
 

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -167,10 +167,8 @@ and techniques, listed in alphabetical order, to see if one of them is a better 
   wrapper around pip that supports ``requirements.txt``, Pipenv and Poetry lock files,
   or converting them to pip-tools compatible output. Designed for containerized
   Python applications, but not limited to them.
-* `PDM <https://github.com/pdm-project/pdm>`_ for a modern Python package management
-  tool supporting :pep:`582` (replacing virtual environments with ``__pypackages__``
-  directory for package installation) and relying on standards such as :pep:`517` and
-  :pep:`621`.
+* `PDM <https://github.com/pdm-project/pdm>`_ for a modern Python package
+  management relying on standards such as :pep:`517` and :pep:`621`.
 * `pip-tools <https://github.com/jazzband/pip-tools>`_ for creating a lock file of all
   dependencies from a list of packages directly used in a project, and ensuring that
   only those dependencies are installed.


### PR DESCRIPTION
The [PEP](https://peps.python.org/pep-0582/#relationship-to-virtual-environments) has been rejected, so we shouldn't mention its support as a feature for tools anymore.