### PR TITLE
Add current URL for Bazaar

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -188,7 +188,7 @@ Bazaar
 
 Home page
 
-   _`https://bazaar.canonical.com` *(Not responding as of 5/2023)*
+   https://www.breezy-vcs.org/
 
 vcs command
 


### PR DESCRIPTION
Both the development of Bazaar and the project's URL `https://bazaar.canonical.com` have been discontinued.

Breezy is the community maintained continuation.