### PR TITLE
Add step to create empty GH Release before upload

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -73,6 +73,11 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
+    - name: Create GitHub Release
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -163,8 +163,13 @@ Signing the distribution packages
 The following job signs the distribution packages with `Sigstore`_,
 the same artifact signing system `used to sign CPython <https://www.python.org/download/sigstore/>`_.
 
-It uses the `sigstore/gh-action-sigstore-python GitHub Action`_,
-and then uploads them to a GitHub Release.
+Firstly, it uses the `sigstore/gh-action-sigstore-python GitHub Action`_
+to sign the distribution packages. In the next step, an empty GitHub Release
+from the current tag is created using the ``gh`` CLI. Note this step can be further
+customised. See the `gh release documentation <https://cli.github.com/manual/gh_release>`_
+as a reference.
+
+Finally, the signed distributions are uploaded to the GitHub Release.
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml


### PR DESCRIPTION
Fixes #1304.

As suggested, I chose adding an empty release body, but we could also demonstrate how to read from a changelog file.

Could I also include fixes for #777 and #804 to solve the issues in one piece?
 