### PR TITLE
Add history section to externally managed environments spec.

### DIFF
--- a/source/specifications/externally-managed-environments.rst
+++ b/source/specifications/externally-managed-environments.rst
@@ -20,3 +20,7 @@ installation to indicate to Python-specific tools such as ``pip`` that they
 neither install nor remove packages into the interpreter’s default installation
 environment, and should instead guide the end user towards using
 :ref:`virtual-environments`.
+
+History
+=======
+- `June 2022 <https://discuss.python.org/t/pep-668-marking-python-base-environments-as-externally-managed/10302/44>`_: ``EXTERNALLY-MANAGED`` marker file was originally specified in :pep:`668#marking-an-interpreter-as-using-an-external-package-manager`.


### PR DESCRIPTION
Addresses a small part of #1203 by adding a history section to the external management environments specification page.