### PR TITLE
Bump version of python-docs-theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sphinx==4.5.0
 sphinx-autobuild==0.7.1
 sphinx-inline-tabs==2021.4.11b9
-python-docs-theme==2022.1
+python-docs-theme==2023.9
 sphinx-copybutton==0.5.0
 pypa-docs-theme @ git+https://github.com/pypa/pypa-docs-theme.git
 sphinx-toolbox==3.5.0


### PR DESCRIPTION
This fixes an issue with monospace fonts in certain browsers as reported and fixed upstream (see [#98 in python-docs-theme](https://github.com/python/python-docs-theme/issues/98)).

As example of before and after this change in version:

before:

![image](https://github.com/pypa/packaging.python.org/assets/1486942/83c9fd36-d6d6-48ca-9e9c-39cd91d5de96)

after:

![image](https://github.com/pypa/packaging.python.org/assets/1486942/901b0538-9127-4f22-9fbf-ff95372eef35)
