### PR TITLE
Update sphinx-autobuild version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,7 @@ def build(session, autobuild=False):
 
     if autobuild:
         command = "sphinx-autobuild"
-        extra_args = "-H", "0.0.0.0"
+        extra_args = "--host", "0.0.0.0"
     else:
         # NOTE: This branch adds options that are unsupported by autobuild
         command = "sphinx-build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==4.5.0
-sphinx-autobuild==0.7.1
+sphinx-autobuild==2021.3.14
 sphinx-inline-tabs==2021.4.11b9
 python-docs-theme==2023.9
 sphinx-copybutton==0.5.0


### PR DESCRIPTION
I was having errors from the pinned version of `sphinx-autobuild`. 
- Updates to most recent release.
- Corrects CLI change in noxfile for autobuild host