### PR TITLE
Add stub for a how-to guide for virtualenv

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -10,6 +10,7 @@ introduction to packaging, see :doc:`/tutorials/index`.
    :caption: Installing Packages:
 
    installing-using-pip-and-virtual-environments
+   installing-using-virtualenv
    installing-stand-alone-command-line-tools
    installing-using-linux-tools
    installing-scientific-packages

--- a/source/guides/installing-using-virtualenv.rst
+++ b/source/guides/installing-using-virtualenv.rst
@@ -1,0 +1,17 @@
+Installing packages using virtualenv
+====================================
+
+This guide discusses how to install packages using :ref:`pip` and
+:ref:`virtualenv`, a tool to create isolated Python environments.
+
+.. important::
+    This "how to" guide on installing packages and using :ref:`virtualenv` is
+    under development. Please refer to the `virtualenv's documentation`_ for
+    details on installation and usage.
+
+    .. virtualenv's documentation:: https://virtualenv.pypa.io/
+
+
+.. note:: This doc uses the term **package** to refer to a
+    :term:`Distribution Package`  which is different from an :term:`Import
+    Package` that which is used to import modules in your Python source code.

--- a/source/guides/installing-using-virtualenv.rst
+++ b/source/guides/installing-using-virtualenv.rst
@@ -9,7 +9,7 @@ This guide discusses how to install packages using :ref:`pip` and
     under development. Please refer to the `virtualenv's documentation`_ for
     details on installation and usage.
 
-    .. virtualenv's documentation:: https://virtualenv.pypa.io/
+    .. virtualenv's documentation: https://virtualenv.pypa.io/
 
 
 .. note:: This doc uses the term **package** to refer to a

--- a/source/guides/installing-using-virtualenv.rst
+++ b/source/guides/installing-using-virtualenv.rst
@@ -6,10 +6,8 @@ This guide discusses how to install packages using :ref:`pip` and
 
 .. important::
     This "how to" guide on installing packages and using :ref:`virtualenv` is
-    under development. Please refer to the `virtualenv's documentation`_ for
+    under development. Please refer to the :ref:`virtualenv` documentation for
     details on installation and usage.
-
-    .. virtualenv's documentation: https://virtualenv.pypa.io/
 
 
 .. note:: This doc uses the term **package** to refer to a


### PR DESCRIPTION
This PR is a follow up to #1338. In keeping with diaxtaxis doc process, this stub provides a starting point for a "how to" guide focused on using virtualenv to create isolated environments and installing packages. For now, it refers readers to the virtualenv documentation for details.