### PR TITLE
Clarify that packages don't need `__init__.py`

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -54,8 +54,8 @@ Create the following file structure locally:
 The directory containing the Python files should match the project name. This
 simplifies the configuration and is more obvious to users who install the package.
 
-:file:`__init__.py` is required to import the directory as a package,
-even if as is our case for this tutorial that file is empty.
+:file:`__init__.py` is recommended to import the directory as a regular package,
+even if as is our case for this tutorial that file is empty [#namespace-packages]_.
 
 :file:`example.py` is an example of a module within the package that could
 contain the logic (functions, classes, constants, etc.) of your package.
@@ -535,3 +535,15 @@ some things you can do:
   :ref:`pdm`, and :ref:`poetry`.
 * Read :pep:`517` and :pep:`518` for background and details on build tool configuration.
 * Read about :doc:`/guides/packaging-binary-extensions`.
+
+
+----
+
+.. rubric:: Notes
+
+.. [#namespace-packages]
+   Technically, you can also create Python packages without an ``__init__.py`` file,
+   but those are called :doc:`namespace packages </guides/packaging-namespace-packages>`
+   and considered an **advanced topic** (not covered in this tutorial).
+   If you are only getting started with Python packaging, it is recommended to
+   stick with *regular packages* and ``__init__.py`` (even if the file is empty).


### PR DESCRIPTION
This is a follow up on #1342: the tutorial implies that a Python package requires an `__init__.py` file.

I think that is the best to avoid this implication, otherwise we might "mis-educate" "packaging beginners" from the start.

The idea of this change is to introduce minimal rewording and a footnote.
The terms "regular package" and "namespace package" were introduced in [PEP 420](https://peps.python.org/pep-0420/), which is also very intentional when it comes to equating regular and namespace packages:

> A namespace package is not fundamentally different from a regular package. It is just a different way of creating packages. Once a namespace package is created, there is no functional difference between it and a regular package.

The change still recommends people that are getting started with Python packaging to add `__init__.py` as a result of the discussion in #1292: the general understanding in the community is that *some tools* might not fully support namespace packages yet (or be a bit more fussy about it) - although I cannot point out examples of these tools from the top of my mind...

Closes #1292.