### PR TITLE
Remove contents directives

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -6,9 +6,6 @@ Deploying Python applications
 :Page Status: Incomplete
 :Last Reviewed: 2021-8-24
 
-.. contents:: Contents
-   :local:
-
 
 Overview
 ========

--- a/source/discussions/install-requires-vs-requirements.rst
+++ b/source/discussions/install-requires-vs-requirements.rst
@@ -4,9 +4,6 @@
 install_requires vs requirements files
 ======================================
 
-.. contents:: Contents
-   :local:
-
 
 install_requires
 ----------------

--- a/source/guides/analyzing-pypi-package-downloads.rst
+++ b/source/guides/analyzing-pypi-package-downloads.rst
@@ -7,9 +7,6 @@ to learn more about downloads of a package (or packages) hosted on PyPI. For
 example, you can use it to discover the distribution of Python versions used to
 download a package.
 
-.. contents:: Contents
-   :local:
-
 
 Background
 ==========

--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -19,8 +19,6 @@ Packages <setuptools:userguide/index>` in the :ref:`setuptools` docs, but note
 that some advisory content there may be outdated. In the event of
 conflicts, prefer the advice in the Python Packaging User Guide.
 
-.. contents:: Contents
-   :local:
 
 
 Requirements for packaging and distributing

--- a/source/guides/index-mirrors-and-caches.rst
+++ b/source/guides/index-mirrors-and-caches.rst
@@ -7,9 +7,6 @@ Package index mirrors and caches
 :Page Status: Incomplete
 :Last Reviewed: 2014-12-24
 
-.. contents:: Contents
-   :local:
-
 
 Mirroring or caching of PyPI can be used to speed up local package installation,
 allow offline work, handle corporate firewalls or just plain Internet flakiness.

--- a/source/guides/installing-scientific-packages.rst
+++ b/source/guides/installing-scientific-packages.rst
@@ -4,9 +4,6 @@
 Installing scientific packages
 ==============================
 
-.. contents:: Contents
-   :local:
-
 
 Scientific software tends to have more complex dependencies than most, and
 it will often have multiple build options to take advantage of different

--- a/source/guides/installing-using-linux-tools.rst
+++ b/source/guides/installing-using-linux-tools.rst
@@ -7,9 +7,6 @@ Installing pip/setuptools/wheel with Linux Package Managers
 :Page Status: Incomplete
 :Last Reviewed: 2021-07-26
 
-.. contents:: Contents
-  :local:
-
 This section covers how to install :ref:`pip`, :ref:`setuptools`, and
 :ref:`wheel` using Linux package managers.
 

--- a/source/guides/packaging-binary-extensions.rst
+++ b/source/guides/packaging-binary-extensions.rst
@@ -13,8 +13,6 @@ C API for use by other software. One of the most common uses of this C API
 is to create importable C extensions that allow things which aren't
 always easy to achieve in pure Python code.
 
-.. contents:: Contents
-   :local:
 
 An overview of binary extensions
 ================================

--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -9,9 +9,6 @@ Supporting multiple Python versions
 :Page Status: Obsolete
 :Last Reviewed: 2014-12-24
 
-.. contents:: Contents
-   :local:
-
 
 ::
 

--- a/source/guides/supporting-windows-using-appveyor.rst
+++ b/source/guides/supporting-windows-using-appveyor.rst
@@ -12,9 +12,6 @@ service to provide Windows support for your project. This includes testing
 the code on Windows, and building Windows-targeted binaries for projects
 that use C extensions.
 
-.. contents:: Contents
-   :local:
-
 
 Background
 ==========

--- a/source/overview.rst
+++ b/source/overview.rst
@@ -19,9 +19,6 @@ This overview provides a general-purpose decision tree for reasoning
 about Python's plethora of packaging options. Read on to choose the best
 technology for your next project.
 
-.. contents:: Contents
-   :local:
-
 Thinking about deployment
 -------------------------
 

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -37,8 +37,6 @@ to a new format.
    more relaxed formatting rules even for metadata files that are nominally
    less than version 2.1.
 
-.. contents:: Contents
-   :local:
 
 .. _core-metadata-metadata-version:
 

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -13,8 +13,6 @@ The representation of the components of this data structure as a :rfc:`1738` URL
 is not formally specified at time of writing. A common representation is the pip URL
 format. Other examples are provided in :pep:`440`.
 
-.. contents:: Contents
-   :local:
 
 Specification
 =============

--- a/source/specifications/direct-url.rst
+++ b/source/specifications/direct-url.rst
@@ -10,8 +10,6 @@ This document specifies a :file:`direct_url.json` file in the
 Direct URL Origin of the distribution. The general structure and usage of
 ``*.dist-info`` directories is described in :ref:`recording-installed-packages`.
 
-.. contents:: Contents
-   :local:
 
 Specification
 =============

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -18,10 +18,6 @@ confused with a Linux distribution, or another larger software distribution
 like Python itself.
 
 
-.. contents:: Contents
-   :local:
-
-
 .. _installing_requirements:
 
 Requirements for Installing Packages


### PR DESCRIPTION
They're not useful with Furo, which has a right sidebar with the local TOC, and they make it generate warnings in the rendered documentation.

@pradyunsg 