### PR TITLE
Document hosted/managed package indexes

### DIFF
--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -52,6 +52,87 @@ directory with autoindex enabled. For an example using the built in Web server
 in `Twisted`_, you would simply run ``twistd -n web --path .`` and then
 instruct users to add the URL to their installer's configuration.
 
+
+Hosted and managed solutions
+============================
+
+These options are provided by third-party organisations, and are generally
+not open-source nor free.
+
+Gemfury
+^^^^^^^
+
+`Product page <https://fury.co/l/pypi-server/>`__ |
+`Documentation <https://gemfury.com/help/pypi-server/>`__
+
+Private indexes are paid.
+
+Artifactory
+^^^^^^^^^^^
+
+`Product page <https://jfrog.com/artifactory/>`__ |
+`Documentation
+<https://www.jfrog.com/confluence/display/JFROG/PyPI+Repositories/>`__
+
+Cached proxy for multiple package indexes (including PyPI), and hosting a
+new package index (supporting upload) with fall-through. Can be self-hosted
+(not for free).
+
+Nexus Repository Manager
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Product page <https://www.sonatype.com/products/nexus-repository/>`__ |
+`Documentation
+<https://help.sonatype.com/repomanager3/nexus-repository-administration/formats/pypi-repositories/>`__
+
+Cached proxy for multiple package indexes (including PyPI), and hosting a
+new package index (supporting upload) with fall-through.
+
+Coherent Minds PyPI Filter
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Documentation <https://pypi.coherentminds.de/redoc/>`__
+
+Only filters requests, redirecting to PyPI if not filtered, and blocking
+requests otherwise.
+
+GitLab Package Registry
+^^^^^^^^^^^^^^^^^^^^^^^
+
+`Documentation
+<https://docs.gitlab.com/ee/user/packages/pypi_repository/>`__
+
+Private and public package index with optional fall-through, permissioning.
+
+AWS CodeArtifact
+^^^^^^^^^^^^^^^^
+
+`Product page <https://aws.amazon.com/codeartifact/>`__ |
+`Documentation
+<https://docs.aws.amazon.com/codeartifact/latest/ug/using-python.html>`__
+
+Private package index with optional cached fall-through to PyPI.
+
+Azure Artifacts
+^^^^^^^^^^^^^^^
+
+`Product page
+<https://azure.microsoft.com/en-us/products/devops/artifacts/>`__ |
+`Documentation
+<https://learn.microsoft.com/en-us/azure/devops/artifacts/quickstarts/python-packages/>`__
+
+Private package index with optional fall-through.
+
+Google Artifact Registry
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Product page
+<https://cloud.google.com/artifact-registry/>`__ |
+`Documentation
+<https://cloud.google.com/artifact-registry/docs/python/>`__
+
+Private package index with no fall-through nor mirroring.
+
 ----
 
 .. [1] For complete documentation of the simple repository protocol, see


### PR DESCRIPTION
Add a list of hosted and managed package index services to indicate to new users they don't have to build their own solution (as currently that's all the guide suggests at the moment, apart from devpi). Also include documentation links