### PR TITLE
Improve namespace packaging guide

### DIFF
--- a/source/discussions/src-layout-vs-flat-layout.rst
+++ b/source/discussions/src-layout-vs-flat-layout.rst
@@ -1,3 +1,5 @@
+.. _src-layout-vs-flat-layout:
+
 =========================
 src layout vs flat layout
 =========================

--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -83,7 +83,7 @@ structure (following :ref:`src-layout <setuptools:src-layout>`):
         pyproject.toml # AND/OR setup.py, setup.cfg
         src/
             mynamespace/ # namespace package
-            # No __init__.py here.
+                # No __init__.py here.
                 subpackage_a/
                     # Sub-packages have an __init__.py.
                     __init__.py
@@ -117,7 +117,7 @@ The same can be accomplished with a :file:`setup.cfg`:
 
 .. code-block:: ini
 
-   [options]
+    [options]
     package_dir =
         =src
     packages = find_namespace:
@@ -135,7 +135,7 @@ Or :file:`setup.py`:
         name='mynamespace-subpackage-a',
         ...
         packages=find_namespace_packages(where='src/', include=['mynamespace.subpackage_a']),
-        package_dir={"": "src"},
+        package_dir={'': 'src'},
     )
 
 :ref:`setuptools` will search the directory structure for implicit namespace

--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -96,7 +96,7 @@ logic to fail and the other sub-packages will not be importable.
 
 The ``src-layout`` directory structure allows automatic discovery of packages
 by most :term:`build backends <Build Backend>`. See :ref:`src-layout-vs-flat-layout`
-for more information. If however you want to manage exclusions or inclusions of packages 
+for more information. If however you want to manage exclusions or inclusions of packages
 yourself, this is possible to be configured in the top-level :file:`pyproject.toml`:
 
 .. code-block:: toml

--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -156,7 +156,7 @@ the `native namespace package example project`_.
 Legacy namespace packages
 -------------------------
 
-These to methods, that were used to create namespace packages prior to :pep:`420`,
+These two methods, that were used to create namespace packages prior to :pep:`420`,
 are now considered to be obsolete and should not be used unless you need compatibility
 with packages already using this method. Also, :doc:`pkg_resources <setuptools:pkg_resources>`
 has been deprecated.

--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -95,9 +95,9 @@ package omits the :file:`__init__.py` or uses a pkgutil-style
 logic to fail and the other sub-packages will not be importable.
 
 The ``src-layout`` directory structure allows automatic discovery of packages
-by most :term:`build backends <Build Backend>`. If however you want to manage
-exclusions or inclusions of packages yourself, this is possible to be configured
-in the top-level :file:`pyproject.toml`:
+by most :term:`build backends <Build Backend>`. See :ref:`src-layout-vs-flat-layout`
+for more information. If however you want to manage exclusions or inclusions of packages 
+yourself, this is possible to be configured in the top-level :file:`pyproject.toml`:
 
 .. code-block:: toml
 

--- a/source/guides/packaging-namespace-packages.rst
+++ b/source/guides/packaging-namespace-packages.rst
@@ -85,7 +85,7 @@ structure (following :ref:`src-layout <setuptools:src-layout>`):
             mynamespace/ # namespace package
                 # No __init__.py here.
                 subpackage_a/
-                    # Sub-packages have an __init__.py.
+                    # Regular import packages have an __init__.py.
                     __init__.py
                     module.py
 
@@ -102,8 +102,7 @@ yourself, this is possible to be configured in the top-level :file:`pyproject.to
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools", "setuptools-scm"]
-    build-backend = "setuptools.build_meta"
+    ...
 
     [tool.setuptools.packages.find]
     where = ["src/"]
@@ -188,7 +187,7 @@ To create a pkgutil-style namespace package, you need to provide an
             mynamespace/
                 __init__.py  # Namespace package __init__.py
                 subpackage_a/
-                    __init__.py  # Sub-package __init__.py
+                    __init__.py  # Regular package __init__.py
                     module.py
 
 The :file:`__init__.py` file for the namespace package needs to contain
@@ -235,7 +234,7 @@ To create a pkg_resources-style namespace package, you need to provide an
             mynamespace/
                 __init__.py  # Namespace package __init__.py
                 subpackage_a/
-                    __init__.py  # Sub-package __init__.py
+                    __init__.py  # Regular package __init__.py
                     module.py
 
 The :file:`__init__.py` file for the namespace package needs to contain


### PR DESCRIPTION
This addresses the linked issues, and adds a `pyproject.toml` example for how to find native or implicit namespace packages with `setuptools`.

- Closes #1222
- Closes #689
- Closes #1305

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1379.org.readthedocs.build/en/1379/

<!-- readthedocs-preview python-packaging-user-guide end -->