### PR TITLE
Add 2 german words to codespell to fix pre-commit check in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   rev: v2.2.6
   hooks:
   - id: codespell
-    args: ["-L", "ned"]
+    args: ["-L", "ned,ist,oder"]
 
 - repo: local
   hooks:


### PR DESCRIPTION
This PR fixes CI.

A new file in specifications has 2 german phrases. Add the words to the spelling ignore list.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1386.org.readthedocs.build/en/1386/

<!-- readthedocs-preview python-packaging-user-guide end -->