### PR TITLE
Link to pyproject.toml guide in "Packaging Python projects" tutorial

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -28,8 +28,8 @@ Most of the time, you will directly write the value of a field in
 
 However, in some cases, it is useful to let your build backend compute
 the metadata for you. For example: many build backends can read the
-version from a ``__version__`` attribute in your code, or similar.
-In such cases, you should mark the field as dynamic using, e.g.,
+version from a ``__version__`` attribute in your code, a Git tag, or
+similar. In such cases, you should mark the field as dynamic using, e.g.,
 
 .. code-block:: toml
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -214,17 +214,16 @@ following this tutorial.
     ]
 
     [project.urls]
-    "Homepage" = "https://github.com/pypa/sampleproject"
-    "Bug Tracker" = "https://github.com/pypa/sampleproject/issues"
+    Homepage = "https://github.com/pypa/sampleproject"
+    Issues = "https://github.com/pypa/sampleproject/issues"
 
 - ``name`` is the *distribution name* of your package. This can be any name as
   long as it only contains letters, numbers, ``.``, ``_`` , and ``-``. It also
   must not already be taken on PyPI. **Be sure to update this with your
   username** for this tutorial, as this ensures you won't try to upload a
   package with the same name as one which already exists.
-- ``version`` is the package version. See the :ref:`version specifier specification <version-specifiers>`
-  for more details on versions. Some build backends allow it to be specified
-  another way, such as from a file or a git tag.
+- ``version`` is the package version. (Some build backends allow it to be
+  specified another way, such as from a file or Git tag.)
 - ``authors`` is used to identify the author of the package; you specify a name
   and an email for each author. You can also list ``maintainers`` in the same
   format.
@@ -233,9 +232,9 @@ following this tutorial.
   package. This is shown on the package detail page on PyPI.
   In this case, the description is loaded from :file:`README.md` (which is a
   common pattern). There also is a more advanced table form described in the
-  :ref:`project metadata specification <declaring-project-metadata>`.
+  :ref:`pyproject.toml guide <writing-pyproject-toml>`.
 - ``requires-python`` gives the versions of Python supported by your
-  project. Installers like :ref:`pip` will look back through older versions of
+  project. An installer like :ref:`pip` will look back through older versions of
   packages until it finds one that has a matching Python version.
 - ``classifiers`` gives the index and :ref:`pip` some additional metadata
   about your package. In this case, the package is only compatible with Python
@@ -247,10 +246,11 @@ following this tutorial.
 - ``urls`` lets you list any number of extra links to show on PyPI.
   Generally this could be to the source, documentation, issue trackers, etc.
 
-See the :ref:`project metadata specification <declaring-project-metadata>` for
-details on these and other fields that can be defined in the ``[project]``
-table. Other common fields are ``keywords`` to improve discoverability and the
-``dependencies`` that are required to install your package.
+See the :ref:`pyproject.toml guide <writing-pyproject-toml>` for details
+on these and other fields that can be defined in the ``[project]``
+table. Other common fields are ``keywords`` to improve discoverability
+and the ``dependencies`` that are required to install your package.
+
 
 Creating README.md
 ------------------


### PR DESCRIPTION
Replace links to the "Declaring project metadata" specification with links to the "Writing pyproject.toml guide" since this is more likely what the user wants after a tutorial. Also harmonize with the guide slightly and leave link to version specifier specification (advanced reading) for the guide.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1391.org.readthedocs.build/en/1391/

<!-- readthedocs-preview python-packaging-user-guide end -->