### PR TITLE
Fix link to Bazaar VCS

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -186,7 +186,7 @@ Bazaar
 
 Home page
 
-   https://www.breezy-vcs.org/
+   https://launchpad.net/bzr
 
 vcs command
 


### PR DESCRIPTION
This broken link is caught by the linkcheck target.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1398.org.readthedocs.build/en/1398/

<!-- readthedocs-preview python-packaging-user-guide end -->