### PR TITLE
Ignore .po files for caps pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
   - id: disallow-caps
     name: Disallow improper capitalization
     language: pygrep
-    entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|*.po
+    entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
+    exclude_types: ["pofile"]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: disallow-caps
     name: Disallow improper capitalization
     language: pygrep
-    entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
+    entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|*.po
     exclude: .pre-commit-config.yaml
 
 - repo: https://github.com/pre-commit/pygrep-hooks
@@ -33,7 +33,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.5
+  rev: v0.1.6
   hooks:
     - id: ruff
     - id: ruff-format


### PR DESCRIPTION
Closes #1403

~I'm not sure that I put the *.po file ignore in the correct place for the capitalization hook. If someone has a better solution, please update this PR. Thanks.~

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1404.org.readthedocs.build/en/1404/

<!-- readthedocs-preview python-packaging-user-guide end -->