### PR TITLE
Fix virtualenv description

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -341,11 +341,9 @@ virtualenv
 virtualenv is a tool for creating isolated Python :term:`Virtual Environments
 <Virtual Environment>`, like :ref:`venv`. Unlike :ref:`venv`, virtualenv can
 create virtual environments for other versions of Python, which it locates
-using the PATH environment variable. It also provides
-additional functionality, compared to :ref:`venv`, by supporting Python
-2.7 and by providing convenient features for configuring, maintaining,
-duplicating, and troubleshooting the virtual environments. For more
-information, see the section on :ref:`Creating and using Virtual
+using the PATH environment variable. It also provides convenient features for
+configuring, maintaining, duplicating, and troubleshooting virtual environments.
+For more information, see the section on :ref:`Creating and using Virtual
 Environments`.
 
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -338,9 +338,10 @@ virtualenv
 `GitHub <https://github.com/pypa/virtualenv>`__ |
 `PyPI <https://pypi.org/project/virtualenv/>`__
 
-virtualenv is a tool which uses the command-line path environment
-variable to create isolated Python :term:`Virtual Environments
-<Virtual Environment>`, much as :ref:`venv` does. virtualenv provides
+virtualenv is a tool for creating isolated Python :term:`Virtual Environments
+<Virtual Environment>`, like :ref:`venv`. Unlike :ref:`venv`, virtualenv can
+create virtual environments for other versions of Python, which it locates
+using the PATH environment variable. It also provides
 additional functionality, compared to :ref:`venv`, by supporting Python
 2.7 and by providing convenient features for configuring, maintaining,
 duplicating, and troubleshooting the virtual environments. For more

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -333,7 +333,7 @@ it's fast and secure, it's maintained, and it reliably works.
 virtualenv
 ==========
 
-:doc:`Docs <virtualenv:index>` |
+`Docs <https://virtualenv.pypa.io/en/stable/index.html>`__ |
 `Issues <https://github.com/pypa/virtualenv/issues>`__ |
 `GitHub <https://github.com/pypa/virtualenv>`__ |
 `PyPI <https://pypi.org/project/virtualenv/>`__


### PR DESCRIPTION
Okay, I managed to figure out how to do this properly (I think). Maybe I'm the only one who feels this way, but sometimes GitHub is harder for me to understand than Git itself.

Anyway, here are a few quick changes to update the description of virtualenv and make it read more cleanly.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1407.org.readthedocs.build/en/1407/

<!-- readthedocs-preview python-packaging-user-guide end -->