### PR TITLE
Remove outdated "distribute" fork info

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -268,7 +268,7 @@ display on PyPI.
 .. _setuptools:
 .. _easy_install:
 
-setuptools
+Setuptools
 ==========
 
 `Docs <https://setuptools.readthedocs.io/en/latest/>`__ |
@@ -276,7 +276,7 @@ setuptools
 `GitHub <https://github.com/pypa/setuptools>`__ |
 `PyPI <https://pypi.org/project/setuptools>`__
 
-setuptools (which includes ``easy_install``) is a collection of
+Setuptools (which includes ``easy_install``) is a collection of
 enhancements to the Python distutils that allow you to more easily
 build and distribute Python :term:`distributions <Distribution
 Package>`, especially ones that have dependencies on other packages.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -281,10 +281,6 @@ enhancements to the Python distutils that allow you to more easily
 build and distribute Python :term:`distributions <Distribution
 Package>`, especially ones that have dependencies on other packages.
 
-`distribute`_ was a fork of setuptools that was merged back into setuptools (in
-v0.7), thereby making setuptools the primary choice for Python packaging.
-
-
 .. _trove-classifiers:
 
 trove-classifiers
@@ -742,6 +738,5 @@ information, see the section on :ref:`Creating and using Virtual Environments`.
 
 ----
 
-.. _distribute: https://pypi.org/project/distribute
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _pytest: https://docs.pytest.org/en/stable/


### PR DESCRIPTION
https://packaging.python.org/en/latest/key_projects/#setuptools mentions the "distribute" fork under setuptools:

<img width="769" alt="image" src="https://github.com/pypa/packaging.python.org/assets/1324225/ce1250f4-d271-46c8-b3b1-1a6630ad760d">

In 2023:

* the info about the "distribute" fork of setuptools is outdated - it was deprecated and merged back into setuptools in 2013: https://pypi.org/project/distribute/#history

* likewise, it's been a decade since setuptools 0.7 was released, supporting Python 2.4-2.7 and 3.1-3.3: https://pypi.org/project/setuptools/0.7.8/ Anyone using setuptools will have a much newer version.

* finally, setuptools is a fine choice but it's arguable that setuptools is no longer "the primary choice for Python packaging"

Let's remove this paragraph.

---

Also, the setuptools project normally capitalises the first letter when at the start of a sentence, or in a title. (And inconsistently uses setuptools and Setuptools when used in the middle of a sentence.)

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1410.org.readthedocs.build/en/1410/

<!-- readthedocs-preview python-packaging-user-guide end -->