### PR TITLE
verbiage tweak in installing-using-pip-and-virtual-environments.rst

### DIFF
--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -104,20 +104,20 @@ Python interpreter:
 
         where python
 
-When the virtual environment is activated, the location will include
-the ``.venv`` directory:
+While the virtual environment is active, the above command will output a
+filepath that includes the ``.venv`` directory, by ending with the following:
 
 .. tab:: Unix/macOS
 
     .. code-block:: bash
 
-        .../.venv/bin/python
+        .venv/bin/python
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        ...\.venv\bin\python.exe
+        .venv\bin\python.exe
 
 
 While a virtual environment is activated, pip will install packages into that


### PR DESCRIPTION
I think this language is a little bit clearer, especially because it makes it clear that you aren't supposed to run the code block. The section could probably be made yet more clear, however.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1413.org.readthedocs.build/en/1413/

<!-- readthedocs-preview python-packaging-user-guide end -->