### PR TITLE
Fix bits of "Is `setup.py` deprecated?" discussion

### DIFF
--- a/source/discussions/setup-py-deprecated.rst
+++ b/source/discussions/setup-py-deprecated.rst
@@ -105,7 +105,7 @@ A trusted replacement is :ref:`twine`:
 * ``python -m twine upload dist/*``
 
 .. [#not-pypi] Not necessary, nor supported on :term:`PyPI <Python Package Index (PyPI)>`.
-    But might be necessary on other :term:`package indexes <package index>`.
+    But might be necessary on other :term:`package indexes <package index>` (for example :ref:`devpi`).
 
 
 ``python setup.py --version``

--- a/source/discussions/setup-py-deprecated.rst
+++ b/source/discussions/setup-py-deprecated.rst
@@ -100,9 +100,12 @@ The recommendation is to use a test runner such as pytest_.
 
 A trusted replacement is :ref:`twine`:
 
-* ``python -m twine check``
-* ``python -m twine register``
-* ``python -m twine upload``
+* ``python -m twine check --strict dist/*``
+* ``python -m twine register dist/*.whl`` [#not-pypi]_
+* ``python -m twine upload dist/*``
+
+.. [#not-pypi] Not necessary, nor supported on :term:`PyPI <Python Package Index (PyPI)>`.
+    But might be necessary on other :term:`package indexes <package index>`.
 
 
 ``python setup.py --version``
@@ -110,7 +113,7 @@ A trusted replacement is :ref:`twine`:
 
 A possible replacement solution (among others) is to rely on setuptools-scm_:
 
-* ``python -m setuptools-scm``
+* ``python -m setuptools_scm``
 
 .. _setuptools-scm: https://setuptools-scm.readthedocs.io/en/latest/usage/#as-cli-tool
 


### PR DESCRIPTION
GitHub: refs https://github.com/pypa/packaging.python.org/pull/1418

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1429.org.readthedocs.build/en/1429/

<!-- readthedocs-preview python-packaging-user-guide end -->