### PR TITLE
Test translations for reST syntax errors

### DIFF
--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.I18N_BRANCH }}
-    
+
     - name: List languages
       id: languages
       working-directory: locales
@@ -65,7 +65,10 @@ jobs:
           3.10
 
     - name: Install Python tooling
-      run: python -m pip install --upgrade nox virtualenv
+      run: python -m pip install --upgrade nox virtualenv sphinx-lint
 
     - name: Build translated docs in ${{ matrix.language }}
-      run: nox -s build -- -D language=${{ matrix.language }}
+      run: nox -s build -- -q -D language=${{ matrix.language }}
+
+    - name: Lint translation file
+      run: sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/message.po

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -71,4 +71,4 @@ jobs:
       run: nox -s build -- -q -D language=${{ matrix.language }}
 
     - name: Lint translation file
-      run: sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/message.po
+      run: sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/messages.po

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -39,8 +39,7 @@ jobs:
       id: languages
       working-directory: locales
       run: |
-        dirs=$(find * -maxdepth 0 -type d)
-        list="$(echo $dirs | sed "s|^|['|;s|$|']|;s| |', '|g")"
+        list=$(find * -maxdepth 0 -type d | jq -nRc '[inputs]')
         echo "languages=$list" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -1,0 +1,71 @@
+name: Test translations
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - '**.po'
+    branches:
+    - translation/source
+  push:
+    paths:
+    - '**.po'
+    branches:
+    - translation/source
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  I18N_BRANCH: translation/source
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.languages.outputs.languages }}
+
+    steps:
+    - name: Grab the repo src
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.I18N_BRANCH }}
+    
+    - name: List languages
+      id: languages
+      working-directory: locales
+      run: |
+        dirs=$(find * -maxdepth 0 -type d)
+        list="$(echo $dirs | sed "s|^|['|;s|$|']|;s| |', '|g")"
+        echo "languages=$list" >> $GITHUB_OUTPUT
+
+
+  test-translation:
+    runs-on: ubuntu-latest
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{fromJson(needs.matrix.outputs.languages)}}
+
+    steps:
+    - name: Grab the repo src
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.I18N_BRANCH }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: >-
+          3.10
+
+    - name: Install Python tooling
+      run: python -m pip install --upgrade nox virtualenv
+
+    - name: Build translated docs in ${{ matrix.language }}
+      run: nox -s build -- -D language=${{ matrix.language }}


### PR DESCRIPTION
This workflow is intended for a centralized and easy to find point of syntax errors in translation files. 

Currently, one can only find syntax errors by browsing the logs in Read The Docs, and each language is its own separated rtd project. I doubt anyone will do that, except for me.

Translation file update triggers in both push and pull request events. E.g. When Weblate files a pull request with new translations.

Examples of runs:

![Captura de tela de 2023-12-03 17-29-24](https://github.com/pypa/packaging.python.org/assets/1571783/776b9486-4a26-4d99-a1a5-881c5a68d310)


![Captura de tela de 2023-12-03 17-29-32](https://github.com/pypa/packaging.python.org/assets/1571783/f6b65143-043c-470e-b68b-f1c0fed498a6)


<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1431.org.readthedocs.build/en/1431/

<!-- readthedocs-preview python-packaging-user-guide end -->