### PR TITLE
Improve "further reading" at end of "packaging projects" tutorial

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -141,6 +141,7 @@ intersphinx_mapping = {
     "dh-virtualenv": ("https://dh-virtualenv.readthedocs.io/en/latest/", None),
     "distlib": ("https://distlib.readthedocs.io/en/latest/", None),
     "flexx": ("https://flexx.readthedocs.io/en/latest/", None),
+    "flit": ("https://flit.pypa.io/en/stable/", None),
     "nox": ("https://nox.thea.codes/en/latest/", None),
     "openstack": ("https://docs.openstack.org/glance/latest/", None),
     "packaging": ("https://packaging.pypa.io/en/latest/", None),

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -529,14 +529,16 @@ differences:
 At this point if you want to read more on packaging Python libraries here are
 some things you can do:
 
-.. TODO: Add links to other guides
-.. TODO: Add links to backend configuration docs
-
+* Read about advanced configuration for your chosen build backend:
+  `Hatchling <hatchling-config_>`_,
+  :doc:`setuptools <setuptools:userguide/pyproject_config>`,
+  :doc:`Flit <flit:pyproject_toml>`, `PDM <pdm-config_>`_.
+* Look at the :doc:`guides </guides/index>` on this site for more advanced
+  practical information, or the :doc:`discussions </discussions/index>`
+  for explanations and background on specific topics.
 * Consider packaging tools that provide a single command-line interface for
   project management and packaging, such as :ref:`hatch`, :ref:`flit`,
   :ref:`pdm`, and :ref:`poetry`.
-* Read :pep:`517` and :pep:`518` for background and details on build tool configuration.
-* Read about :doc:`/guides/packaging-binary-extensions`.
 
 
 ----
@@ -549,3 +551,7 @@ some things you can do:
    and considered an **advanced topic** (not covered in this tutorial).
    If you are only getting started with Python packaging, it is recommended to
    stick with *regular packages* and ``__init__.py`` (even if the file is empty).
+
+
+.. _hatchling-config: https://hatch.pypa.io/latest/config/metadata/
+.. _pdm-config: https://pdm-project.org/latest/reference/pep621/


### PR DESCRIPTION
- Add links to advanced configuration for each build backend
- Replace link to "Packaging binary extensions" guide (an advanced topic, probably not what newcomers want to read) with links to the TOCs for guides and discussions
- Remove links to PEP 517 and PEP 518, which are technical standards, not user-facing documentation

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1432.org.readthedocs.build/en/1432/

<!-- readthedocs-preview python-packaging-user-guide end -->