### PR TITLE
Prevent workflow failures on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     # This job does nothing and is only used for the branch protection
     # or multi-stage CI jobs, like making sure that all tests pass before
     # a publishing job is started.
-    if: always()
+    if: ${{ github.repository_owner == 'pypa' || github.event_name != 'schedule' }}
 
     needs:
     - build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,9 @@ jobs:
     # This job does nothing and is only used for the branch protection
     # or multi-stage CI jobs, like making sure that all tests pass before
     # a publishing job is started.
-    if: ${{ github.repository_owner == 'pypa' || github.event_name != 'schedule' }}
+    if: >-
+      github.repository_owner == 'pypa'
+      || github.event_name != 'schedule'
 
     needs:
     - build

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: $${ github.repository_owner == 'pypa' }}
 
     steps:
     - name: Grab the repo src

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: $${ github.repository_owner == 'pypa' }}
+    if: github.repository_owner == 'pypa'
 
     steps:
     - name: Grab the repo src


### PR DESCRIPTION
I'm getting notifications every day that workflow runs on my fork of this repository had failures.

- Test workflow: add condition to skip the daily run on forks in the `check` job, just like in the `build` job
- Translation workflow: likewise, skip on forks

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1436.org.readthedocs.build/en/1436/

<!-- readthedocs-preview python-packaging-user-guide end -->