### PR TITLE
Remove the guide from its own Intersphinx mapping

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -145,7 +145,6 @@ intersphinx_mapping = {
     "nox": ("https://nox.thea.codes/en/latest/", None),
     "openstack": ("https://docs.openstack.org/glance/latest/", None),
     "packaging": ("https://packaging.pypa.io/en/latest/", None),
-    "packaging.python.org": ("https://packaging.python.org/en/latest/", None),
     "pip": ("https://pip.pypa.io/en/latest/", None),
     "pipenv": ("https://pipenv.pypa.io/en/latest/", None),
     "piwheels": ("https://piwheels.readthedocs.io/en/latest/", None),

--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -233,8 +233,7 @@ the front-page lists of trending projects and new releases, and the list of
 projects you maintain within your account profile (such as
 https://pypi.org/user/jaraco/).
 
-A `content type
-<https://packaging.python.org/specifications/core-metadata/#description-content-type-optional>`_
+A :ref:`content type <core-metadata-description-content-type>`
 can be specified with the ``long_description_content_type`` argument, which can
 be one of ``text/plain``, ``text/x-rst``, or ``text/markdown``, corresponding
 to no formatting, `reStructuredText (reST)

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -244,7 +244,7 @@ causing dependency conflicts with other packages installed on the system.
 Python Packaging User Guide
 ===========================
 
-:doc:`Docs <packaging.python.org:index>` |
+:doc:`Docs <index>` |
 `Issues <https://github.com/pypa/packaging.python.org/issues>`__ |
 `GitHub <https://github.com/pypa/packaging.python.org>`__
 
@@ -292,8 +292,7 @@ trove-classifiers
 
 trove-classifiers is the canonical source for `classifiers on PyPI
 <https://pypi.org/classifiers/>`_, which project maintainers use to
-`systematically describe their projects
-<https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`_
+:ref:`systematically describe their projects <core-metadata-classifier>`
 so that users can better find projects that match their needs on the PyPI.
 
 The trove-classifiers package contains a list of valid classifiers and


### PR DESCRIPTION
Fixes #1438

Also replace a few hyperlinks inside packaging.python.org with normal references.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--1439.org.readthedocs.build/en/1439/

<!-- readthedocs-preview python-packaging-user-guide end -->