### PR TITLE
glossary.rst: Update link to requirement specifier syntax to PEP 508

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -209,10 +209,8 @@ Glossary
     Requirement Specifier
 
        A format used by :ref:`pip` to install packages from a :term:`Package
-       Index`. For an EBNF diagram of the format, see the
-       `pkg_resources.Requirement
-       <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects>`_
-       entry in the :ref:`setuptools` docs. For example, "foo>=1.3" is a
+       Index`. For an EBNF diagram of the format, see `PEP 508
+       <https://peps.python.org/pep-0508/>`_. For example, "foo>=1.3" is a
        requirement specifier, where "foo" is the project name, and the ">=1.3"
        portion is the :term:`Version Specifier`
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -209,8 +209,8 @@ Glossary
     Requirement Specifier
 
        A format used by :ref:`pip` to install packages from a :term:`Package
-       Index`. For an EBNF diagram of the format, see `PEP 508
-       <https://peps.python.org/pep-0508/>`_. For example, "foo>=1.3" is a
+       Index`. For an EBNF diagram of the format, see :ref:`dependency-specifiers`.
+       For example, "foo>=1.3" is a
        requirement specifier, where "foo" is the project name, and the ">=1.3"
        portion is the :term:`Version Specifier`
 


### PR DESCRIPTION
The current link doesn't actually give the syntax of the requirement specifier. PEP 508 is much better.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1456.org.readthedocs.build/en/1456/

<!-- readthedocs-preview python-packaging-user-guide end -->