### PR TITLE
docs: update testpypi guide for api token

### DIFF
--- a/source/guides/using-testpypi.rst
+++ b/source/guides/using-testpypi.rst
@@ -72,12 +72,13 @@ you're testing has dependencies:
 Setting up TestPyPI in :file:`.pypirc`
 --------------------------------------
 
-If you want to avoid entering your username, you can configure TestPyPI in
-your :file:`$HOME/.pypirc`:
+If you want to avoid being prompted for your username and password every time,
+you can configure TestPyPI in your :file:`$HOME/.pypirc`:
 
 .. code:: ini
 
     [testpypi]
-    username = <your TestPyPI username>
+    username = __token__
+    password = <your TestPyPI API Token>
 
 For more details, see the :ref:`specification <pypirc>` for :file:`.pypirc`.


### PR DESCRIPTION
With the upcoming change to require 2FA for all users (already enforced on TestPyPI), update guidance to point the user in the right direction.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1457.org.readthedocs.build/en/1457/

<!-- readthedocs-preview python-packaging-user-guide end -->