### PR TITLE
Remove unnecessary word from documentation

### DIFF
--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -6,7 +6,7 @@ Hosting your own simple repository
 
 
 If you wish to host your own simple repository [1]_, you can either use a
-software package like :doc:`devpi <devpi:index>` or you can use simply create the proper
+software package like :doc:`devpi <devpi:index>` or you can simply create the proper
 directory structure and use any web server that can serve static files and
 generate an autoindex.
 


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1461.org.readthedocs.build/en/1461/

<!-- readthedocs-preview python-packaging-user-guide end -->