### PR TITLE
Deduplicate specification of valid package names

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -73,7 +73,7 @@ Name
 
 .. versionadded:: 1.0
 .. versionchanged:: 2.1
-   Added restrictions on format from the :ref:`name grammar <name-grammar>`.
+   Added restrictions on format from the :ref:`name format <name-format>`.
 
 The name of the distribution. The name field is the primary identifier for a
 distribution. It must conform to the :ref:`name format specification

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -73,15 +73,10 @@ Name
 
 .. versionadded:: 1.0
 .. versionchanged:: 2.1
-   Added additional restrictions on format from :pep:`508`
+   Added restrictions on format from the :ref:`name grammar <name-grammar>`.
 
 The name of the distribution. The name field is the primary identifier for a
-distribution. A valid name consists only of ASCII letters and numbers, period,
-underscore and hyphen. It must start and end with a letter or number.
-Distribution names are limited to those which match the following
-regex (run with ``re.IGNORECASE``)::
-
-    ^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
+distribution. It must conform to the :ref:`package name grammar <name-grammar>`.
 
 Example::
 

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -76,7 +76,8 @@ Name
    Added restrictions on format from the :ref:`name grammar <name-grammar>`.
 
 The name of the distribution. The name field is the primary identifier for a
-distribution. It must conform to the :ref:`package name grammar <name-grammar>`.
+distribution. It must conform to the :ref:`name format specification
+<name-format>`.
 
 Example::
 

--- a/source/specifications/name-normalization.rst
+++ b/source/specifications/name-normalization.rst
@@ -1,16 +1,16 @@
-======================================
-Package name grammar and normalization
-======================================
+=======================
+Names and normalization
+=======================
 
-Project names obey a restricted format, and are "normalized" for use in various
-contexts. This document describes what the valid project names are, and how
-project names should be normalized.
+This specification defines the format that names for packages and extras are
+required to follow. It also describes how to normalize them, which should be
+done before lookups and comparisons.
 
 
-.. _name-grammar:
+.. _name-format:
 
-Name grammar
-============
+Name format
+===========
 
 A valid name consists only of ASCII letters and numbers, period,
 underscore and hyphen. It must start and end with a letter or number.

--- a/source/specifications/name-normalization.rst
+++ b/source/specifications/name-normalization.rst
@@ -1,13 +1,16 @@
-.. _name-normalization:
+======================================
+Package name grammar and normalization
+======================================
 
-==========================
-Package name normalization
-==========================
+Project names obey a restricted format, and are "normalized" for use in various
+contexts. This document describes what the valid project names are, and how
+project names should be normalized.
 
-Project names are "normalized" for use in various contexts. This document describes how project names should be normalized.
 
-Valid non-normalized names
---------------------------
+.. _name-grammar:
+
+Name grammar
+============
 
 A valid name consists only of ASCII letters and numbers, period,
 underscore and hyphen. It must start and end with a letter or number.
@@ -16,10 +19,15 @@ following regex (run with ``re.IGNORECASE``)::
 
     ^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
 
-Normalization
--------------
 
-The name should be lowercased with all runs of the characters ``.``, ``-``, or ``_`` replaced with a single ``-`` character. This can be implemented in Python with the re module:
+.. _name-normalization:
+
+Name normalization
+==================
+
+The name should be lowercased with all runs of the characters ``.``, ``-``, or
+``_`` replaced with a single ``-`` character. This can be implemented in Python
+with the re module:
 
 .. code-block:: python
 
@@ -30,7 +38,7 @@ The name should be lowercased with all runs of the characters ``.``, ``-``, or `
 
 This means that the following names are all equivalent:
 
-* ``friendly-bard``  (normalized form)
+* ``friendly-bard`` (normalized form)
 * ``Friendly-Bard``
 * ``FRIENDLY-BARD``
 * ``friendly.bard``


### PR DESCRIPTION
- Rename the "Package name normalization" specification into "Package name grammar and normalization", to make it explicitly about the format of valid names too.

- Link to this spec in the core metadata specification instead of duplicating the part about valid names.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1463.org.readthedocs.build/en/1463/

<!-- readthedocs-preview python-packaging-user-guide end -->