### PR TITLE
Increase number of linkcheck retries

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -108,6 +108,7 @@ linkcheck_ignore = [
     # https://github.com/pypa/packaging.python.org/pull/1308#issuecomment-1775347690
     "https://www.breezy-vcs.org/*",
 ]
+linkcheck_retries = 5
 
 # -- Options for extlinks ----------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration


### PR DESCRIPTION
We're getting frequent flaky CI failures due to the huge number of links that have to be checked, making the check sensitive to random connection errors.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1465.org.readthedocs.build/en/1465/

<!-- readthedocs-preview python-packaging-user-guide end -->