### PR TITLE
Add problem matcher for test-translations.yml

### DIFF
--- a/.github/sphinx_lint_matcher.json
+++ b/.github/sphinx_lint_matcher.json
@@ -1,0 +1,15 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "sphinx-lint-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -67,7 +67,7 @@ jobs:
       run: python -m pip install --upgrade nox virtualenv sphinx-lint
 
     - name: Set Sphinx problem matcher
-      uses: sphinx-doc/github-problem-matcher@master
+      uses: sphinx-doc/github-problem-matcher@v1.0
 
     - name: Build translated docs in ${{ matrix.language }}
       run: nox -s build -- -q -D language=${{ matrix.language }}

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -72,7 +72,10 @@ jobs:
     - name: Build translated docs in ${{ matrix.language }}
       run: nox -s build -- -q -D language=${{ matrix.language }}
 
+    - name: Set Sphinx Lint problem matcher
+      if: always()
+      run: echo '::add-matcher::.github/sphinx_lint_matcher.json'
+
     - name: Lint translation file
-      run: |
-        echo '::add-matcher::.github/sphinx_lint_matcher.json'
-        sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/messages.po
+      if: always()
+      run: sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/messages.po

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -58,7 +58,7 @@ jobs:
         ref: ${{ env.I18N_BRANCH }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: >-
           3.10
@@ -66,8 +66,13 @@ jobs:
     - name: Install Python tooling
       run: python -m pip install --upgrade nox virtualenv sphinx-lint
 
+    - name: Set Sphinx problem matcher
+      uses: sphinx-doc/github-problem-matcher@master
+
     - name: Build translated docs in ${{ matrix.language }}
       run: nox -s build -- -q -D language=${{ matrix.language }}
 
     - name: Lint translation file
-      run: sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/messages.po
+      run: |
+        echo '::add-matcher::.github/sphinx_lint_matcher.json'
+        sphinx-lint locales/${{ matrix.language }}/LC_MESSAGES/messages.po


### PR DESCRIPTION
Changes in here include:

- Make sure that the lint is ran even when build fails
- Add problem matcher for both build and lint
- Update version of the action/setup-python action

Link of tests done: rffontenelle/packaging.python.org#3

Screenshot from my personal tests showing errors in a language:

![Annotations for sphinx-lint](https://github.com/pypa/packaging.python.org/assets/1571783/8e73e5d0-ade1-4c2c-b4dd-584b121e1094)

Screenshot of the summary of a pull request:

![sphinx-lint outputs shown as annotations](https://github.com/pypa/packaging.python.org/assets/1571783/c7a9a663-7117-44b7-b5e2-84ceeb697a97)



<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1469.org.readthedocs.build/en/1469/

<!-- readthedocs-preview python-packaging-user-guide end -->