### PR TITLE
Fix linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -109,6 +109,12 @@ linkcheck_ignore = [
     "https://www.breezy-vcs.org/*",
 ]
 linkcheck_retries = 5
+# Ignore anchors for links to GitHub project pages -- GitHub adds anchors from
+# README.md headings through JavaScript, so Sphinx's linkcheck can't find them
+# in the HTML.
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/",
+]
 
 # -- Options for extlinks ----------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration


### PR DESCRIPTION
Apparently, GitHub now adds the README HTML on a project page dynamically through JS, which prevents Sphinx's link checker from finding anchors into the README.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1484.org.readthedocs.build/en/1484/

<!-- readthedocs-preview python-packaging-user-guide end -->