### PR TITLE
Update pex entry.

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -534,11 +534,14 @@ pex
 `GitHub <https://github.com/pantsbuild/pex/>`__ |
 `PyPI <https://pypi.org/project/pex>`__
 
-pex is both a library and tool for generating :file:`.pex` (Python EXecutable)
+Pex is a tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
-:file:`.pex` files are just carefully constructed zip files with a
-``#!/usr/bin/env python`` and special :file:`__main__.py`, and are designed to
-make deployment of Python applications as simple as ``cp``.
+PEX files are zipapps as outlined :pep:`441` that
+make deployment of Python applications as simple as ``cp``. A single PEX
+file can support multiple target platforms and can be created from standard
+:ref:`pip`-resolvable requirements, a lockfile generated with `pex3 lock ...`
+or even another PEX. PEX files can optionally have tools embedded that support
+turning the PEX file into a standard venv, graphing dependencies and more.
 
 .. _pip-tools:
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -536,7 +536,7 @@ pex
 
 Pex is a tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
-PEX files are zipapps as outlined :pep:`441` that
+PEX files are zipapps as outlined in :pep:`441` that
 make deployment of Python applications as simple as ``cp``. A single PEX
 file can support multiple target platforms and can be created from standard
 :ref:`pip`-resolvable requirements, a lockfile generated with ``pex3 lock ...``

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -536,7 +536,7 @@ pex
 
 Pex is a tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
-PEX files are :ref:`zipapps <python:library/zipapp>` that
+PEX files are :doc:`zipapps <python:library/zipapp>` that
 make deployment of Python applications as simple as ``cp``. A single PEX
 file can support multiple target platforms and can be created from standard
 :ref:`pip`-resolvable requirements, a lockfile generated with ``pex3 lock ...``

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -536,7 +536,7 @@ pex
 
 Pex is a tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
-PEX files are zipapps as outlined in :pep:`441` that
+PEX files are :ref:`zipapps <python:library/zipapp>` that
 make deployment of Python applications as simple as ``cp``. A single PEX
 file can support multiple target platforms and can be created from standard
 :ref:`pip`-resolvable requirements, a lockfile generated with ``pex3 lock ...``

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -539,7 +539,7 @@ files, standalone Python environments in the spirit of :ref:`virtualenv`.
 PEX files are zipapps as outlined :pep:`441` that
 make deployment of Python applications as simple as ``cp``. A single PEX
 file can support multiple target platforms and can be created from standard
-:ref:`pip`-resolvable requirements, a lockfile generated with `pex3 lock ...`
+:ref:`pip`-resolvable requirements, a lockfile generated with ``pex3 lock ...``
 or even another PEX. PEX files can optionally have tools embedded that support
 turning the PEX file into a standard venv, graphing dependencies and more.
 


### PR DESCRIPTION
Pex long ago stopped offering a programmatic API in favor of its CLI
API. I was remiss in not updating this description. Note is made of the
more expansive features Pex and PEX files have grown in the meantime,
including a nod to Pex multi-platform lock support (RIP PEP 665 - you
live on in Pex).

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1485.org.readthedocs.build/en/1485/

<!-- readthedocs-preview python-packaging-user-guide end -->