### PR TITLE
Use intersphinx to link to `hashlib` docs

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -79,10 +79,10 @@ MUST be present as a dictionary with the following keys:
 
   These hash names SHOULD always be normalized to be lowercase.
 
-  Any hash algorithm available via ``hashlib`` (specifically any that can be passed to
-  ``hashlib.new()`` and do not require additional parameters) can be used as a key for
+  Any hash algorithm available via :py:mod:`hashlib` (specifically any that can be passed to
+  :py:func:`hashlib.new()` and do not require additional parameters) can be used as a key for
   the hashes dictionary. At least one secure algorithm from
-  ``hashlib.algorithms_guaranteed`` SHOULD always be included. At time of writing,
+  :py:data:`hashlib.algorithms_guaranteed` SHOULD always be included. At time of writing,
   ``sha256`` specifically is recommended.
 
 - A deprecated ``hash`` key (type ``string``) MAY be present for backwards compatibility

--- a/source/specifications/recording-installed-packages.rst
+++ b/source/specifications/recording-installed-packages.rst
@@ -112,7 +112,7 @@ On Windows, directories may be separated either by forward- or backslashes
 (``/`` or ``\``).
 
 The *hash* is either an empty string or the name of a hash algorithm from
-``hashlib.algorithms_guaranteed``, followed by the equals character ``=`` and
+:py:data:`hashlib.algorithms_guaranteed`, followed by the equals character ``=`` and
 the digest of the file's contents, encoded with the urlsafe-base64-nopad
 encoding (``base64.urlsafe_b64encode(digest)`` with trailing ``=`` removed).
 

--- a/source/specifications/simple-repository-api.rst
+++ b/source/specifications/simple-repository-api.rst
@@ -71,7 +71,7 @@ In addition to the above, the following constraints are placed on the API:
   URL.
 
 * Repositories **SHOULD** choose a hash function from one of the ones
-  guaranteed to be available via the ``hashlib`` module in the Python standard
+  guaranteed to be available via the :py:mod:`hashlib` module in the Python standard
   library (currently ``md5``, ``sha1``, ``sha224``, ``sha256``, ``sha384``,
   ``sha512``). The current recommendation is to use ``sha256``.
 
@@ -452,11 +452,10 @@ Each individual file dictionary has the following keys:
   for the file, however it is **HIGHLY** recommended that at least one secure,
   guaranteed-to-be-available hash is always included.
 
-  By default, any hash algorithm available via `hashlib
-  <https://docs.python.org/3/library/hashlib.html>`_ (specifically any that can
-  be passed to ``hashlib.new()`` and do not require additional parameters) can
+  By default, any hash algorithm available via :py:mod:`hashlib` (specifically any that can
+  be passed to :py:func:`hashlib.new()` and do not require additional parameters) can
   be used as a key for the hashes dictionary. At least one secure algorithm from
-  ``hashlib.algorithms_guaranteed`` **SHOULD** always be included. At the time
+  :py:data:`hashlib.algorithms_guaranteed` **SHOULD** always be included. At the time
   of this spec, ``sha256`` specifically is recommended.
 - ``requires-python``: An **optional** key that exposes the
   :ref:`core-metadata-requires-python`

--- a/source/specifications/version-specifiers.rst
+++ b/source/specifications/version-specifiers.rst
@@ -1113,7 +1113,7 @@ and MAY refuse to rely on the URL. If such a direct reference also uses an
 insecure transport, automated tools SHOULD NOT rely on the URL.
 
 It is RECOMMENDED that only hashes which are unconditionally provided by
-the latest version of the standard library's ``hashlib`` module be used
+the latest version of the standard library's :py:mod:`hashlib` module be used
 for source archive hashes. At time of writing, that list consists of
 ``'md5'``, ``'sha1'``, ``'sha224'``, ``'sha256'``, ``'sha384'``, and
 ``'sha512'``.


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1488.org.readthedocs.build/en/1488/

<!-- readthedocs-preview python-packaging-user-guide end -->