### PR TITLE
Replace regex which allows dubble hyphens by one that does not.

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -631,7 +631,7 @@ of lowercase ASCII letters, ASCII numbers, and hyphen. It must start and end
 with a letter or number. Hyphens cannot be followed by another hyphen. Names are
 limited to those which match the following regex (which guarantees unambiguity)::
 
-    ^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$
+    ^[a-z0-9]+(-[a-z0-9]+)*$
 
 
 The specified name may be used to make a dependency conditional on whether the


### PR DESCRIPTION
The current version disallows tripple hyphens but allows dubble hyphens. (It also seems overcomplicated)

Alternatively we can make it a negative lookbehind instead of a negative lookahead, but the complexity is much higher.

See https://regex101.com/r/Xyu0bt/1 for proof the current version matches double hyphens

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1491.org.readthedocs.build/en/1491/

<!-- readthedocs-preview python-packaging-user-guide end -->