### PR TITLE
Fix a typo in the `pip install` command @ `modernize-setup-py-project.rst`

### DIFF
--- a/source/guides/modernize-setup-py-project.rst
+++ b/source/guides/modernize-setup-py-project.rst
@@ -124,7 +124,7 @@ and trigger the build in that environment.
 For some projects this isolation is unwanted and it can be deactivated as follows:
 
 * ``python -m build --no-isolation``
-* ``python -m install --no-build-isolation``
+* ``python -m pip install --no-build-isolation``
 
 For more details:
 


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1497.org.readthedocs.build/en/1497/

<!-- readthedocs-preview python-packaging-user-guide end -->