### PR TITLE
RFC: Clarify that the direct_url.json url field must be a spec-compliant url

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -11,7 +11,7 @@ URLs to python projects and distribution artifacts such as VCS source trees, loc
 source trees, source distributions and wheels.
 
 At time of writing, it is not formally specified how to merge the parts of this
-file into single URL that can be passed to tools. A common representation is the
+data structure into single URL that can be passed to tools. A common representation is the
 pip URL format (`VCS Support <pip-vcs-support_>`_), other examples are provided in the
 :ref:`Version specifier specification <version-specifiers>`.
 

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -27,7 +27,7 @@ type ``string``. Its content must be a valid URL according to the
 
 Depending on what ``url`` refers to, the second field MUST be one of ``vcs_info``
 (if ``url`` is a VCS reference), ``archive_info`` (if
-``url`` is a source archives or a wheel), or ``dir_info`` (if ``url``  is a
+``url`` is a source archive or a wheel), or ``dir_info`` (if ``url``  is a
 local directory). These info fields have a (possibly empty) subdictionary as
 value, with the possible keys defined below.
 

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -12,7 +12,7 @@ source trees, source distributions and wheels.
 
 At time of writing, it is not formally specified how to merge the parts of this
 file into single URL that can be passed to tools. A common representation is the
-pip URL format, other examples are provided in the
+pip URL format (`VCS Support <pip-vcs-support_>`_), other examples are provided in the
 :ref:`Version specifier specification <version-specifiers>`.
 
 Specification
@@ -397,4 +397,5 @@ History
 
 
 .. _archive-info-hashes: https://discuss.python.org/t/22299
+.. _pip-vcs-support: https://pip.pypa.io/en/stable/topics/vcs-support/
 .. _whatwg-url-standard: https://url.spec.whatwg.org/

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -10,11 +10,6 @@ This document specifies a JSON-serializable abstract data structure that can rep
 URLs to python projects and distribution artifacts such as VCS source trees, local
 source trees, source distributions and wheels.
 
-The representation of the components of this data structure as a :rfc:`1738` URL
-is not formally specified at time of writing. A common representation is the pip URL
-format. Other examples are provided in the :ref:`Version specifier specification <version-specifiers>`.
-
-
 Specification
 =============
 
@@ -22,8 +17,9 @@ The Direct URL Data Structure MUST be a dictionary, serializable to JSON accordi
 :rfc:`8259`.
 
 It MUST contain at least two fields. The first one is ``url``, with
-type ``string``. Depending on what ``url`` refers to, the second field MUST be
-one of ``vcs_info`` (if ``url`` is a VCS reference), ``archive_info`` (if
+type ``string``. Its content must be a valid URL according to the
+`WHATWG URL Standard <whatwg-url-standard_>`_. Depending on what ``url`` refers to,
+the second field MUST be one of ``vcs_info`` (if ``url`` is a VCS reference), ``archive_info`` (if
 ``url`` is a source archives or a wheel), or ``dir_info`` (if ``url``  is a
 local directory). These info fields have a (possibly empty) subdictionary as
 value, with the possible keys defined below.
@@ -396,3 +392,4 @@ History
 
 
 .. _archive-info-hashes: https://discuss.python.org/t/22299
+.. _whatwg-url-standard: https://url.spec.whatwg.org/

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -10,6 +10,11 @@ This document specifies a JSON-serializable abstract data structure that can rep
 URLs to python projects and distribution artifacts such as VCS source trees, local
 source trees, source distributions and wheels.
 
+At time of writing, it is not formally specified how to merge the parts of this
+file into single URL that can be passed to tools. A common representation is the
+pip URL format, other examples are provided in the
+:ref:`Version specifier specification <version-specifiers>`.
+
 Specification
 =============
 

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -23,8 +23,10 @@ The Direct URL Data Structure MUST be a dictionary, serializable to JSON accordi
 
 It MUST contain at least two fields. The first one is ``url``, with
 type ``string``. Its content must be a valid URL according to the
-`WHATWG URL Standard <whatwg-url-standard_>`_. Depending on what ``url`` refers to,
-the second field MUST be one of ``vcs_info`` (if ``url`` is a VCS reference), ``archive_info`` (if
+`WHATWG URL Standard <whatwg-url-standard_>`_.
+
+Depending on what ``url`` refers to, the second field MUST be one of ``vcs_info``
+(if ``url`` is a VCS reference), ``archive_info`` (if
 ``url`` is a source archives or a wheel), or ``dir_info`` (if ``url``  is a
 local directory). These info fields have a (possibly empty) subdictionary as
 value, with the possible keys defined below.

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -11,7 +11,7 @@ URLs to python projects and distribution artifacts such as VCS source trees, loc
 source trees, source distributions and wheels.
 
 At time of writing, it is not formally specified how to merge the parts of this
-data structure into single URL that can be passed to tools. A common representation is the
+data structure into a single URL that can be passed to tools. A common representation is the
 pip URL format (`VCS Support <pip-vcs-support_>`_), other examples are provided in the
 :ref:`Version specifier specification <version-specifiers>`.
 


### PR DESCRIPTION
Clarify that the `url` field in `direct_url.json` must be a valid url. This was prompted by a case where the `url` field contained a value that was not a url (https://github.com/astral-sh/uv/issues/1744). I'm not sure what the best venue to discuss this change is, so i'm putting it up as a PR here.

Relatedly, would it make sense to write a json schem for direct_url.json? A machine readable spec would allow tooling to generate types and would simplify verification.

[Post on discuss.python.org](https://discuss.python.org/t/clarify-that-the-direct-url-json-url-field-must-be-a-spec-compliant-url/46518)

Closes #1510 (link check fix)

---

Thanks to whoever set up nox + sphinx-autobuild, `nox -s preview` is great!

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1506.org.readthedocs.build/en/1506/

<!-- readthedocs-preview python-packaging-user-guide end -->