### PR TITLE
Document the JSON schema of `direct_url.json`

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -213,6 +213,128 @@ vcs command
    this field is the Subversion revision number in the corresponding
    repository.
 
+JSON Schema
+===========
+
+The following JSON Schema can be used to validate the contents of ``direct_url.json``:
+
+.. code-block::
+
+     {
+       "$schema": "https://json-schema.org/draft/2019-09/schema",
+       "title": "Direct URL Data",
+       "description": "Data structure that can represent URLs to python projects and distribution artifacts such as VCS source trees, local source trees, source distributions and wheels.",
+       "definitions": {
+         "URL": {
+           "type": "string",
+           "format": "uri"
+         },
+         "DirInfo": {
+           "type": "object",
+           "properties": {
+             "editable": {
+               "type": ["boolean", "null"]
+             }
+           }
+         },
+         "VCSInfo": {
+           "type": "object",
+           "properties": {
+             "vcs": {
+               "type": "string",
+               "enum": [
+                 "git",
+                 "hg",
+                 "bzr",
+                 "svn"
+               ]
+             },
+             "requested_revision": {
+               "type": "string"
+             },
+             "commit_id": {
+               "type": "string"
+             },
+             "resolved_revision": {
+               "type": "string"
+             }
+           },
+           "required": [
+             "vcs",
+             "commit_id"
+           ]
+         },
+         "ArchiveInfo": {
+           "type": "object",
+           "properties": {
+             "hash": {
+               "type": "string",
+               "pattern": "^\\w+=[a-f0-9]+$",
+               "deprecated": true
+             },
+             "hashes": {
+               "type": "object",
+               "patternProperties": {
+                 "^[a-f0-9]+$": {
+                   "type": "string"
+                 }
+               }
+             }
+           }
+         }
+       },
+       "allOf": [
+         {
+           "type": "object",
+           "properties": {
+             "url": {
+               "$ref": "#/definitions/URL"
+             }
+           },
+           "required": [
+             "url"
+           ]
+         },
+         {
+           "anyOf": [
+             {
+               "type": "object",
+               "properties": {
+                 "dir_info": {
+                   "$ref": "#/definitions/DirInfo"
+                 }
+               },
+               "required": [
+                 "dir_info"
+               ]
+             },
+             {
+               "type": "object",
+               "properties": {
+                 "vcs_info": {
+                   "$ref": "#/definitions/VCSInfo"
+                 }
+               },
+               "required": [
+                 "vcs_info"
+               ]
+             },
+             {
+               "type": "object",
+               "properties": {
+                 "archive_info": {
+                   "$ref": "#/definitions/ArchiveInfo"
+                 }
+               },
+               "required": [
+                 "archive_info"
+               ]
+             }
+           ]
+         }
+       ]
+     }
+
 Examples
 ========
 


### PR DESCRIPTION
Adds a JSON schema for the structure of `direct_url.json`.

Based on https://github.com/edgarrmondragon/pep610/blob/41a39253521637e85f364f60d1106c25dfa03d02/tests/fixtures/direct_url.schema.json with some changes to make it more accurate:

* Updated the JSON schema draft version to [2019-09](https://json-schema.org/draft/2019-09/release-notes) so `deprecated` can be used for `archive_info.hash`.
* Fixed the pattern of `archive_info.hash` to actually accomodate valid algorithm names. e.g. `md5=...` wouldn't have been valid before.

See the [discuss thread](https://discuss.python.org/t/clarify-that-the-direct-url-json-url-field-must-be-a-spec-compliant-url/46518/7) for more context.

Relevant docs preview: https://python-packaging-user-guide--1512.org.readthedocs.build/en/1512/specifications/direct-url-data-structure/#json-schema

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1512.org.readthedocs.build/en/1512/

<!-- readthedocs-preview python-packaging-user-guide end -->