### PR TITLE
Point pip's `setup.py` link to its latest version

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -9,7 +9,8 @@ Single-sourcing the package version
 There are many techniques to maintain a single source of truth for the version
 number of your project:
 
-#.  Read the file in :file:`setup.py` and get the version. Example::
+#.  Read the file in :file:`setup.py` and get the version. Example (from `pip setup.py
+    <https://github.com/pypa/pip/blob/003c7ac/setup.py>`_)::
 
         import codecs
         import os.path


### PR DESCRIPTION
This file no longer exists on the `main` branch as of https://github.com/pypa/pip/pull/12537 /
https://github.com/pypa/pip/commit/0ad4c94b.

It's an alternative to removing the link performed in https://github.com/pypa/packaging.python.org/commit/3e65739d8078603eec17bc2a38a1bab1a74ccb37.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1514.org.readthedocs.build/en/1514/

<!-- readthedocs-preview python-packaging-user-guide end -->