### PR TITLE
pyproject.toml: specify description is one line

### DIFF
--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -180,7 +180,8 @@ Users SHOULD prefer to specify already-normalized versions.
 - Corresponding :ref:`core metadata <core-metadata>` field:
   :ref:`Summary <core-metadata-summary>`
 
-The summary description of the project.
+The summary description of the project in one line. Tools MAY error
+if this includes multiple lines.
 
 
 ``readme``


### PR DESCRIPTION
See https://github.com/pypa/pyproject-metadata/issues/30. This fills the Summary field, which must be a single line, so this should also be a single line. Historically, tools have done different things here. Setuptools removes anything after the first line. pyproject-metadata based backends (pdm-backend, scikit-build-core, and meson-python) join the lines into one line. The next version of scikit-build-core will error instead. Third party tools reading a config like this:

```toml
[project]
description = """Two
Line"""
```

Cannot know if the `Summary` will be `"Two Line"`, `"Two"`, or an error.

Enforcing this as one line also helps authors that put what should go into `project.readme.text` here instead.

There are three levels of response possible here, this PR is the middle one:

1. Just mention one line, pulled from the Summary field.
2. Mention that tools MAY error here. That's the current state of this PR. I think this will help validation tools (validate-pyproject and SchemaStore) make newlines a validation error.
3. Say tools MUST error. My favorite, I think it would help authors in the long run, but probably too late to do this.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1533.org.readthedocs.build/en/1533/

<!-- readthedocs-preview python-packaging-user-guide end -->