### PR TITLE
Update glossary.rst

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -15,7 +15,7 @@ Glossary
     Build Backend
 
         A library that takes a source tree
-        and builds a :term:`source distribution <Source Distribution (or "sdist")>` or 
+        and builds a :term:`source distribution <Source Distribution (or "sdist")>` or
         :term:`built distribution <Built Distribution>` from it.
         The build is delegated to the backend by a
         :term:`frontend <Build Frontend>`.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -15,7 +15,8 @@ Glossary
     Build Backend
 
         A library that takes a source tree
-        and builds a :term:`source distribution <Source Distribution (or "sdist")>` or :term:`built distribution <Built Distribution>` from it.
+        and builds a :term:`source distribution <Source Distribution (or "sdist")>` or 
+        :term:`built distribution <Built Distribution>` from it.
         The build is delegated to the backend by a
         :term:`frontend <Build Frontend>`.
         All backends offer a standardized interface.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -14,9 +14,8 @@ Glossary
 
     Build Backend
 
-        A library that takes a source tree or
-        :term:`source distribution <Source Distribution (or "sdist")>`
-        and builds a :term:`built distribution <Built Distribution>` or :term:`wheel <Wheel>` from it.
+        A library that takes a source tree
+        and builds a :term:`source distribution <Source Distribution (or "sdist")>` or :term:`built distribution <Built Distribution>` from it.
         The build is delegated to the backend by a
         :term:`frontend <Build Frontend>`.
         All backends offer a standardized interface.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -16,7 +16,7 @@ Glossary
 
         A library that takes a source tree or
         :term:`source distribution <Source Distribution (or "sdist")>`
-        and builds a source distribution or :term:`wheel <Wheel>` from it.
+        and builds a :term:`built distribution <Built Distribution>` or :term:`wheel <Wheel>` from it.
         The build is delegated to the backend by a
         :term:`frontend <Build Frontend>`.
         All backends offer a standardized interface.


### PR DESCRIPTION
fix seeming typo and add link to the correct term

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1537.org.readthedocs.build/en/1537/

<!-- readthedocs-preview python-packaging-user-guide end -->