### PR TITLE
Update packaging-projects.rst: rephrase first explanation of __init__.py

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -54,9 +54,9 @@ Create the following file structure locally:
 The directory containing the Python files should match the project name. This
 simplifies the configuration and is more obvious to users who install the package.
 
-Creating the file :file:`__init__.py` is recommended because the existence of a
+Creating the file :file:`__init__.py` is recommended because the existence of an
 :file:`__init__.py` file allows users to import the directory as a regular package,
-even if (as is the case for this tutorial) :file:`__init__.py` is empty.
+even if (as is the case in this tutorial) :file:`__init__.py` is empty.
 [#namespace-packages]_
 
 :file:`example.py` is an example of a module within the package that could

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -54,8 +54,10 @@ Create the following file structure locally:
 The directory containing the Python files should match the project name. This
 simplifies the configuration and is more obvious to users who install the package.
 
-:file:`__init__.py` is recommended to import the directory as a regular package,
-even if as is our case for this tutorial that file is empty [#namespace-packages]_.
+Creating the file :file:`__init__.py` is recommended because the existence of a
+:file:`__init__.py` file allows users to import the directory as a regular package,
+even if (as is the case for this tutorial) :file:`__init__.py` is empty.
+[#namespace-packages]_
 
 :file:`example.py` is an example of a module within the package that could
 contain the logic (functions, classes, constants, etc.) of your package.


### PR DESCRIPTION
I thought the explanation of __init__.py was kind of confusing, so I have improved it somewhat.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1538.org.readthedocs.build/en/1538/

<!-- readthedocs-preview python-packaging-user-guide end -->