### PR TITLE
publish-to-test-pypi: bump action versions

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -68,7 +68,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
This bumps two referenced action versions:

1. The latest stable `setup-python` is `v5`, which is compatible with the previous use.
2. The example workflow previously referred to a very old version of `gh-action-sigstore-python`, which was no longer supported. This bumps it to a newer version that is similarly compatible with the previous use.

For (2), see https://github.com/sigstore/gh-action-sigstore-python/issues/122 for an example of a user who was snarled by the old version :slightly_smiling_face: 

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1539.org.readthedocs.build/en/1539/

<!-- readthedocs-preview python-packaging-user-guide end -->