### PR TITLE
Add glossary definitions of packaging and metadata terms

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -54,6 +54,39 @@ Glossary
         Python files). See :ref:`package-formats` for more information.
 
 
+    Built Metadata
+
+        The concrete form :term:`Core Metadata` takes
+        when included inside an installed :term:`Project` (``METADATA`` file)
+        or a :term:`Distribution Archive`
+        (``PKG-INFO`` in a
+        :term:`Sdist <Source Distribution (or "sdist")>`
+        and ``METADATA`` in a :term:`Wheel`).
+
+
+    Core Metadata
+
+        The :ref:`specification <core-metadata>`
+        and the set of :term:`Core Metadata Field`\s it defines
+        that describe key static attributes of
+        a :term:`Distribution Package` or :term:`Installed Project`.
+
+
+    Core Metadata Field
+
+        A single key-value pair
+        (or sequence of such with the same name, for multiple-use fields)
+        defined in the :term:`Core Metadata` spec
+        and stored in the :term:`Built Metadata`.
+        Notably, distinct from a :term:`Pyproject Metadata Key`.
+
+
+    Distribution Archive
+
+        The physical distribution artifact (i.e. a file on disk)
+        for a :term:`Distribution Package`.
+
+
     Distribution Package
 
         A versioned archive file that contains Python :term:`packages <Import
@@ -106,6 +139,14 @@ Glossary
         is also commonly called a "package". See :ref:`distribution-package-vs-import-package`
         for a breakdown of the differences.
 
+
+    Installed Project
+
+        A :term:`Project` that is installed for use with
+        a Python interpreter or :term:`Virtual Environment`,
+        as described in the specicifcation :ref:`recording-installed-packages`.
+
+
     Module
 
         The basic unit of code reusability in Python, existing in one of two
@@ -149,10 +190,62 @@ Glossary
         'bar'.
 
 
+    Project Root Directory
+
+        The filesystem directory in which
+        a :term:`Project`'s :term:`source tree <Project Source Tree>` is located.
+
+
+    Project Source Tree
+
+        The on-disk format of a :term:`Project` used for development,
+        containing its raw source code before being packaged
+        into a
+        :term:`Source Distribution <Source Distribution (or "sdist")>`
+        or :term:`Built Distribution`.
+
+
+    Project Source Metadata
+
+        Metadata defined by the package author
+        in a :term:`Project`'s :term:`source tree <Project Source Tree>`,
+        to be transformed into :term:`Core Metadata field`\s
+        in the :term:`Built Metadata`
+        by the project's build backend.
+        Can be written as :term:`Pyproject Metadata`,
+        or in a tool-specific format
+        (under the ``[tool]`` table in ``pyproject.toml``,
+        or in a tool's own configuration file).
+
+
     Pure Module
 
         A :term:`Module` written in Python and contained in a single ``.py`` file (and
         possibly associated ``.pyc`` and/or ``.pyo`` files).
+
+
+    Pyproject Metadata
+
+        The :term:`Project Source Metadata` format
+        defined by the :ref:`declaring-project-metadata` specification
+        and originally introduced in :pep:`621`,
+        stored as :term:`Pyproject Metadata Key`\s
+        under the ``[project]`` table of a :term:`pyproject.toml` file.
+        Notably, *not* a tool-specific source metadata format
+        under the ``[tool]`` table in ``pyproject.toml``.
+
+
+    Pyproject Metadata Key
+
+        A top-level TOML key in the ``[project]`` table in ``pyproject.toml``;
+        part of the :term:`Pyproject Metadata`.
+        Notably, distinct from a :term:`Core Metadata Field`.
+
+
+    Pyproject Metadata Subkey
+
+        A second-level TOML key under a table-valued
+        :term:`Pyproject Metadata Key`.
 
 
     Python Packaging Authority (PyPA)
@@ -236,7 +329,7 @@ Glossary
 
     Source Distribution (or "sdist")
 
-        A :term:`distribution <Distribution Package>` format (usually generated
+        A :term:`distribution <Distribution Archive>` format (usually generated
         using ``python -m build --sdist``) that provides metadata and the
         essential source files needed for installing by a tool like :ref:`pip`,
         or for generating a :term:`Built Distribution`. See :ref:`package-formats`
@@ -264,10 +357,22 @@ Glossary
         wide. For more information, see the section on :ref:`Creating and using
         Virtual Environments`.
 
+
+    Wheel Format
     Wheel
 
-        The standard :term:`Built Distribution` format.
+        The standard :term:`Built Distribution` format
+        originally introduced in :pep:`427`
+        and defined by the :ref:`binary-distribution-format` specification.
         See :ref:`package-formats` for more information.
+        Not to be confused with its reference implementation,
+        the :term:`Wheel Project`.
+
+
+    Wheel Project
+
+        The PyPA reference implementation of the :term:`Wheel Format`.
+
 
     Working Set
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -211,7 +211,7 @@ Glossary
         in a :term:`Project`'s :term:`source tree <Project Source Tree>`,
         to be transformed into :term:`Core Metadata field`\s
         in the :term:`Built Metadata`
-        by the project's build backend.
+        by the project's :term:`build backend <Build Backend>`.
         Can be written as :term:`Pyproject Metadata`,
         or in a tool-specific format
         (under the ``[tool]`` table in ``pyproject.toml``,
@@ -371,7 +371,7 @@ Glossary
 
     Wheel Project
 
-        The PyPA reference implementation of the :term:`Wheel Format`.
+        The PyPA reference implementation of the :term:`Wheel Format`; see :ref:`wheel`.
 
 
     Working Set


### PR DESCRIPTION
The definitions were originally included in (the draft of) PEP 639, refining and extending the existing glossary terms.
Having the unified vocabulary in place is essential to accurately describe the complex Python packaging landscape.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1541.org.readthedocs.build/en/1541/glossary/#term-Built-Metadata

<!-- readthedocs-preview python-packaging-user-guide end -->