### PR TITLE
Update installing-using-pip-and-virtual-environments.rst

### DIFF
--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -103,7 +103,8 @@ Python interpreter:
 
     .. code-block:: bat
 
-        where python
+        Get-Command python   # If using PowerShell
+        where python         # If using Command Prompt
 
 While the virtual environment is active, the above command will output a
 filepath that includes the ``.venv`` directory, by ending with the following:


### PR DESCRIPTION
Use `Get-Command` if on PowerShell

`where` in PowerShell is an alias for `Where-Object`.

If you use `where` in Powershell, no output is returned. Use `Get-Command` instead:

![image](https://github.com/pypa/packaging.python.org/assets/20816/e01afdab-3f0b-44de-8d30-4f8772a5022b)
