### PR TITLE
Update section-install.rst

### DIFF
--- a/source/guides/section-install.rst
+++ b/source/guides/section-install.rst
@@ -6,7 +6,6 @@ Installation
    :titlesonly:
 
    installing-using-pip-and-virtual-environments
-   installing-using-virtualenv
    installing-stand-alone-command-line-tools
    installing-using-linux-tools
    installing-scientific-packages


### PR DESCRIPTION
installing-using-virtualenv has no instructions.

Removing the reference to it.

Here's what the page looks like:

![image](https://github.com/pypa/packaging.python.org/assets/20816/c8de0831-25a0-4ccb-b9a4-a2b2f06a5514)
