### PR TITLE
allow trailing comma in `version_many`

### DIFF
--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -482,7 +482,7 @@ History
   ``'.'.join(platform.python_version_tuple()[:2])``, to accommodate potential
   future versions of Python with 2-digit major and minor versions
   (e.g. 3.10). [#future_versions]_
-- May 2024: The definition of ``version_many`` was changed to allow trailing
+- June 2024: The definition of ``version_many`` was changed to allow trailing
   commas, matching with the behavior of the Python implementation that has been
   in use since late 2022.
 

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -66,7 +66,7 @@ URI is defined in :rfc:`std-66 <3986>`)::
     version_cmp   = wsp* '<' | '<=' | '!=' | '==' | '>=' | '>' | '~=' | '==='
     version       = wsp* ( letterOrDigit | '-' | '_' | '.' | '*' | '+' | '!' )+
     version_one   = version_cmp version wsp*
-    version_many  = version_one (wsp* ',' version_one)*
+    version_many  = version_one (',' version_one)* (',' wsp*)?
     versionspec   = ( '(' version_many ')' ) | version_many
     urlspec       = '@' wsp* <URI_reference>
 
@@ -303,7 +303,7 @@ The complete parsley grammar::
     version_cmp   = wsp* <'<=' | '<' | '!=' | '==' | '>=' | '>' | '~=' | '==='>
     version       = wsp* <( letterOrDigit | '-' | '_' | '.' | '*' | '+' | '!' )+>
     version_one   = version_cmp:op version:v wsp* -> (op, v)
-    version_many  = version_one:v1 (wsp* ',' version_one)*:v2 -> [v1] + v2
+    version_many  = version_one:v1 (',' version_one)*:v2 (',' wsp*)? -> [v1] + v2
     versionspec   = ('(' version_many:v ')' ->v) | version_many
     urlspec       = '@' wsp* <URI_reference>
     marker_op     = version_cmp | (wsp* 'in') | (wsp* 'not' wsp+ 'in')
@@ -424,6 +424,7 @@ A test program - if the grammar is in a string ``grammar``:
         "name",
         "name<=1",
         "name>=3",
+        "name>=3,",
         "name>=3,<2",
         "name@http://foo.com",
         "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
@@ -481,6 +482,9 @@ History
   ``'.'.join(platform.python_version_tuple()[:2])``, to accommodate potential
   future versions of Python with 2-digit major and minor versions
   (e.g. 3.10). [#future_versions]_
+- May 2024: The definition of ``version_many`` was changed to allow trailing
+  commas, matching with the behavior of the Python implementation that has been
+  in use since late 2022.
 
 
 References


### PR DESCRIPTION
This PR makes a minor adjustment to the `version_many` grammar to allow a trailing comma to match the behavior of [`_parse_version_many`](https://github.com/pypa/packaging/blob/3e67fc775e93166600c84a5183ab6a86afff84b5/src/packaging/_parser.py#L220-L246).

Users may assume that setuptools `install_requires` is a comma separated list or otherwise leave trailing commas in dependency specifiers, leading to requirements like [`numpy >=1.19,`](https://inspector.pypi.io/project/pymixfit-tspspi/0.0.1/packages/23/a0/e3a6f5b3691cfc9c5aedf6f11cf9e806c40966a7250216a684ea62fdf90c/pymixfit_tspspi-0.0.1.tar.gz/pymixfit_tspspi-0.0.1/setup.cfg#line.21). Since https://github.com/pypa/packaging/pull/484 released in late 2022, the `packaging` package used by most packaging tools has been silently discarding trailing commas in version specifiers due to a slight misimplementation of a comma separated list. Because of this bug, users have created packages that do not conform to the spec yet work without issue.

More details about the behavior are on https://github.com/pypa/packaging/issues/803 .

Even if everyone were using PEP 517 and had their build dependencies specified such that the version of the packaging package used in the build would be semver compatible (advisable but not recommended: [setuptools](https://peps.python.org/pep-0518/#build-system-table) [setuptools](https://setuptools.pypa.io/en/latest/setuptools.html#setup-cfg-only-projects) [hatch](https://hatch.pypa.io/1.9/config/build/#build-system)), the regression would still not be fixable in the packaging package because the same PEP 508 version specifiers are also used by PEP 518 when specifying the build backend. Packages authored since late 2022 may have these incorrect specifiers in their `build-system.requires` section and such packages would not be buildable by package managers with a fixed version of the packaging package.

This is important because tools like uv use alternative implementations of PEP 508. If 99% of users are using the packaging package's slightly broken implementation, the implementation becomes the de facto specification, and packages that comply to the de facto specification but not the documented specification become a problem for alternative implementations.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1550.org.readthedocs.build/en/1550/

<!-- readthedocs-preview python-packaging-user-guide end -->