### PR TITLE
Add HTML snippet for Plausible metrics

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -1,6 +1,14 @@
 # -- Project information ---------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+
+# Some options are only enabled for the main packaging.python.org deployment builds
+RTD_BUILD = bool(os.getenv("READTHEDOCS"))
+RTD_PR_BUILD = RTD_BUILD and os.getenv("READTHEDOCS_VERSION_TYPE") == "external"
+RTD_URL = os.getenv("READTHEDOCS_CANONICAL_URL")
+RTD_CANONICAL_BUILD = RTD_BUILD and not RTD_PR_BUILD and "packaging.python.org" in RTD_URL
+
 project = "Python Packaging User Guide"
 
 copyright = "2013–2020, PyPA"
@@ -54,6 +62,15 @@ html_theme = "furo"
 
 html_favicon = "assets/py.png"
 html_last_updated_fmt = ""
+
+_metrics_js_files = [
+    ("https://plausible.io/js/script.js", {"data-domain": "packaging.python.org"})
+]
+html_js_files = []
+if RTD_CANONICAL_BUILD:
+    # Enable collection of the visitor metrics reported at
+    # https://plausible.io/packaging.python.org
+    html_js_files.extend(_metrics_js_files)
 
 # -- Options for HTML help output ------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-help-output

--- a/source/conf.py
+++ b/source/conf.py
@@ -7,7 +7,9 @@ import os
 RTD_BUILD = bool(os.getenv("READTHEDOCS"))
 RTD_PR_BUILD = RTD_BUILD and os.getenv("READTHEDOCS_VERSION_TYPE") == "external"
 RTD_URL = os.getenv("READTHEDOCS_CANONICAL_URL")
-RTD_CANONICAL_BUILD = RTD_BUILD and not RTD_PR_BUILD and "packaging.python.org" in RTD_URL
+RTD_CANONICAL_BUILD = (
+    RTD_BUILD and not RTD_PR_BUILD and "packaging.python.org" in RTD_URL
+)
 
 project = "Python Packaging User Guide"
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -66,7 +66,10 @@ html_favicon = "assets/py.png"
 html_last_updated_fmt = ""
 
 _metrics_js_files = [
-    ("https://plausible.io/js/script.js", {"data-domain": "packaging.python.org", "defer": "defer"})
+    (
+        "https://plausible.io/js/script.js",
+        {"data-domain": "packaging.python.org", "defer": "defer"},
+    )
 ]
 html_js_files = []
 if RTD_CANONICAL_BUILD:

--- a/source/conf.py
+++ b/source/conf.py
@@ -66,7 +66,7 @@ html_favicon = "assets/py.png"
 html_last_updated_fmt = ""
 
 _metrics_js_files = [
-    ("https://plausible.io/js/script.js", {"data-domain": "packaging.python.org"})
+    ("https://plausible.io/js/script.js", {"data-domain": "packaging.python.org", "defer": "defer"})
 ]
 html_js_files = []
 if RTD_CANONICAL_BUILD:


### PR DESCRIPTION
Metrics are only collected for the main packaging.python.org documentation deployments.

Closes #1561

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1564.org.readthedocs.build/en/1564/

<!-- readthedocs-preview python-packaging-user-guide end -->