### PR TITLE
Enhance README: Shields to capture the attention of potential contributors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ issue trackers, chat rooms, and mailing lists are expected to follow the
 Contributing
 ------------
 
+[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/pypa/packaging.python.org/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/pypa/packaging.python.org/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/pypa/packaging.python.org?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen)
+
 This guide is community-maintained and contributions are welcome! Please see the
 `contributing guide`_ for details on our writing style guide and how to build
 the guide locally to test your changes.


### PR DESCRIPTION
I noticed you have opened issues labeled `help wanted`. I recommend enhancing the README to make the call for new contributors more prominent.

### Changes Made:

1. **Shields:** Added Shields.io badges at the top of the README

[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/pypa/packaging.python.org/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/pypa/packaging.python.org/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/pypa/packaging.python.org?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen)

```markdown
[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/pypa/packaging.python.org/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/pypa/packaging.python.org/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/pypa/packaging.python.org/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/pypa/packaging.python.org?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/pypa/packaging.python.org/issues?q=is%3Aopen)
```

2. **Welcoming Message:** Enhanced the README with a more prominent and inviting message to welcome new contributors.

### Why This Matters:

- **Attract New Contributors:** Considering there is a number of opened issues labeled 'Help Wanted' - a welcoming and appealing README is one of the most efficient ways to attract new contributors

### Additional Resources:

For more insights into building a strong open-source community, check out the [Building Community guide](https://opensource.guide/building-community/). 

🚀 **Thank you for considering this pull request!** 🚀

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1571.org.readthedocs.build/en/1571/

<!-- readthedocs-preview python-packaging-user-guide end -->