### PR TITLE
Fix conflicting classification of install

### DIFF
--- a/source/discussions/setup-py-deprecated.rst
+++ b/source/discussions/setup-py-deprecated.rst
@@ -141,7 +141,6 @@ This guide does not make suggestions of replacement solutions for those commands
     * ``easy_install``
     * ``editable_wheel``
     * ``egg_info``
-    * ``install``
     * ``install_data``
     * ``install_egg_info``
     * ``install_headers``


### PR DESCRIPTION
Lines 21 to 23 state that the `install` command must not be run anymore.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1572.org.readthedocs.build/en/1572/

<!-- readthedocs-preview python-packaging-user-guide end -->