### PR TITLE
WIP: updated single_source_version with a much simpler page.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -19,6 +19,7 @@ This guide is maintained on `github
    current
    installing
    distributing
+   single_source_version
    additional
    projects
    glossary

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -9,15 +9,13 @@ Single-sourcing the Project Version
 
 One of the challenges in building packages is that the version string can be required in multiple places.
 
-* It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
+* It needs to be specified when building the package (e.g. in :file:``pyproject.toml``)
    - That will assure that it is properly assigned in the distribution file name, and in the installed package.
 
-* Some projects prefer that there be a version string available as an attribute in the importable module, e.g::
+* A package may, if the maintainers think it useful, to be able to determine the version of the package from Python code without relying on a package manager's metadata, set a top level ``__version__`` attribute.
+The value of ``__version__`` attribute and that passed to the build system can (and should) be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
 
-    import a_package
-    print(a_package.__version__)
-
-* In the metadata of the artifacts for each of the packaging ecosystems    
+Should a package not set a top level ``__version__`` attribute, the version can still be accessed using ``importlib.metadata.version("distribution_name")``.
 
 While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
 
@@ -27,17 +25,15 @@ In general, the options are:
 
 2) The version can be hard-coded into the `pyproject.toml` file -- and the build system can copy it into other locations it may be required.
 
-3) The version string can be hard-coded into the source code -- either in a special purpose file, such as `_version.txt`, or as a attribute in the `__init__.py`, and the build system can extract it at build time.
-
-If the version string is not in the source, it can be extracted at runtime with code in `__init__.py`, such as::
-
-    import importlib.metadata
-    __version__ = importlib.metadata.version('the_distribution_name')
+3) The version string can be hard-coded into the source code -- either in a special purpose file, such as ``_version.txt``, or as a attribute in the ``__init__.py``, and the build system can extract it at build time.
 
 
 Consult your build system documentation for how to implement your preferred method.
 
-Here are the common ones:
+.. _how_to_set_version_links:
+
+Build System Version Handling
+----------------------------
 
 * `Hatch <https://hatch.pypa.io/1.9/version/>`_
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -32,7 +32,7 @@ Consult your build system's documentation for their recommended method.
 .. _how_to_set_version_links:
 
 Build System Version Handling
-----------------------------
+-----------------------------
 
 * `Flit <https://flit.pypa.io/en/stable/>`_
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -16,6 +16,7 @@ One of the challenges in building packages is that the version string can be req
 
     import a_package
     print(a_package.__version__)
+* In the metadata of the artifacts for each of the packaging ecosystems    
 
 While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -17,7 +17,7 @@ The value of ``__version__`` attribute and that passed to the build system can (
 
 In the cases where a package does not set a top level ``__version__`` attribute, the version may still be accessible using ``importlib.metadata.version("distribution_name")``.
 
-While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
+To ensure that version numbers do not get out of sync, it is recommended that there is a single source of truth for the version number.
 
 In general, the options are:
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -12,7 +12,7 @@ One of the challenges in building packages is that the version string can be req
 * It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
    - That will assure that it is properly assigned in the distribution file name, and in the installed package metadata.
 
-* A package may set a top level ``__version__`` attribute to provide runtime access to the version of the installed package. If this is done, the value of ``__version__`` attribute and that used by the build system to set the distribution's version should be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
+* A package may set a top level ``__version__`` attribute to provide runtime access to the version of the imported package. If this is done, the value of ``__version__`` attribute and that used by the build system to set the distribution's version should be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
 
 In the cases where a package does not set a top level ``__version__`` attribute, the version may still be accessible using ``importlib.metadata.version("distribution_name")``.
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -7,111 +7,45 @@ Single-sourcing the Project Version
 :Page Status: Complete
 :Last Reviewed: 2015-09-08
 
+One of the challenges in building packages is that the version string can be required in multiple places.
 
-There are a few techniques to store the version in your project code without duplicating the value stored in
-``setup.py``:
+* It needs to be specified when building the package (e.g. in pyproject.toml)
+   - That will assure that it is properly assigned in the distribution file name, and in teh installed package.
 
-#.  Read the file in ``setup.py`` and parse the version with a regex. Example (
-    from `pip setup.py <https://github.com/pypa/pip/blob/1.5.6/setup.py#L33>`_)::
+* Some projects require that there be a version string available as an attribute in the importable module, e.g::
 
-        def read(*names, **kwargs):
-            with io.open(
-                os.path.join(os.path.dirname(__file__), *names),
-                encoding=kwargs.get("encoding", "utf8")
-            ) as fp:
-                return fp.read()
+    import a_package
+    print(a_package.__version__)
 
-        def find_version(*file_paths):
-            version_file = read(*file_paths)
-            version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                                      version_file, re.M)
-            if version_match:
-                return version_match.group(1)
-            raise RuntimeError("Unable to find version string.")
+While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
 
-        setup(
-           ...
-           version=find_version("package", "__init__.py")
-           ...
-        )
+In general, the options are:
 
-    .. note::
+1) If the code is in a version control system (VCS), e.g. git, then the version can be extracted from the VCS.
 
-        This technique has the disadvantage of having to deal with complexities of regular expressions.
+2) The version can be hard-coded into the `pyproject.toml` file -- and the build system can copy it into other locations it may be required.
 
-#.  Use an external build tool that either manages updating both locations, or
-    offers an API that both locations can use.
+3) The version string can be hard-coded into the source code -- either in a special purpose file, such as `_version.txt`, or as a attribute in the `__init__.py`, and the build system can extract it at build time.
 
-    Few tools you could use, in no particular order, and not necessarily complete:
-    `bumpversion <https://pypi.python.org/pypi/bumpversion>`_,
-    `changes <https://pypi.python.org/pypi/changes>`_, `zest.releaser <https://pypi.python.org/pypi/zest.releaser>`_.
+If the version string is not in the source, it can be extracted at runtime with code in `__init__.py`, such as::
+
+    import importlib.metadata
+    __version__ = importlib.metadata.version('the_distribution_name')
 
 
-#.  Set the value to a ``__version__`` global variable in a dedicated module in
-    your project (e.g. ``version.py``), then have ``setup.py`` read and ``exec`` the
-    value into a variable.
+Consult your build system documentation for how to implement your preferred method.
 
-    Using ``execfile``:
-
-    ::
-
-        execfile('...sample/version.py')
-        # now we have a `__version__` variable
-        # later on we use: __version__
-
-    Using ``exec``:
-
-    ::
-
-        version = {}
-        with open("...sample/version.py") as fp:
-            exec(fp.read(), version)
-        # later on we use: version['__version__']
-
-    Example using this technique: `warehouse <https://github.com/pypa/warehouse/blob/master/warehouse/__about__.py>`_.
-
-#.  Place the value in a simple ``VERSION`` text file and have both ``setup.py``
-    and the project code read it.
-
-    ::
-
-        with open(os.path.join(mypackage_root_dir, 'VERSION')) as version_file:
-            version = version_file.read().strip()
-
-    An advantage with this technique is that it's not specific to Python.  Any
-    tool can read the version.
-
-    .. warning::
-
-        With this approach you must make sure that the ``VERSION`` file is included in
-        all your source and binary distributions.
-
-#.  Set the value in ``setup.py``, and have the project code use the
-    ``pkg_resources`` API.
-
-    ::
-
-        import pkg_resources
-        assert pkg_resources.get_distribution('pip').version == '1.2.0'
-
-    Be aware that the ``pkg_resources`` API only knows about what's in the
-    installation metadata, which is not necessarily the code that's currently
-    imported.
+Put links in to build system docs?
+-- I have no idea which are currently robust and maintained -- do we want to get into seeming endorsing particular tools in this doc?
 
 
-#.  Set the value to ``__version__`` in ``sample/__init__.py`` and import
-    ``sample`` in ``setup.py``.
+* setuptools:
 
-    ::
+* hatch:
 
-        import sample
-        setup(
-            ...
-            version=sample.__version__
-            ...
-        )
+* poetry:
 
-    Although this technique is common, beware that it will fail if
-    ``sample/__init__.py`` imports packages from ``install_requires``
-    dependencies, which will very likely not be installed yet when ``setup.py``
-    is run.
+* PyBuilder:
+
+* Others?
+

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -12,9 +12,9 @@ One of the challenges in building packages is that the version string can be req
 * It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
    - That will assure that it is properly assigned in the distribution file name, and in the installed package metadata.
 
-* A package may set a top level ``__version__`` attribute to provide runtime access to the version of the imported package. If this is done, the value of ``__version__`` attribute and that used by the build system to set the distribution's version should be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
+* A package may set a top level ``__version__`` attribute to provide runtime access to the version of the imported package. If this is done, the value of ``__version__`` attribute and that used by the build system to set the distribution's version should be kept in sync in :ref:`the build systems's recommended way <Build system version handling>`.
 
-In the cases where a package does not set a top level ``__version__`` attribute, the version may still be accessible using ``importlib.metadata.version("distribution_name")``.
+In any case, The installed distribution version should be accessible using ``importlib.metadata.version("distribution_name")``.
 
 To ensure that version numbers do not get out of sync, it is recommended that there is a single source of truth for the version number.
 
@@ -29,10 +29,12 @@ In general, the options are:
 
 Consult your build system's documentation for their recommended method.
 
-.. _how_to_set_version_links:
+.. _Build system version handling:
 
 Build System Version Handling
 -----------------------------
+
+The following are links to some build system's documentation for handling version strings.
 
 * `Flit <https://flit.pypa.io/en/stable/>`_
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -28,7 +28,7 @@ In general, the options are:
 3) The version string can be hard-coded into the source code -- either in a special purpose file, such as ``_version.txt``, or as a attribute in the ``__init__.py``, and the build system can extract it at build time.
 
 
-Consult your build system documentation for how to implement your preferred method.
+Consult your build system's documentation for their recommended method.
 
 .. _how_to_set_version_links:
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -12,8 +12,7 @@ One of the challenges in building packages is that the version string can be req
 * It needs to be specified when building the package (e.g. in :file:``pyproject.toml``)
    - That will assure that it is properly assigned in the distribution file name, and in the installed package.
 
-* A package may, if the maintainers think it useful, to be able to determine the version of the package from Python code without relying on a package manager's metadata, set a top level ``__version__`` attribute.
-The value of ``__version__`` attribute and that passed to the build system can (and should) be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
+* A package may set a top level ``__version__`` attribute to provide runtime access to the version of the installed package. If this is done, the value of ``__version__`` attribute and that used by the build system to set the distribution's version should be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
 
 In the cases where a package does not set a top level ``__version__`` attribute, the version may still be accessible using ``importlib.metadata.version("distribution_name")``.
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -10,12 +10,13 @@ Single-sourcing the Project Version
 One of the challenges in building packages is that the version string can be required in multiple places.
 
 * It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
-   - That will assure that it is properly assigned in the distribution file name, and in teh installed package.
+   - That will assure that it is properly assigned in the distribution file name, and in the installed package.
 
 * Some projects require that there be a version string available as an attribute in the importable module, e.g::
 
     import a_package
     print(a_package.__version__)
+
 * In the metadata of the artifacts for each of the packaging ecosystems    
 
 While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
@@ -36,17 +37,15 @@ If the version string is not in the source, it can be extracted at runtime with 
 
 Consult your build system documentation for how to implement your preferred method.
 
-Put links in to build system docs?
--- I have no idea which are currently robust and maintained -- do we want to get into seeming endorsing particular tools in this doc?
+Here are the common ones:
 
+* `Hatch <https://hatch.pypa.io/1.9/version/>`_
 
-* setuptools:
+* `Setuptools <https://setuptools.pypa.io/en/latest/userguide/distribution.html#specifying-your-project-s-version>`_
 
-* hatch:
+  -  `setuptools_scm <https://setuptools-scm.readthedocs.io/en/latest/>`_
 
-* poetry:
+* `Flit <https://flit.pypa.io/en/stable/>`_
 
-* PyBuilder:
-
-* Others?
+* `PDM <https://pdm-project.org/en/latest/reference/pep621/#__tabbed_1_2>`_
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -15,7 +15,7 @@ One of the challenges in building packages is that the version string can be req
 * A package may, if the maintainers think it useful, to be able to determine the version of the package from Python code without relying on a package manager's metadata, set a top level ``__version__`` attribute.
 The value of ``__version__`` attribute and that passed to the build system can (and should) be kept in sync in :ref:`the build systems's recommended way <how_to_set_version_links>`.
 
-Should a package not set a top level ``__version__`` attribute, the version can still be accessed using ``importlib.metadata.version("distribution_name")``.
+In the cases where a package does not set a top level ``__version__`` attribute, the version may still be accessible using ``importlib.metadata.version("distribution_name")``.
 
 While different projects have different needs, it's important to make sure that there is a single source of truth for the version number.
 

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -9,7 +9,7 @@ Single-sourcing the Project Version
 
 One of the challenges in building packages is that the version string can be required in multiple places.
 
-* It needs to be specified when building the package (e.g. in pyproject.toml)
+* It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
    - That will assure that it is properly assigned in the distribution file name, and in teh installed package.
 
 * Some projects require that there be a version string available as an attribute in the importable module, e.g::

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -12,7 +12,7 @@ One of the challenges in building packages is that the version string can be req
 * It needs to be specified when building the package (e.g. in :file:`pyproject.toml`)
    - That will assure that it is properly assigned in the distribution file name, and in the installed package.
 
-* Some projects require that there be a version string available as an attribute in the importable module, e.g::
+* Some projects prefer that there be a version string available as an attribute in the importable module, e.g::
 
     import a_package
     print(a_package.__version__)

--- a/source/single_source_version.rst
+++ b/source/single_source_version.rst
@@ -5,7 +5,7 @@ Single-sourcing the Project Version
 ===================================
 
 :Page Status: Complete
-:Last Reviewed: 2015-09-08
+:Last Reviewed: 2024-??
 
 One of the challenges in building packages is that the version string can be required in multiple places.
 
@@ -34,13 +34,15 @@ Consult your build system's documentation for their recommended method.
 Build System Version Handling
 ----------------------------
 
-* `Hatch <https://hatch.pypa.io/1.9/version/>`_
+* `Flit <https://flit.pypa.io/en/stable/>`_
+
+* `Hatchling <https://hatch.pypa.io/1.9/version/>`_
+
+* `PDM <https://pdm-project.org/en/latest/reference/pep621/#__tabbed_1_2>`_
 
 * `Setuptools <https://setuptools.pypa.io/en/latest/userguide/distribution.html#specifying-your-project-s-version>`_
 
   -  `setuptools_scm <https://setuptools-scm.readthedocs.io/en/latest/>`_
 
-* `Flit <https://flit.pypa.io/en/stable/>`_
 
-* `PDM <https://pdm-project.org/en/latest/reference/pep621/#__tabbed_1_2>`_
 


### PR DESCRIPTION
Initial comment edited as of Jul 30 2024

This was quick draft I whipped out -- turns out there's interest, 

As per discussion on Discourse, and #1276, here is a single source page that is far simpler, and essentially refers users to their build systems for instructions.

NOTE: There is disagreement about what *should* be done re versioning and a `__version__` attribute. This PR is NOT the place to resolve those disagreements.

Rather, I'm hoping this page can capture the state of the practice without specification of every detail of what should be done.

I am hoping to at least capture what I think is the consensus:

The very short version:
- for a given distribution, the version string(s) should be fully consistent, and be specified in only one place.

Some detailed points:

1) When a distribution is built, it should have proper PEP-conforming version info, which is consistent within that entire distribution.

2) The user, when setting up their distribution build, should specify the version string in *only one place* (or only one way) - and the build system should be responsible for making sure it is consistent everywhere else (e.g. the filenames, the metadata, or attributes.

3) **If** a distribution maintainer wants to put an attribute in the installed importable module it should be consistent with the metadata of the installed package.

4) It's best for the community that an importable version attribute uses a consistent name: `__version__` is a defacto standard for that name.

If you disagree with these points, please make that argument specifically, rather than suggesting edits that don't conform to these points. That is, let's get a consensus for what this doc should say first, and then figure out how to say it.

I think (4) is the perhaps the most controversial -- though I don't understand why. I can't see how it benefits ANYONE for different distributions to use a different name for the version string. Frankly, the only explanation I can think of for why people advocate for other names, is that that way it's harder for anyone to *think* that having a version string is a standard -- and they really don't want having a version string to be a standard.
But I ask that if you feel that way, please make sure that the text is clear that providing a version string is OPTIONAL, rather than arguing against us using the most common name in the text.

Anyway -- my goal with this doc is to capture those points, and not be prescriptive about  what should be done about having or not having a version string in the installed package.

NOTE: the preview doesn't seem to be working -- I get a 404 *maybe* because of the merge conflict? (which I thought I'd wait for something closer to final before worrying about)

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1578.org.readthedocs.build/en/1578/

<!-- readthedocs-preview python-packaging-user-guide end -->