### PR TITLE
If the "build" package does not exist, you will get an error

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -339,7 +339,7 @@ Make sure you have the latest version of PyPA's :ref:`build` installed:
 
 .. tip:: If you have trouble installing these, see the
    :doc:`installing-packages` tutorial. You will get an error if you don't have the build package so install it first .. code-block:: bash pip install build
-   
+
 Now run this command from the same directory where :file:`pyproject.toml` is located:
 
 .. tab:: Unix/macOS


### PR DESCRIPTION
if the build package does not exist, there will be an error such "Not recognized .."

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1582.org.readthedocs.build/en/1582/

<!-- readthedocs-preview python-packaging-user-guide end -->