### PR TITLE
Update referenced RFC specification

### DIFF
--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -269,7 +269,7 @@ meaning is open to interpretation.
 These keys accept an array of tables with 2 keys: ``name`` and
 ``email``. Both values must be strings. The ``name`` value MUST be a
 valid email name (i.e. whatever can be put as a name, before an email,
-in :rfc:`822`) and not contain commas. The ``email`` value MUST be a
+in :rfc:`5322`) and not contain commas. The ``email`` value MUST be a
 valid email address. Both keys are optional, but at least one of the
 keys must be specified in the table.
 


### PR DESCRIPTION
Update the referenced RFC specification:
  - from [obsoleted](https://datatracker.ietf.org/doc/html/rfc822.html) version `822`,
  - through newer [obsoleted](https://datatracker.ietf.org/doc/html/rfc2822) version `2822`,
  - to [current](https://datatracker.ietf.org/doc/html/rfc5322) version `5322`.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1584.org.readthedocs.build/en/1584/

<!-- readthedocs-preview python-packaging-user-guide end -->