### PR TITLE
Add Direct URL security heading

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -31,6 +31,9 @@ Depending on what ``url`` refers to, the second field MUST be one of ``vcs_info`
 local directory). These info fields have a (possibly empty) subdictionary as
 value, with the possible keys defined below.
 
+Security Considerations
+-----------------------
+
 When persisted, ``url`` MUST be stripped of any sensitive authentication information,
 for security reasons.
 


### PR DESCRIPTION
No changes to the spec, just adding a heading to
highlight the notes on avoiding credential leaks.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1585.org.readthedocs.build/en/1585/

<!-- readthedocs-preview python-packaging-user-guide end -->