### PR TITLE
clarify ``Provides-Dist`` example to match warehouse metadata validation

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -725,7 +725,7 @@ This field may be followed by an environment marker after a semicolon.
 Examples::
 
     Provides-Dist: OtherProject
-    Provides-Dist: AnotherProject (3.4)
+    Provides-Dist: AnotherProject==3.4
     Provides-Dist: virtual_package; python_version >= "3.4"
 
 .. _core-metadata-obsoletes-dist:


### PR DESCRIPTION
So I ran into the issue over of the weekend of getting 502s from PyPI on upload of one of my repos. After exhausting everything else I found out that using the format for ``Provides-Dist`` in the spec causes uploads to fail because warehouse uses ``packaging.requirements.Requirement`` to validate wheel METADATA. See https://github.com/pypi/warehouse/issues/16452 It should also be noted that auditwheel and twine did not flag any problems with the wheel format and the only point of failure was a HTTP 502 from warehouse. It seemed in my judgement that editing the spec to keep people from running into this is a good idea. I defer to the PyPA team, though, it may be that warehouse needs changed instead as I am not privy to the original intent of the spec writers.

Thanks,
Eden Ross Duff

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1586.org.readthedocs.build/en/1586/

<!-- readthedocs-preview python-packaging-user-guide end -->