### PR TITLE
Update creating-command-line-tools.rst to fix typo

### DIFF
--- a/source/guides/creating-command-line-tools.rst
+++ b/source/guides/creating-command-line-tools.rst
@@ -78,7 +78,7 @@ in :file:`cli.py`:
 
     import typer
 
-    from .hello import greet
+    from .greet import greet
 
 
     app = typer.Typer()


### PR DESCRIPTION
The import statement in `cli.py`, as written, fails. It doesn’t match the name of the file (`greet.py`) that is set up with the greet() function. 

An alternative solution would be to edit the name of `greet.py` to be `hello.py`, which I could also imagine being a useful approach, to avoid potential ambiguity from repeated words in different places. I chose to submit the simpler fix, though.

(By the way, thank you for this amazing guide! It’s so clear and helpful.)

One further thought/question: maybe it would be helpful to say that this can also be installed with pip? I wasn’t sure if I could just use pip and a venv, but didn’t want to add another layer of complexity to my setup, so I tried. And, sure enough, pip and a venv will install this, no problem! I get that you want to present a single, simple path, however, so I can understand just mentioning pipx if that seems like the best choice.