### PR TITLE
Clarified note on [build-system] and [project]

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -24,15 +24,15 @@ three possible TOML tables in this file.
 
    The ``[build-system]`` table should always be present,
    regardless of which build backend you use (``[build-system]`` *defines* the
-   build tool you use). 
+   build tool you use).
 
-   On the other hand, the ``[project]`` table is understood by *most* build 
+   On the other hand, the ``[project]`` table is understood by *most* build
    backends, but some build backends use a different format.
 
-   As of August 2024, Poetry_ is a notable build backend that does not use 
-   the ``[project]`` table, it uses the ``[tool.poetry]`` table instead. 
+   As of August 2024, Poetry_ is a notable build backend that does not use
+   the ``[project]`` table, it uses the ``[tool.poetry]`` table instead.
    Also, the setuptools_ build backend supports both the ``[project]`` table,
-   and the older format in ``setup.cfg`` or ``setup.py``. 
+   and the older format in ``setup.cfg`` or ``setup.py``.
 
    For new projects, use the ``[project]`` table, and keep ``setup.py`` only if
    some programmatic configuration is needed (such as building C extensions),

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -22,19 +22,19 @@ three possible TOML tables in this file.
 
 .. note::
 
-   There is a significant difference between the ``[build-system]`` and
-   ``[project]`` tables. The former should always be present, regardless of
-   which build backend you use (since it *defines* the tool you use). The latter
-   is understood by *most* build backends, but some build backends use a
-   different format.
+   The ``[build-system]`` table should always be present,
+   regardless of which build backend you use (``[build-system]`` *defines* the
+   build tool you use). 
 
-   At the time of writing this (November 2023), Poetry_ is a notable build
-   backend that does not use the ``[project]`` table (it uses the
-   ``[tool.poetry]`` table instead).
+   On the other hand, the ``[project]`` table is understood by *most* build 
+   backends, but some build backends use a different format.
 
+   As of August 2024, Poetry_ is a notable build backend that does not use 
+   the ``[project]`` table, it uses the ``[tool.poetry]`` table instead. 
    Also, the setuptools_ build backend supports both the ``[project]`` table,
-   and the older format in ``setup.cfg`` or ``setup.py``. For new projects, it
-   is recommended to use the ``[project]`` table, and keep ``setup.py`` only if
+   and the older format in ``setup.cfg`` or ``setup.py``. 
+
+   For new projects, use the ``[project]`` table, and keep ``setup.py`` only if
    some programmatic configuration is needed (such as building C extensions),
    but the ``setup.cfg`` and ``setup.py`` formats are still valid. See
    :ref:`setup-py-deprecated`.


### PR DESCRIPTION
Used clearer wording, instead of referring to tables as 'former' and 'latter', and some sentence cleanup.

I was reading the note and just noticed (ha) that it was a bit verbose. I removed some words and replaced them with direct mentions of the table names so it's easier to understand for first time readers.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1593.org.readthedocs.build/en/1593/

<!-- readthedocs-preview python-packaging-user-guide end -->