### PR TITLE
Fixed bad command in `Tutorials -> Packaging Python Projects`

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -451,13 +451,13 @@ and install your package from TestPyPI:
 
     .. code-block:: bash
 
-        python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package-YOUR-USERNAME-HERE
+        python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package
 
 .. tab:: Windows
 
     .. code-block:: bat
 
-        py -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package-YOUR-USERNAME-HERE
+        py -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package
 
 Make sure to specify your username in the package name!
 


### PR DESCRIPTION
The command template currently present in [Installing your newly uploaded package](https://packaging.python.org/en/latest/tutorials/packaging-projects/#installing-your-newly-uploaded-package):
```
python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package-YOUR-USERNAME-HERE
```
Results in the following error:
```
Looking in indexes: https://test.pypi.org/simple/
ERROR: Could not find a version that satisfies the requirement openbambucommands-shitwolfymakes (from versions: none)
ERROR: No matching distribution found for openbambucommands-shitwolfymakes
```

Trying again with the command:
```
python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps openbambucommands
```
Results in a successful installation:
```
Looking in indexes: https://test.pypi.org/simple/
Collecting openbambucommands
  Downloading https://test-files.pythonhosted.org/packages/0f/c8/3530b5a3aa7e1f6cb23e1b83b0b3608d1bcce6a32197dfbd2ba247ef9998/openbambucommands-0.1.0-py3-none-any.whl.metadata (1.2 kB)
Downloading https://test-files.pythonhosted.org/packages/0f/c8/3530b5a3aa7e1f6cb23e1b83b0b3608d1bcce6a32197dfbd2ba247ef9998/openbambucommands-0.1.0-py3-none-any.whl (3.5 kB)
Installing collected packages: openbambucommands
Successfully installed openbambucommands-0.1.0
```

I'm not sure if this is caused by a lack of package name collisions, or something else, but it seems the appropriate command template should be `python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps example-package`. If that is not the case I can add a sentence or two explaining the circumstances under which `-YOUR-USERNAME-HERE` would need to be added.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1604.org.readthedocs.build/en/1604/

<!-- readthedocs-preview python-packaging-user-guide end -->