### PR TITLE
Add dependabot.yml to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       pip:
         patterns:


### PR DESCRIPTION
Add dependabot.yml to update GitHub action and Python package dependencies to date automatically. 
(maybe it also can help with pull requests like #1614 )

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1613.org.readthedocs.build/en/1613/

<!-- readthedocs-preview python-packaging-user-guide end -->