### PR TITLE
Update contribute.rst reference to out of date django documentation version

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -45,7 +45,7 @@ Tutorials are focused on teaching the reader new concepts by accomplishing a
 goal. They are opinionated step-by-step guides. They do not include extraneous
 warnings or information. `example tutorial-style document`_.
 
-.. _example tutorial-style document: https://docs.djangoproject.com/en/1.11/intro/
+.. _example tutorial-style document: https://docs.djangoproject.com/en/dev/intro/
 
 Guides
 ------


### PR DESCRIPTION
Update contribute.rst reference to out of date django documentation version

Point at dev dependency, which should always stay up to date

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1615.org.readthedocs.build/en/1615/

<!-- readthedocs-preview python-packaging-user-guide end -->