### PR TITLE
version-specifiers: add a custom anchor for `Pre-releases` section

### DIFF
--- a/source/specifications/version-specifiers.rst
+++ b/source/specifications/version-specifiers.rst
@@ -237,6 +237,8 @@ release scheme using the year and month of the release::
     ...
 
 
+.. _pre-release-versions:
+
 Pre-releases
 ------------
 


### PR DESCRIPTION
This makes it possible to direct-link to this section from other Sphinx documentation, e.g. Python PEPs.

CC @miketheman 

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1625.org.readthedocs.build/en/1625/

<!-- readthedocs-preview python-packaging-user-guide end -->