### PR TITLE
Change pre-commit.ci `autoupdate_schedule` to `quarterly`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: quarterly
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0


### PR DESCRIPTION
Hi @webknjaz

I’ve addressed your feedback https://github.com/pypa/packaging.python.org/pull/1613#issuecomment-2445568431 in this PR.

Previously pre-commit.ci was seems run weekly, now I changed to quarterly. Let me know if you'd prefer to switch to a monthly schedule instead.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1629.org.readthedocs.build/en/1629/

<!-- readthedocs-preview python-packaging-user-guide end -->