### PR TITLE
Add simple issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Community Guidelines"
+    url: "https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md"
+    about: "Please make sure to follow the PSF Code of Conduct when participating in this repository."
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,3 @@ contact_links:
   - name: "Community Guidelines"
     url: "https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md"
     about: "Please make sure to follow the PSF Code of Conduct when participating in this repository."
-

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -11,6 +11,7 @@ body:
       description: "Please provide a detailed description of your issue."
       placeholder: "Describe your issue here..."
       value: ""
+      required: true
 
   - type: checkboxes
     id: code_of_conduct

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -10,7 +10,6 @@ body:
         **Thanks for taking a minute to file an issue!**
 
         Read the [PSF Code of Conduct][CoC] first.
-        [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
 
         ⚠
         Verify first that your issue is not [already reported on
@@ -19,6 +18,7 @@ body:
         _Please fill out the form below with as many precise
         details as possible._
 
+        [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
         [issue search]: ../search?q=is%3Aissue&type=issues
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -4,22 +4,34 @@ labels: []
 assignees: []
 
 body:
-  - type: textarea
-    id: issue_description
+  - type: markdown
     attributes:
-      label: "Issue Description"
-      description: "Please provide a detailed description of your issue."
-      placeholder: "Describe your issue here..."
-      value: ""
+      value: |
+        **Thanks for taking a minute to file an issue!**
+
+        Read the [PSF Code of Conduct][CoC] first.
+        [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+
+        ⚠
+        Verify first that your issue is not [already reported on
+        GitHub][issue search].
+
+        _Please fill out the form below with as many precise
+        details as possible._
+
+        [issue search]: ../search?q=is%3Aissue&type=issues
+
+  - type: textarea
+    attributes:
+      label: Issue Description
+      description: Please provide a detailed description of your issue.
+      placeholder: Describe your issue here...
+    validations:
       required: true
 
   - type: checkboxes
-    id: code_of_conduct
     attributes:
       label: Code of Conduct
-      description: |
-        **Please read the [PSF Code of Conduct][CoC] first.**
-        [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
       options:
-        - label: "I am aware that participants in this repository must follow the PSF Code of Conduct."
+        - label: I am aware that participants in this repository must follow the PSF Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -23,4 +23,3 @@ body:
       options:
         - label: "I am aware that participants in this repository must follow the PSF Code of Conduct."
           required: true
-

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,25 @@
+name: General Issue
+description: Please fill out the form below to submit an issue.
+labels: []
+assignees: []
+
+body:
+  - type: textarea
+    id: issue_description
+    attributes:
+      label: "Issue Description"
+      description: "Please provide a detailed description of your issue."
+      placeholder: "Describe your issue here..."
+      value: ""
+
+  - type: checkboxes
+    id: code_of_conduct
+    attributes:
+      label: Code of Conduct
+      description: |
+        **Please read the [PSF Code of Conduct][CoC] first.**
+        [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+      options:
+        - label: "I am aware that participants in this repository must follow the PSF Code of Conduct."
+          required: true
+


### PR DESCRIPTION
This is a follow up on a discussion on PyPA discord.
The hope is that having some mandatory fields will reduce the amount of spam or at least confuse a little bit the bots.

I am using the text `I am aware that participants in this repository must follow the PSF Code of Conduct`, instead of `I agree to follow the PSF Code of Conduct`, just to workaround some criticism we received in the past (e.g. https://discuss.python.org/t/what-to-do-with-contributors-who-refuse-code-of-conduct/13287).

Pretty much everything can be changed, this is just a initial draft to get things started.

I haven't been able to double check this renders correctly (so it may have problems). Possibly a maintainer also have access to Github UI to do this.