### PR TITLE
Update the specification with PEP 639

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -147,6 +147,40 @@ Glossary
         multiple individual distributions.
 
 
+    License Classifier
+
+        A PyPI Trove classifier
+        (as :ref:`described <core-metadata-classifier>`
+        in the :term:`Core Metadata` specification)
+        which begins with ``License ::``.
+
+
+    License Expression
+    SPDX Expression
+
+        A string with valid SPDX license expression syntax,
+        including one or more SPDX :term:`License Identifier`\(s),
+        which describes a :term:`Project`'s license(s)
+        and how they inter-relate.
+        Examples:
+        ``GPL-3.0-or-later``,
+        ``MIT AND (Apache-2.0 OR BSD-2-Clause)``
+
+
+    License Identifier
+    SPDX Identifier
+
+        A valid SPDX short-form license identifier,
+        originally specified in :pep:`639`.
+        This includes all valid SPDX identifiers and
+        the custom ``LicenseRef-[idstring]`` strings conforming to the
+        SPDX specification.
+        Examples:
+        ``MIT``,
+        ``GPL-3.0-only``,
+        ``LicenseRef-My-Custom-License``
+
+
     Module
 
         The basic unit of code reusability in Python, existing in one of two
@@ -311,6 +345,23 @@ Glossary
        A file containing a list of :term:`Requirements <Requirement>` that can
        be installed using :ref:`pip`. For more information, see the :ref:`pip`
        docs on :ref:`pip:Requirements Files`.
+
+
+    Root License Directory
+    License Directory
+
+        The directory under which license files are stored in a
+        :term:`Project Source Tree`, :term:`Distribution Archive`
+        or :term:`Installed Project`.
+        For a :term:`Project Source Tree` or
+        :term:`Source Distribution (or "sdist")`, this is the
+        :term:`Project Root Directory`.
+        For a :term:`Built Distribution` or :term:`Installed Project`,
+        this is the :file:`.dist-info/licenses/` directory of
+        the wheel archive or project folder respectively.
+        Also, the root directory that paths
+        recorded in the ``License-File``
+        :term:`Core Metadata Field` are relative to.
 
 
     setup.py

--- a/source/guides/licensing-examples-and-user-scenarios.rst
+++ b/source/guides/licensing-examples-and-user-scenarios.rst
@@ -1,0 +1,356 @@
+.. _licensing-examples-and-user-scenarios:
+
+
+=====================================
+Licensing examples and user scenarios
+=====================================
+
+
+:pep:`639` has specified the way to declare a project's license and paths to
+license files and other legally required information.
+This document aims to provide clear guidance how to migrate from the legacy
+to the standardized way of declaring licenses.
+
+
+Licensing Examples
+==================
+
+.. _licensing-example-basic:
+
+Basic example
+-------------
+
+The Setuptools project itself, as of `version 75.6.0 <setuptools7560_>`__,
+does not use the ``License`` field in its own project source metadata.
+Further, it no longer explicitly specifies ``license_file``/``license_files``
+as it did previously, since Setuptools relies on its own automatic
+inclusion of license-related files matching common patterns,
+such as the :file:`LICENSE` file it uses.
+
+It includes the following license-related metadata in its
+:file:`pyproject.toml`:
+
+.. code-block:: toml
+
+    [project]
+    classifiers = [
+        "License :: OSI Approved :: MIT License"
+    ]
+
+The simplest migration to PEP 639 would consist of using this instead:
+
+.. code-block:: toml
+
+    [project]
+    license = "MIT"
+
+Or, if the project used :file:`setup.cfg`, in its ``[metadata]`` table:
+
+.. code-block:: ini
+
+    [metadata]
+    license = MIT
+
+The output Core Metadata for the distribution packages would then be:
+
+.. code-block:: email
+
+    License-Expression: MIT
+    License-File: LICENSE
+
+The :file:`LICENSE` file would be stored at :file:`/setuptools-{VERSION}/LICENSE`
+in the sdist and :file:`/setuptools-{VERSION}.dist-info/licenses/LICENSE`
+in the wheel, and unpacked from there into the site directory (e.g.
+:file:`site-packages/`) on installation; :file:`/` is the root of the respective archive
+and ``{VERSION}`` the version of the Setuptools release in the Core Metadata.
+
+
+.. _licensing-example-advanced:
+
+Advanced example
+----------------
+
+Suppose Setuptools were to include the licenses of the third-party projects
+that are vendored in the :file:`setuptools/_vendor/` and :file:`pkg_resources/_vendor/`
+directories; specifically:
+
+.. code-block:: text
+
+    packaging==21.2
+    pyparsing==2.2.1
+    ordered-set==3.1.1
+    more_itertools==8.8.0
+
+The license expressions for these projects are:
+
+.. code-block:: text
+
+    packaging: Apache-2.0 OR BSD-2-Clause
+    pyparsing: MIT
+    ordered-set: MIT
+    more_itertools: MIT
+
+A comprehensive license expression covering both Setuptools
+proper and its vendored dependencies would contain these metadata,
+combining all the license expressions into one. Such an expression might be:
+
+.. code-block:: text
+
+    MIT AND (Apache-2.0 OR BSD-2-Clause)
+
+In addition, per the requirements of the licenses, the relevant license files
+must be included in the package. Suppose the :file:`LICENSE` file contains the text
+of the MIT license and the copyrights used by Setuptools, ``pyparsing``,
+``more_itertools`` and ``ordered-set``; and the :file:`LICENSE*` files in the
+:file:`setuptools/_vendor/packaging/` directory contain the Apache 2.0 and
+2-clause BSD license text, and the Packaging copyright statement and
+`license choice notice <packaginglicense_>`__.
+
+Specifically, we assume the license files are located at the following
+paths in the project source tree (relative to the project root and
+:file:`pyproject.toml`):
+
+.. code-block:: text
+
+    LICENSE
+    setuptools/_vendor/packaging/LICENSE
+    setuptools/_vendor/packaging/LICENSE.APACHE
+    setuptools/_vendor/packaging/LICENSE.BSD
+
+Putting it all together, our :file:`pyproject.toml` would be:
+
+.. code-block:: toml
+
+    [project]
+    license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
+    license-files = [
+        "LICENSE*",
+        "setuptools/_vendor/LICENSE*",
+    ]
+
+Or alternatively, the license files can be specified explicitly (paths will be
+interpreted as glob patterns):
+
+.. code-block:: toml
+
+    [project]
+    license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
+    license-files = [
+        "LICENSE",
+        "setuptools/_vendor/LICENSE",
+        "setuptools/_vendor/LICENSE.APACHE",
+        "setuptools/_vendor/LICENSE.BSD",
+    ]
+
+If our project used :file:`setup.cfg`, we could define this in :
+
+.. code-block:: ini
+
+    [metadata]
+    license = MIT AND (Apache-2.0 OR BSD-2-Clause)
+    license_files =
+        LICENSE
+        setuptools/_vendor/packaging/LICENSE
+        setuptools/_vendor/packaging/LICENSE.APACHE
+        setuptools/_vendor/packaging/LICENSE.BSD
+
+With either approach, the output Core Metadata in the distribution
+would be:
+
+.. code-block:: email
+
+    License-Expression: MIT AND (Apache-2.0 OR BSD-2-Clause)
+    License-File: LICENSE
+    License-File: setuptools/_vendor/packaging/LICENSE
+    License-File: setuptools/_vendor/packaging/LICENSE.APACHE
+    License-File: setuptools/_vendor/packaging/LICENSE.BSD
+
+In the resulting sdist, with :file:`/` as the root of the archive and ``{VERSION}``
+the version of the Setuptools release specified in the Core Metadata,
+the license files would be located at the paths:
+
+.. code-block:: text
+
+    /setuptools-{VERSION}/LICENSE
+    /setuptools-{VERSION}/setuptools/_vendor/packaging/LICENSE
+    /setuptools-{VERSION}/setuptools/_vendor/packaging/LICENSE.APACHE
+    /setuptools-{VERSION}/setuptools/_vendor/packaging/LICENSE.BSD
+
+In the built wheel, with :file:`/` being the root of the archive and
+``{VERSION}`` as the previous, the license files would be stored at:
+
+.. code-block:: text
+
+    /setuptools-{VERSION}.dist-info/licenses/LICENSE
+    /setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE
+    /setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE.APACHE
+    /setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE.BSD
+
+Finally, in the installed project, with :file:`site-packages/` being the site dir
+and ``{VERSION}`` as the previous, the license files would be installed to:
+
+.. code-block:: text
+
+    site-packages/setuptools-{VERSION}.dist-info/licenses/LICENSE
+    site-packages/setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE
+    site-packages/setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE.APACHE
+    site-packages/setuptools-{VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE.BSD
+
+
+Expression examples
+'''''''''''''''''''
+
+Some additional examples of valid ``License-Expression`` values:
+
+.. code-block:: email
+
+    License-Expression: MIT
+    License-Expression: BSD-3-Clause
+    License-Expression: MIT AND (Apache-2.0 OR BSD-2-Clause)
+    License-Expression: MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
+    License-Expression: GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
+    License-Expression: LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
+    License-Expression: LicenseRef-Proprietary
+    License-Expression: LicenseRef-Custom-License
+
+
+User Scenarios
+==============
+
+The following covers the range of common use cases from a user perspective,
+providing guidance for each. Do note that the following
+should **not** be considered legal advice, and readers should consult a
+licensed legal practitioner in their jurisdiction if they are unsure about
+the specifics for their situation.
+
+
+I have a private package that won't be distributed
+--------------------------------------------------
+
+If your package isn't shared publicly, i.e. outside your company,
+organization or household, it *usually* isn't strictly necessary to include
+a formal license, so you wouldn't necessarily have to do anything extra here.
+
+However, it is still a good idea to include ``LicenseRef-Proprietary``
+as a license expression in your package configuration, and/or a
+copyright statement and any legal notices in a :file:`LICENSE.txt` file
+in the root of your project directory, which will be automatically
+included by packaging tools.
+
+
+I just want to share my own work without legal restrictions
+-----------------------------------------------------------
+
+While you aren't required to include a license, if you don't, no one has
+`any permission to download, use or improve your work <dontchoosealicense_>`__,
+so that's probably the *opposite* of what you actually want.
+The `MIT license <chooseamitlicense_>`__ is a great choice instead, as it's simple,
+widely used and allows anyone to do whatever they want with your work
+(other than sue you, which you probably also don't want).
+
+To apply it, just paste `the text <chooseamitlicense_>`__ into a file named
+:file:`LICENSE.txt` at the root of your repo, and add the year and your name to
+the copyright line. Then, just add ``license = "MIT"`` under
+``[project]`` in your :file:`pyproject.toml` if your packaging tool supports it,
+or in its config file/section. You're done!
+
+
+I want to distribute my project under a specific license
+--------------------------------------------------------
+
+To use a particular license, simply paste its text into a :file:`LICENSE.txt`
+file at the root of your repo, if you don't have it in a file starting with
+:file:`LICENSE` or :file:`COPYING` already, and add
+``license = "LICENSE-ID"`` under ``[project]`` in your
+:file:`pyproject.toml` if your packaging tool supports it, or else in its
+config file. You can find the ``LICENSE-ID``
+and copyable license text on sites like
+`ChooseALicense <choosealicenselist_>`__ or `SPDX <spdxlist_>`__.
+
+Many popular code hosts, project templates and packaging tools can add the
+license file for you, and may support the expression as well in the future.
+
+
+I maintain an existing package that's already licensed
+------------------------------------------------------
+
+If you already have license files and metadata in your project, you
+should only need to make a couple of tweaks to take advantage of the new
+functionality.
+
+In your project config file, enter your license expression under
+``license`` (``[project]`` table in :file:`pyproject.toml`),
+or the equivalent for your packaging tool,
+and make sure to remove any legacy ``license`` table subkeys or
+``License ::`` classifiers. Your existing ``license`` value may already
+be valid as one (e.g. ``MIT``, ``Apache-2.0 OR BSD-2-Clause``, etc);
+otherwise, check the `SPDX license list <spdxlist_>`__ for the identifier
+that matches the license used in your project.
+
+Make sure to list your license files under ``license-files``
+under ``[project]`` in :file:`pyproject.toml`
+or else in your tool's configuration file.
+
+See the :ref:`licensing-example-basic` for a simple but complete real-world demo
+of how this works in practice.
+See also the best-effort guidance on how to translate license classifiers
+into license expression provided by the :pep:`639` authors:
+`Mapping License Classifiers to SPDX Identifiers <mappingclassifierstospdx_>`__.
+Packaging tools may support automatically converting legacy licensing
+metadata; check your tool's documentation for more information.
+
+
+My package includes other code under different licenses
+-------------------------------------------------------
+
+If your project includes code from others covered by different licenses,
+such as vendored dependencies or files copied from other open source
+software, you can construct a license expression
+to describe the licenses involved and the relationship
+between them.
+
+In short, ``License-1 AND License-2`` mean that *both* licenses apply
+to your project, or parts of it (for example, you included a file
+under another license), and ``License-1 OR License-2`` means that
+*either* of the licenses can be used, at the user's option (for example,
+you want to allow users a choice of multiple licenses). You can use
+parenthesis (``()``) for grouping to form expressions that cover even the most
+complex situations.
+
+In your project config file, enter your license expression under
+``license`` (``[project]`` table of :file:`pyproject.toml`),
+or the equivalent for your packaging tool,
+and make sure to remove any legacy ``license`` table subkeys
+or ``License ::`` classifiers.
+
+Also, make sure you add the full license text of all the licenses as files
+somewhere in your project repository. List the
+relative path or glob patterns to each of them under ``license-files``
+under ``[project]`` in :file:`pyproject.toml`
+(if your tool supports it), or else in your tool's configuration file.
+
+As an example, if your project was licensed MIT but incorporated
+a vendored dependency (say, ``packaging``) that was licensed under
+either Apache 2.0 or the 2-clause BSD, your license expression would
+be ``MIT AND (Apache-2.0 OR BSD-2-Clause)``. You might have a
+:file:`LICENSE.txt` in your repo root, and a :file:`LICENSE-APACHE.txt` and
+:file:`LICENSE-BSD.txt` in the :file:`_vendor/` subdirectory, so to include
+all of them, you'd specify ``["LICENSE.txt", "_vendor/packaging/LICENSE*"]``
+as glob patterns, or
+``["LICENSE.txt", "_vendor/LICENSE-APACHE.txt", "_vendor/LICENSE-BSD.txt"]``
+as literal file paths.
+
+See a fully worked out :ref:`licensing-example-advanced` for an end-to-end
+application of this to a real-world complex project, with many technical
+details, and consult a `tutorial <spdxtutorial_>`__ for more help and examples
+using SPDX identifiers and expressions.
+
+
+.. _chooseamitlicense: https://choosealicense.com/licenses/mit/
+.. _choosealicenselist: https://choosealicense.com/licenses/
+.. _dontchoosealicense: https://choosealicense.com/no-permission/
+.. _mappingclassifierstospdx: https://peps.python.org/pep-0639/appendix-mapping-classifiers/
+.. _packaginglicense: https://github.com/pypa/packaging/blob/21.2/LICENSE
+.. _setuptools7560: https://github.com/pypa/setuptools/blob/v75.6.0/pyproject.toml
+.. _spdxlist: https://spdx.org/licenses/
+.. _spdxtutorial: https://github.com/david-a-wheeler/spdx-tutorial

--- a/source/guides/section-build-and-publish.rst
+++ b/source/guides/section-build-and-publish.rst
@@ -16,3 +16,4 @@ Building and Publishing
    making-a-pypi-friendly-readme
    publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
    modernize-setup-py-project
+   licensing-examples-and-user-scenarios

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -324,26 +324,59 @@ You can also specify the format explicitly, like this:
 ``license``
 -----------
 
-This can take two forms. You can put your license in a file, typically
-``LICENSE`` or ``LICENSE.txt``, and link that file here:
+This is a valid :term:`SPDX license expression <License Expression>` consisting
+of one or more :term:`license identifiers <License Identifier>`.
+The full license list is available at the
+`SPDX license list page <spdxlicenselist_>`_. The supported list version is
+3.17 or any later compatible one.
 
 .. code-block:: toml
 
     [project]
-    license = {file = "LICENSE"}
+    license = "GPL-3.0-or-later"
+    # or
+    license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
 
-or you can write the name of the license:
-
-.. code-block:: toml
-
-    [project]
-    license = {text = "MIT License"}
-
-If you are using a standard, well-known license, it is not necessary to use this
-field. Instead, you should use one of the :ref:`classifiers` starting with ``License
-::``. (As a general rule, it is a good idea to use a standard, well-known
+As a general rule, it is a good idea to use a standard, well-known
 license, both to avoid confusion and because some organizations avoid software
-whose license is unapproved.)
+whose license is unapproved.
+
+If your project is licensed with a license that doesn't have an existing SPDX
+identifier, you can create a custom one in format ``LicenseRef-[idstring]``.
+The custom identifiers must follow the SPDX specification,
+`clause 10.1 <spdxcustomids_>`_ of the version 2.2 or any later compatible one.
+
+.. code-block:: toml
+
+    [project]
+    license = "LicenseRef-My-Custom-License"
+
+
+``license-files``
+-----------------
+
+This is a list of license files and files containing other legal
+information you want to distribute with your package.
+
+.. code-block:: toml
+
+    [project]
+    license-files = ["LICEN[CS]E*", "vendored/licenses/*.txt", "AUTHORS.md"]
+
+The glob patterns must follow the specification:
+
+- Alphanumeric characters, underscores (``_``), hyphens (``-``) and dots (``.``)
+  will be matched verbatim.
+- Special characters: ``*``, ``?``, ``**`` and character ranges: [] are supported.
+- Path delimiters must be the forward slash character (``/``).
+- Patterns are relative to the directory containing :file:`pyproject.toml`, and
+  thus may not start with a slash character.
+- Parent directory indicators (``..``) must not be used.
+- Each glob must match at least one file.
+
+Literal paths are valid globs.
+Any characters or character sequences not covered by this specification are
+invalid.
 
 
 ``keywords``
@@ -378,9 +411,6 @@ A list of PyPI classifiers that apply to your project. Check the
       # Indicate who your project is intended for
       "Intended Audience :: Developers",
       "Topic :: Software Development :: Build Tools",
-
-      # Pick your license as you wish (see also "license" above)
-      "License :: OSI Approved :: MIT License",
 
       # Specify the Python versions you support here.
       "Programming Language :: Python :: 3",
@@ -498,7 +528,8 @@ A full example
    ]
    description = "Lovely Spam! Wonderful Spam!"
    readme = "README.rst"
-   license = {file = "LICENSE.txt"}
+   license = "MIT"
+   license-files = ["LICEN[CS]E.*"]
    keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
    classifiers = [
      "Development Status :: 4 - Beta",
@@ -545,3 +576,5 @@ A full example
 .. _pytest: https://pytest.org
 .. _pygments: https://pygments.org
 .. _rest: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _spdxcustomids: https://spdx.github.io/spdx-spec/v2.2.2/other-licensing-information-detected/
+.. _spdxlicenselist: https://spdx.org/licenses/

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -182,6 +182,7 @@ its version, e.g. ``1.0.0``, consist of:
    ``purelib`` or ``platlib`` as specified in ``WHEEL``.  ``purelib`` and
    ``platlib`` are usually both ``site-packages``.
 #. ``{distribution}-{version}.dist-info/`` contains metadata.
+#. :file:`{distribution}-{version}.dist-info/licenses/` contains license files.
 #. ``{distribution}-{version}.data/`` contains one subdirectory
    for each non-empty install scheme key not already covered, where
    the subdirectory name is an index into a dictionary of install paths
@@ -248,6 +249,16 @@ The .dist-info directory
    against the file contents.  Apart from RECORD and its signatures,
    installation will fail if any file in the archive is not both
    mentioned and correctly hashed in RECORD.
+
+
+The :file:`.dist-info/licenses/` directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the metadata version is 2.4 or greater and one or more ``License-File``
+fields is specified, the :file:`.dist-info/` directory MUST contain a
+:file:`licenses/` subdirectory, which MUST contain the files listed in the
+``License-File`` fields in the :file:`METADATA` file at their respective paths
+relative to the :file:`licenses/` directory.
 
 
 The .data directory
@@ -427,6 +438,8 @@ History
   regular files (the expected behaviour of consuming tools when encountering
   symlinks or subdirectories in this folder is not formally defined, and hence
   may vary between tools).
+- December 2024: The :file:`.dist-info/licenses/` directory was specified through
+  :pep:`639`.
 
 
 Appendix

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -301,6 +301,9 @@ Build tools:
 If the ``license-files`` key is present and
 is set to a value of an empty array, then tools MUST NOT include any
 license files and MUST NOT raise an error.
+If the ``license-files`` key is not defined, tools can decide how to handle
+license files. For example they can choose not to include any files or use
+their own logic to discover the appropriate files in the distribution.
 
 
 ``authors``/``maintainers``

--- a/source/specifications/recording-installed-packages.rst
+++ b/source/specifications/recording-installed-packages.rst
@@ -66,6 +66,11 @@ The ``METADATA`` file is mandatory.
 All other files may be omitted at the installing tool's discretion.
 Additional installer-specific files may be present.
 
+This :file:`.dist-info/` directory may contain the following directory, described in
+detail below:
+
+* :file:`licenses/`: contains license files.
+
 .. note::
 
    The :ref:`binary-distribution-format` specification describes additional
@@ -144,7 +149,7 @@ Here is an example snippet of a possible ``RECORD`` file::
     __pycache__/black.cpython-38.pyc,,
     __pycache__/blackd.cpython-38.pyc,,
     black-19.10b0.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-    black-19.10b0.dist-info/LICENSE,sha256=nAQo8MO0d5hQz1vZbhGqqK_HLUqG1KNiI9erouWNbgA,1080
+    black-19.10b0.dist-info/licenses/LICENSE,sha256=nAQo8MO0d5hQz1vZbhGqqK_HLUqG1KNiI9erouWNbgA,1080
     black-19.10b0.dist-info/METADATA,sha256=UN40nGoVVTSpvLrTBwNsXgZdZIwoKFSrrDDHP6B7-A0,58841
     black-19.10b0.dist-info/RECORD,,
     black.py,sha256=45IF72OgNfF8WpeNHnxV2QGfbCLubV5Xjl55cI65kYs,140161
@@ -219,6 +224,17 @@ of requirement (i.e. name plus version specifier).
 Its detailed specification is at :ref:`direct-url`.
 
 
+The :file:`licenses/` subdirectory
+==================================
+
+If the metadata version is 2.4 or greater and one or more ``License-File``
+fields is specified, the :file:`.dist-info/` directory MUST contain a :file:`licenses/`
+subdirectory which MUST contain the files listed in the ``License-File`` fields in
+the :file:`METADATA` file at their respective paths relative to the
+:file:`licenses/` directory.
+Any files in this directory MUST be copied from wheels by the install tools.
+
+
 Intentionally preventing changes to installed packages
 ======================================================
 
@@ -259,3 +275,5 @@ History
   for the full definition.
 - September 2020: Various amendments and clarifications were approved through
   :pep:`627`.
+- December 2024: The :file:`.dist-info/licenses/` directory was specified through
+  :pep:`639`.

--- a/source/specifications/source-distribution-format.rst
+++ b/source/specifications/source-distribution-format.rst
@@ -58,9 +58,14 @@ A ``.tar.gz`` source distribution (sdist) contains a single top-level directory
 called ``{name}-{version}`` (e.g. ``foo-1.0``), containing the source files of
 the package. The name and version MUST match the metadata stored in the file.
 This directory must also contain a :file:`pyproject.toml` in the format defined in
-:ref:`pyproject-toml-spec`, and a ``PKG-INFO`` file containing
+:ref:`pyproject-toml-spec`, and a :file:`PKG-INFO` file containing
 metadata in the format described in the :ref:`core-metadata` specification. The
 metadata MUST conform to at least version 2.2 of the metadata specification.
+
+If the metadata version is 2.4 or greater, the source distribution MUST contain
+any license files specified by the ``License-File`` field in the :file:`PKG-INFO`
+at their respective paths relative to the root directory of the sdist
+(containing the :file:`pyproject.toml` and the :file:`PKG-INFO` metadata).
 
 No other content of a sdist is required or defined. Build systems can store
 whatever information they need in the sdist to build the project.
@@ -150,3 +155,5 @@ History
   :pep:`625`.
 * August 2023: Source distribution archive features were standardized through
   :pep:`721`.
+* December 2024: License files inclusion into source distribution was standardized
+  through :pep:`639`.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -213,9 +213,10 @@ following this tutorial.
     requires-python = ">=3.8"
     classifiers = [
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ]
+    license = "MIT"
+    license-files = ["LICEN[CS]E*"]
 
     [project.urls]
     Homepage = "https://github.com/pypa/sampleproject"
@@ -242,11 +243,15 @@ following this tutorial.
   packages until it finds one that has a matching Python version.
 - ``classifiers`` gives the index and :ref:`pip` some additional metadata
   about your package. In this case, the package is only compatible with Python
-  3, is licensed under the MIT license, and is OS-independent. You should
-  always include at least which version(s) of Python your package works on,
-  which license your package is available under, and which operating systems
+  3 and is OS-independent. You should
+  always include at least which version(s) of Python your package works on
+  and which operating systems
   your package will work on. For a complete list of classifiers, see
   https://pypi.org/classifiers/.
+- ``license`` is the :term:`SPDX license expression <License Expression>` of
+  your package.
+- ``license-files`` is the list of glob paths to the license files,
+  relative to the directory where :file:`pyproject.toml` is located.
 - ``urls`` lets you list any number of extra links to show on PyPI.
   Generally this could be to the source, documentation, issue trackers, etc.
 
@@ -305,6 +310,9 @@ MIT license:
 
 Most build backends automatically include license files in packages. See your
 backend's documentation for more details.
+If you include the path to license in the ``license-files`` key of
+:file:`pyproject.toml`, and your build backend supports :pep:`639`,
+the file will be automatically included in the package.
 
 
 Including other files


### PR DESCRIPTION
Changed pages:
- glossary
- pyproject.toml
- sdist spec
- wheel spec
- installation spec

:question: The meaning of the `license` key in pyproject.toml is changed. The fact that table subkeys are deprecated is mentioned. Should I also keep the previous specification details?

:question: Cosmetic "unsureness": keep the changelog at November or antidate it to August when the PEP was provisionally accepted? Since the conditions of acceptance were just recently met, it's high time for these updates.

Resolves #1245.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚:
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/glossary/#term-License-Classifier
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/guides/licensing-examples-and-user-scenarios/
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/guides/writing-pyproject-toml/#license
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/specifications/binary-distribution-format/#the-dist-info-licenses-directory
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/specifications/pyproject-toml/#license
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/specifications/recording-installed-packages/#the-licenses-subdirectory
* https://python-packaging-user-guide--1662.org.readthedocs.build/en/1662/specifications/source-distribution-format/#source-distribution-file-format

<!-- readthedocs-preview python-packaging-user-guide end -->