### PR TITLE
Fix the alphabetic order of terms in Glossary

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -119,15 +119,6 @@ Glossary
         extensions.
 
 
-    Known Good Set (KGS)
-
-        A set of distributions at specified versions which are compatible with
-        each other. Typically a test suite will be run which passes all tests
-        before a specific set of packages is declared a known good set. This
-        term is commonly used by frameworks and toolkits which are comprised of
-        multiple individual distributions.
-
-
     Import Package
 
         A Python module which can contain other modules or recursively, other
@@ -145,6 +136,15 @@ Glossary
         A :term:`Project` that is installed for use with
         a Python interpreter or :term:`Virtual Environment`,
         as described in the specicifcation :ref:`recording-installed-packages`.
+
+
+    Known Good Set (KGS)
+
+        A set of distributions at specified versions which are compatible with
+        each other. Typically a test suite will be run which passes all tests
+        before a specific set of packages is declared a known good set. This
+        term is commonly used by frameworks and toolkits which are comprised of
+        multiple individual distributions.
 
 
     Module


### PR DESCRIPTION
Based on request from https://github.com/pypa/packaging.python.org/pull/1662#discussion_r1850418774

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1664.org.readthedocs.build/en/1664/

<!-- readthedocs-preview python-packaging-user-guide end -->