### PR TITLE
fix: typo in installed project glossary

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -135,7 +135,7 @@ Glossary
 
         A :term:`Project` that is installed for use with
         a Python interpreter or :term:`Virtual Environment`,
-        as described in the specicifcation :ref:`recording-installed-packages`.
+        as described in the specification :ref:`recording-installed-packages`.
 
 
     Known Good Set (KGS)


### PR DESCRIPTION
Just corrected a small typo in the glossary.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1671.org.readthedocs.build/en/1671/

<!-- readthedocs-preview python-packaging-user-guide end -->