### PR TITLE
Clarify that the scripts directory is for files only

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -189,7 +189,7 @@ its version, e.g. ``1.0.0``, consist of:
 #. Python scripts must appear in ``scripts`` and begin with exactly
    ``b'#!python'`` in order to enjoy script wrapper generation and
    ``#!python`` rewriting at install time.  They may have any or no
-   extension.
+   extension.  The ``scripts`` directory may only contain regular files.
 #. ``{distribution}-{version}.dist-info/METADATA`` is Metadata version 1.1
    or greater format metadata.
 #. ``{distribution}-{version}.dist-info/WHEEL`` is metadata about the archive

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -423,6 +423,10 @@ History
 - February 2013: This specification was approved through :pep:`427`.
 - February 2021: The rules on escaping in wheel filenames were revised, to bring
   them into line with what popular tools actually do.
+- December 2024: Clarified that the ``scripts`` folder should only contain
+  regular files (the expected behaviour of consuming tools when encountering
+  symlinks or subdirectories in this folder is not formally defined, and hence
+  may vary between tools).
 
 
 Appendix


### PR DESCRIPTION
Following https://github.com/astral-sh/uv/issues/9656 and the discussion in the pypa discord (https://discord.com/channels/803025117553754132/837243676814999553/1314391181656064040), add a clarifying sentence that the scripts directory in wheels if for files only.

A future specification may want to extend this to "regular files and symlinks", for not it's limited to regular for clear rewrite semantics.

For ecosystem impact, uv errors when the scripts directory contains non-files and #9656 is the first time this error was reported.

CC @charliermarsh @pradyunsg @uranusjr 

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1673.org.readthedocs.build/en/1673/

<!-- readthedocs-preview python-packaging-user-guide end -->