### PR TITLE
Use environment variables instead of contexts

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -78,8 +78,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
         --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
@@ -89,8 +89,8 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI


### PR DESCRIPTION
Closes #1748

Updates the "Signing the distribution packages" section to use environment variables rather than GitHub Actions context variables. No additional setting of environment variables are needed - these are all set/available already.

I've got a repo where we're using trusted publishing, although it's a slight variation on this, but hopefully it's an example that the environment variables work just fine:

https://github.com/developersociety/django-findreplace/blob/7fcf87397590b984dacaca58719f2d8b737d4f77/.github/workflows/publish.yml#L81
https://github.com/developersociety/django-findreplace/actions/runs/12457101550

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1765.org.readthedocs.build/en/1765/

<!-- readthedocs-preview python-packaging-user-guide end -->