### PR TITLE
Correct typo in docs for `[project.scripts]`

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -236,7 +236,7 @@ To install a command as part of your package, declare it in the
 
 In this example, after installing your project, a ``spam-cli`` command
 will be available. Executing this command will do the equivalent of
-``from spam import main_cli; exit(main_cli())``.
+``import sys; from spam import main_cli; sys.exit(main_cli())``.
 
 On Windows, scripts packaged this way need a terminal, so if you launch
 them from within a graphical application, they will make a terminal pop

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -236,7 +236,7 @@ To install a command as part of your package, declare it in the
 
 In this example, after installing your project, a ``spam-cli`` command
 will be available. Executing this command will do the equivalent of
-``from spam import main_cli; main_cli()``.
+``from spam import main_cli; exit(main_cli())``.
 
 On Windows, scripts packaged this way need a terminal, so if you launch
 them from within a graphical application, they will make a terminal pop


### PR DESCRIPTION
There is a slight (but important) discrepancy between the docs and the actual behavior.

As observed here in this generated script:
```toml
[project.scripts]
     build_autograder = "autograder_cli.build_autograder:tool"
```

```python
#!/usr/local/bin/python3
#-*- coding: utf-8 -*-
import re
import sys
from autograder_cli.build_autograder import tool
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(tool())
```

We see that the return value from the tool is used as the exit code.

I had my code setup to return `True` in the case of a success and `False` in the case of a failure, thinking that the generated code would simply discard that return value.

As such, adding this one line will make it clear what the function should be returning.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1770.org.readthedocs.build/en/1770/

<!-- readthedocs-preview python-packaging-user-guide end -->