### PR TITLE
Fix link with missing anchor tag

### DIFF
--- a/source/guides/installing-scientific-packages.rst
+++ b/source/guides/installing-scientific-packages.rst
@@ -89,7 +89,7 @@ SciPy distributions
 -------------------
 
 The SciPy site lists `several distributions
-<https://scipy.org/install/#distributions>`_
+<https://scipy.org/install/>`_
 that provide the full SciPy stack to
 end users in an easy to use and update format.
 


### PR DESCRIPTION
This page has changed significantly, linking to the entire page probably makes more sense instead now.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1773.org.readthedocs.build/en/1773/

<!-- readthedocs-preview python-packaging-user-guide end -->