### PR TITLE
Minor fix to a missing in the inline script metadata doc.

### DIFF
--- a/source/specifications/inline-script-metadata.rst
+++ b/source/specifications/inline-script-metadata.rst
@@ -79,7 +79,7 @@ script metadata (dependency data and tool configuration).
 This document MAY include the top-level fields ``dependencies`` and ``requires-python``,
 and MAY optionally include a ``[tool]`` table.
 
-The ``[tool]`` MAY be used by any tool, script runner or otherwise, to configure
+The ``[tool]`` table MAY be used by any tool, script runner or otherwise, to configure
 behavior. It has the same semantics as the :ref:`[tool] table in pyproject.toml
 <pyproject-tool-table>`.
 


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1777.org.readthedocs.build/en/1777/

<!-- readthedocs-preview python-packaging-user-guide end -->