### PR TITLE
Add labels to source-distribution-format.rst for cross-referencing

### DIFF
--- a/source/specifications/source-distribution-format.rst
+++ b/source/specifications/source-distribution-format.rst
@@ -20,6 +20,8 @@ specification.
 
 Source distributions are also known as *sdists* for short.
 
+.. _source-distribution-format-source-tree:
+
 Source trees
 ============
 
@@ -29,6 +31,8 @@ can be use to build a source distribution from the contained files and
 directories. :pep:`517` and :pep:`518` specify what is required to meet the
 definition of what :file:`pyproject.toml` must contain for something to be
 deemed a source tree.
+
+.. _source-distribution-format-sdist:
 
 Source distribution file name
 =============================


### PR DESCRIPTION
Specifically cover source trees and sdist as files.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1784.org.readthedocs.build/en/1784/

<!-- readthedocs-preview python-packaging-user-guide end -->