### PR TITLE
Add subdirectory to Direct URL schema

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -239,7 +239,7 @@ The following JSON Schema can be used to validate the contents of ``direct_url.j
 .. code-block::
 
      {
-       "$schema": "https://json-schema.org/draft/2019-09/schema",
+       "$schema": "https://json-schema.org/draft/2020-12/schema",
        "title": "Direct URL Data",
        "description": "Data structure that can represent URLs to python projects and distribution artifacts such as VCS source trees, local source trees, source distributions and wheels.",
        "definitions": {

--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -252,6 +252,9 @@ The following JSON Schema can be used to validate the contents of ``direct_url.j
            "properties": {
              "editable": {
                "type": ["boolean", "null"]
+             },
+             "subdirectory": {
+               "type": "string"
              }
            }
          },
@@ -274,6 +277,9 @@ The following JSON Schema can be used to validate the contents of ``direct_url.j
                "type": "string"
              },
              "resolved_revision": {
+               "type": "string"
+             },
+             "subdirectory": {
                "type": "string"
              }
            },


### PR DESCRIPTION
The Direct URL JSON schema was missing an entry for `subdirectory` as described in the text.

I've also updated the schema to the 2020-12 draft, which removed some false positives about the schema in my URL.