### PR TITLE
Add archives in Git to Direct URL schema

### DIFF
--- a/source/specifications/direct-url-data-structure.rst
+++ b/source/specifications/direct-url-data-structure.rst
@@ -133,6 +133,16 @@ A top-level ``subdirectory`` field MAY be present containing a directory path,
 relative to the root of the VCS repository, source archive or local directory,
 to specify where ``pyproject.toml`` or ``setup.py`` is located.
 
+.. _direct-url-data-structure-archives-in-git:
+
+Archives in Version Control
+---------------------------
+
+A top-level ``file`` field MAY be present for VCS repositories, containing the
+location of an archive relative to the root of a VCS repository. The filename
+of the path must be a valid distribution name. This key is mutually exclusive
+with ``subdirectory``. Note that ``file`` has no PEP 508 equivalent.
+
 .. _direct-url-data-structure-registered-vcs:
 
 Registered VCS
@@ -274,6 +284,9 @@ The following JSON Schema can be used to validate the contents of ``direct_url.j
                "type": "string"
              },
              "resolved_revision": {
+               "type": "string"
+             },
+             "file": {
                "type": "string"
              }
            },


### PR DESCRIPTION
Many packaging tools, such as pdm, hatch and uv, extend over PEP 621 allow relative paths in their pyproject.toml ([pdm](https://pdm-project.org/en/latest/reference/pep621/#relative-paths), [hatch](https://hatch.pypa.io/1.3/config/dependency/#local), [uv](https://docs.astral.sh/uv/concepts/projects/dependencies/#path)). This means you can have a dependency on a git repository, and the package in that git repository has a dependency on another package in directory or file in that repository.

Currently, `direct_url.json` can only represent subdirectories in a git repository, but not files. This PR tries to fix this asymmetry and make this transitive source representable. It adds a new key `file` to `direct_url.json` that contains the relative path to a source distribution or a wheel. It is mutually exclusive with `subdirectory`, which does the same except pointing to a directory instead of a file.

Unlike other entries in `direct_url.json`, this can not be translated back to PEP 518 lacking both archive-in-git and relative path support in PEP 518. It is needed to correctly represent the installation for tools that do support relative paths in dependencies.

The name of the key is up for bikeshedding (as is other terminology that we want to align to existing usage).

CC @ofek (hatch), @frostming (pdm), @radoering (poetry) in hopes this is relevant for you too