### PR TITLE
Add sphinx-lint session to noxfile

### DIFF
--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -82,6 +82,6 @@ jobs:
 
     - name: Lint translation file
       if: always()
-      run: sphinx-lint locales/${LANGUAGE}/LC_MESSAGES/messages.po
+      run: nox -s sphinx_lint -- locales/${{ matrix.language }}/LC_MESSAGES/messages.po
       env:
         LANGUAGE: ${{ matrix.language }}

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -82,6 +82,6 @@ jobs:
 
     - name: Lint translation file
       if: always()
-      run: nox -s sphinx_lint -- locales/${{ matrix.language }}/LC_MESSAGES/messages.po
+      run: nox -s sphinx_lint -- locales/${LANGUAGE}/LC_MESSAGES/messages.po
       env:
         LANGUAGE: ${{ matrix.language }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         noxenv:
         - build
+        - sphinx_lint
         continue-on-error:
         - false
         include:

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,5 +114,5 @@ def sphinx_lint(session):
     accepting another path as positional argument.
     """
     session.install("sphinx-lint==1.0.0")
-    target = session.posargs if len(session.posargs) >= 1 else ["source"]
+    target = session.posargs or ["source"]
     session.run("sphinx-lint", *target)

--- a/noxfile.py
+++ b/noxfile.py
@@ -115,7 +115,4 @@ def sphinx_lint(session):
     """
     session.install("sphinx-lint==1.0.0")
     target = session.posargs if len(session.posargs) >= 1 else ["source"]
-    session.run(
-        "sphinx-lint",
-        *target
-    )
+    session.run("sphinx-lint", *target)

--- a/noxfile.py
+++ b/noxfile.py
@@ -105,3 +105,17 @@ def checkqa(session):
         "--all-files",
         "--show-diff-on-failure",
     )
+
+
+@nox.session()
+def sphinx_lint(session):
+    """
+    Check for reST format issues in source rst files,
+    accepting another path as positional argument.
+    """
+    session.install("sphinx-lint==1.0.0")
+    target = session.posargs if len(session.posargs) >= 1 else ["source"]
+    session.run(
+        "sphinx-lint",
+        *target
+    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,6 +113,6 @@ def sphinx_lint(session):
     Check for reST format issues in source rst files,
     accepting another path as positional argument.
     """
-    session.install("sphinx-lint==1.0.0")
+    session.install("sphinx-lint==1.0.2")
     target = session.posargs or ["source"]
     session.run("sphinx-lint", *target)

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -290,7 +290,7 @@ Glossary
         <https://github.com/pypa>`_, and discuss issues on the
         `distutils-sig mailing list
         <https://mail.python.org/mailman3/lists/distutils-sig.python.org/>`_
-	and `the Python Discourse forum <https://discuss.python.org/c/packaging>`__.
+        and `the Python Discourse forum <https://discuss.python.org/c/packaging>`__.
 
 
     Python Package Index (PyPI)

--- a/source/guides/creating-command-line-tools.rst
+++ b/source/guides/creating-command-line-tools.rst
@@ -91,9 +91,9 @@ so initialize the command-line interface here:
 
 .. code-block:: python
 
-	if __name__ == "__main__":
-	    from greetings.cli import app
-	    app()
+    if __name__ == "__main__":
+        from greetings.cli import app
+        app()
 
 .. note::
 
@@ -112,8 +112,8 @@ For the project to be recognised as a command-line tool, additionally a ``consol
 
 .. code-block:: toml
 
-	[project.scripts]
-	greet = "greetings.cli:app"
+    [project.scripts]
+    greet = "greetings.cli:app"
 
 Now, the project's source tree is ready to be transformed into a :term:`distribution package <Distribution Package>`,
 which makes it installable.
@@ -134,14 +134,14 @@ Let's test it:
 
 .. code-block:: console
 
-	$ greet
-	Greetings, friend!
-	$ greet --doctor Brennan
-	Greetings, Dr. Brennan!
-	$ greet --title Ms. Parks
-	Greetings, Ms. Parks!
-	$ greet --title Mr.
-	Greetings, Mr. mr!
+    $ greet
+    Greetings, friend!
+    $ greet --doctor Brennan
+    Greetings, Dr. Brennan!
+    $ greet --title Ms. Parks
+    Greetings, Ms. Parks!
+    $ greet --title Mr.
+    Greetings, Mr. mr!
 
 Since this example uses ``typer``, you could now also get an overview of the program's usage by calling it with
 the ``--help`` option, or configure completions via the ``--install-completion`` option.
@@ -151,7 +151,7 @@ To just run the program without installing it permanently, use ``pipx run``, whi
 
 .. code-block:: console
 
-	$ pipx run --spec . greet --doctor
+    $ pipx run --spec . greet --doctor
 
 This syntax is a bit impractical, however; as the name of the entry point we defined above does not match the package name,
 we need to state explicitly which executable script to run (even though there is only one in existence).

--- a/source/specifications/glob-patterns.rst
+++ b/source/specifications/glob-patterns.rst
@@ -15,7 +15,7 @@ Valid glob patterns
 For PyPA purposes, a *valid glob pattern* MUST be a string matched against
 filesystem entries as specified below:
 
-- Alphanumeric characters, spaces (`` ``), underscores (``_``), hyphens (``-``),
+- Alphanumeric characters, spaces (:literal:`\ `), underscores (``_``), hyphens (``-``),
   and dots (``.``) MUST be matched verbatim.
 
 - Special glob characters: ``*``, ``?``, ``**`` and character ranges: ``[]``


### PR DESCRIPTION
See #1166

This runs sphinx-lint in the docs together with HTML build and linkcheck. It accepts one or more path as positional argument, so e.g. one may specify the path of a translation file instead of using the source reST files from "source" directory.

I was going to add sphinx-lint package to requirements.txt and pip-install from that file, but this unnecessarily added dependencies and increased install time.

Running without posargs:

```
$ python -m nox -s sphinx_lint
nox > Running session sphinx_lint
nox > Creating virtual environment (virtualenv) using python in .nox/sphinx_lint
nox > python -m pip install sphinx-lint
nox > sphinx-lint source
source/glossary.rst:294: OMG TABS!!!1 (horipython -m nox -s sphinx_lintzontal-tab)
source/guides/creating-command-line-tools.rst:105: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:106: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:107: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:126: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:127: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:148: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:149: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:150: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:151: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:152: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:153: OMG TABS!!!1 (horizontal-tab)
source/guides/creating-command-line-tools.rst:163: OMG TABS!!!1 (horizontal-tab)
nox > Command sphinx-lint source failed with exit code 1
nox > Session sphinx_lint failed.
```

Running with a posargs as the filepath "messages.po", the Brazilian Portuguese translation obtained from `translation/source` branch:

```
$ python -m nox -s sphinx_lint -- messages.po 
nox > Running session sphinx_lint
nox > Creating virtual environment (virtualenv) using python in .nox/sphinx_lint
nox > python -m pip install sphinx-lint==1.0.0
nox > sphinx-lint messages.po
No problems found.
nox > Session sphinx_lint was successful.
```

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1800.org.readthedocs.build/en/1800/

<!-- readthedocs-preview python-packaging-user-guide end -->