### PR TITLE
Document iOS, Android and macOS platform tag schemes.

### DIFF
--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -227,7 +227,7 @@ Android's release documentation contains the `full list of Android versions and
 their corresponding API levels
 <https://developer.android.com/tools/releases/platforms>`__.
 
-There are 4 `supported ABIs <https://developer.android.com/ndk/guides/abis>`__. 
+There are 4 `supported ABIs <https://developer.android.com/ndk/guides/abis>`__.
 Normalized according to the rules above, they are:
 
 * ``armeabi_v7a``

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -207,7 +207,9 @@ For example, specifying an architecture of ``universal2`` indicates that
 binaries support *both* x86_64 *and* arm64.
 
 The minimum supported macOS version may also be constrained by architecture. For
-example, macOS 11 (Big Sur) was the first release to support arm64.
+example, macOS 11 (Big Sur) was the first release to support arm64. These
+additional constraints are enforced transparently by the macOS compilation
+toolchain when building a ``universal2`` binary.
 
 .. _android:
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -217,10 +217,10 @@ the following list that describes the set of supported architectures:
 ``arch``       Architectures supported
 ============== ========================================
 ``universal2`` ``arm64``, ``x86_64``
-``universal``  ``ppc64``, ``i386``, ``x86_64``
+``universal``  ``i386``, ``ppc``, ``ppc64``, ``x86_64``
 ``intel``      ``i386``, ``x86_64``
-``fat``        ``ppc``, ``ppc64``, ``i386``, ``x86_64``
-``fat32``      ``ppc``, ``i386``
+``fat``        ``i386``, ``ppc``
+``fat3``       ``i386``, ``ppc``, ``x86_64``
 ``fat64``      ``ppc64``, ``x86_64``
 ============== ========================================
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -227,6 +227,12 @@ Android's release documentation contains the `full list of Android versions and
 their corresponding SDK versions
 <https://developer.android.com/tools/releases/platforms>`__.
 
+There are 4 supported architectures:
+* ``armeabi_v7a``
+* ``arm64_v8a``
+* ``x86``
+* ``x86_64``
+
 By default, Python 3.13 is compiled using SDK 24 (i.e, Android 7); Python 3.14
 uses SDK 27 (i.e, Android 8.1).
 
@@ -245,6 +251,9 @@ The iOS platform has two SDKs: ``iphoneos`` for physical devices; and
 but are incompatible at the binary level, even if they are running on the same
 architecture. Code compiled for an arm64 simulator will not run on an arm64
 device.
+
+The ``iphonesimulator`` SDK supports 2 architectures: ``arm64`` and ``x86_64``.
+The ``iphoneos`` SDK only supports the ``arm64`` architecture.
 
 By default, Python is compiled with a minimum iOS compatibility version of 13.0.
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -109,8 +109,8 @@ subset of Linux platforms, and allows building wheels tagged with the
 ``manylinux`` platform tag which can be used across most common Linux
 distributions.
 
-The current standard is the future-proof ``manylinux_x_y`` standard. It defines
-tags of the form ``manylinux_x_y_arch``, where ``x`` and ``y`` are glibc major
+The current standard is the future-proof ``manylinux_<x>_<y>`` standard. It defines
+tags of the form ``manylinux_<x>_<y>_<arch>``, where ``x`` and ``y`` are glibc major
 and minor versions supported (e.g. ``manylinux_2_24_xxx`` should work on any
 distro using glibc 2.24+), and ``arch`` is the architecture, matching the value
 of :py:func:`sysconfig.get_platform()` on the system as in the "simple" form above.
@@ -151,7 +151,7 @@ auditwheel  ``>=1.0.0``     ``>=2.0.0``        ``>=3.0.0``        ``>=3.3.0`` [#
 
 The ``musllinux`` family of tags is similar to ``manylinux``, but for Linux
 platforms that use the musl_ libc rather than glibc (a prime example being Alpine
-Linux). The schema is ``musllinux_x_y_arch``, supporting musl ``x.y`` and higher
+Linux). The schema is ``musllinux_<x>_<y>_<arch>``, supporting musl ``x.y`` and higher
 on the architecture ``arch``.
 
 The musl version values can be obtained by executing the musl libc shared
@@ -189,6 +189,64 @@ There are currently two possible ways to find the musl library’s location that
 Python interpreter is running on, either with the system ldd_ command, or by
 parsing the ``PT_INTERP`` section’s value from the executable’s ELF_ header.
 
+.. _macos:
+
+macOS
+-----
+
+macOS uses the ``macosx`` family of tags (the ``x`` suffix is a historical
+artefact of Apple's official macOS naming scheme). The schema for compatibility
+tags is ``macosx_<x>_<y>_<arch>``, indicating that the wheel is compatible with
+macOS ``x.y`` or later on the architecture ``arch``. The version number always
+includes a major and minor version, even if Apple's official version numbering
+only refers to the major value. For example, a ``macosx_11_0_arm64`` indicates
+compatibility with macOS 11 or later, on arm64 (i.e., Apple Silicon) hardware.
+
+Recent macOS binaries distributed on Python.org are compiled with a minimum
+macOS compatibility version of 11.0, as macOS 11 (Big Sur) was the first release
+to support the ARM64 Apple Silicon architecture. Python binaries obtained from
+other sources may have a different compatibility version.
+
+macOS also supports the use of a combined, or "fat" architecture specification.
+For example, specifying an architecture of ``universal2`` indicates that
+binaries support *both* x86_64 *and* arm64.
+
+.. _android:
+
+android
+-------
+
+Android uses the schema ``android_<sdk>_<arch>``, indicating compatibility with
+Android SDK ``sdk`` or later, on the architecture ``arch``. Android makes no
+distinction between physical devices and emulated devices.
+
+Note that this tag schema uses the *SDK* version, not the Android OS version
+number. The Android release known publicly as Android 12 (code named "Snow
+Cone") uses SDK 31 or 32, depending on the specific Android version in use.
+Android's release documentation contains the `full list of Android versions and
+their corresponding SDK versions
+<https://developer.android.com/tools/releases/platforms>`__.
+
+By default, Python 3.13 is compiled using SDK 24 (i.e, Android 7); Python 3.14
+uses SDK 27 (i.e, Android 8.1).
+
+.. _ios:
+
+iOS
+---
+
+iOS uses the schema ``ios_<x>_<y>_<arch>_<sdk>``, indicating compatibility with
+iOS ``x.y`` or later, on the ``arch`` architecture, using the ``sdk`` SDK. The
+version number always includes a major and minor version, even if Apple's
+official version numbering only refers to the major value.
+
+The iOS platform has two SDKs: ``iphoneos`` for physical devices; and
+``iphonesimulator`` for simulated devices. These SDKs have the same API surface,
+but are incompatible at the binary level, even if they are running on the same
+architecture. Code compiled for an arm64 simulator will not run on an arm64
+device.
+
+By default, Python is compiled with a minimum iOS compatibility version of 13.0.
 
 Use
 ===
@@ -339,7 +397,8 @@ History
 - November 2019: The ``manylinux_x_y`` perennial tag was approved through
   :pep:`600`.
 - April 2021: The ``musllinux_x_y`` tag was approved through :pep:`656`.
-
+- December 2023: The tags for iOS were approved through :pep:`730`.
+- March 2024: The tags for Android were approved through :pep:`738`.
 
 
 .. _musl: https://musl.libc.org

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -234,9 +234,11 @@ toolchain when building binaries that support multiple architectures.
 Android
 -------
 
-Android uses the schema :file:`android_{api_level}_{abi}`, indicating compatibility
-with the given Android API level or later, on the given ABI. Android makes no
-distinction between physical devices and emulated devices.
+Android uses the schema :file:`android_{apilevel}_{abi}`, indicating
+compatibility with the given Android API level or later, on the given ABI. For
+example, ``android_27_arm64_v8a`` indicates support for API level 27 or later,
+on ``arm64_v8a`` devices. Android makes no distinction between physical devices
+and emulated devices.
 
 The API level should be a positive integer. This is *not* the same thing as
 the user-facing Android version. For example, the release known as Android

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -109,8 +109,8 @@ subset of Linux platforms, and allows building wheels tagged with the
 ``manylinux`` platform tag which can be used across most common Linux
 distributions.
 
-The current standard is the future-proof ``manylinux_<x>_<y>`` standard. It defines
-tags of the form ``manylinux_<x>_<y>_<arch>``, where ``x`` and ``y`` are glibc major
+The current standard is the future-proof :file:`manylinux_{x}_{y}` standard. It defines
+tags of the form :file:`manylinux_{x}_{y}_{arch}`, where ``x`` and ``y`` are glibc major
 and minor versions supported (e.g. ``manylinux_2_24_xxx`` should work on any
 distro using glibc 2.24+), and ``arch`` is the architecture, matching the value
 of :py:func:`sysconfig.get_platform()` on the system as in the "simple" form above.
@@ -151,7 +151,7 @@ auditwheel  ``>=1.0.0``     ``>=2.0.0``        ``>=3.0.0``        ``>=3.3.0`` [#
 
 The ``musllinux`` family of tags is similar to ``manylinux``, but for Linux
 platforms that use the musl_ libc rather than glibc (a prime example being Alpine
-Linux). The schema is ``musllinux_<x>_<y>_<arch>``, supporting musl ``x.y`` and higher
+Linux). The schema is :file:`musllinux_{x}_{y}_{arch}``, supporting musl ``x.y`` and higher
 on the architecture ``arch``.
 
 The musl version values can be obtained by executing the musl libc shared
@@ -196,7 +196,7 @@ macOS
 
 macOS uses the ``macosx`` family of tags (the ``x`` suffix is a historical
 artefact of Apple's official macOS naming scheme). The schema for compatibility
-tags is ``macosx_<x>_<y>_<arch>``, indicating that the wheel is compatible with
+tags is :file:`macosx_{x}_{y}_{arch}``, indicating that the wheel is compatible with
 macOS ``x.y`` or later on the architecture ``arch``. The version number always
 includes a major and minor version, even if Apple's official version numbering
 only refers to the major value. For example, a ``macosx_11_0_arm64`` indicates
@@ -243,7 +243,7 @@ uses SDK 27 (i.e, Android 8.1).
 iOS
 ---
 
-iOS uses the schema ``ios_<x>_<y>_<arch>_<sdk>``, indicating compatibility with
+iOS uses the schema :file:`ios_{x}_{y}_{arch}_{sdk}`, indicating compatibility with
 iOS ``x.y`` or later, on the ``arch`` architecture, using the ``sdk`` SDK. The
 version number always includes a major and minor version, even if Apple's
 official version numbering only refers to the major value.

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -216,18 +216,20 @@ toolchain when building a ``universal2`` binary.
 android
 -------
 
-Android uses the schema ``android_<sdk>_<arch>``, indicating compatibility with
-Android SDK ``sdk`` or later, on the architecture ``arch``. Android makes no
+Android uses the schema ``android_<api_level>_<abi>``, indicating compatibility
+with the given Android API level or later, on the given ABI. Android makes no
 distinction between physical devices and emulated devices.
 
-Note that this tag schema uses the *SDK* version, not the Android OS version
-number. The Android release known publicly as Android 12 (code named "Snow
-Cone") uses SDK 31 or 32, depending on the specific Android version in use.
+Note that this tag schema uses the API level, which is a positive integer, not
+the user-facing Android version. The release known as Android 12 (code named "Snow
+Cone") uses API level 31 or 32, depending on the specific Android version in use.
 Android's release documentation contains the `full list of Android versions and
-their corresponding SDK versions
+their corresponding API levels
 <https://developer.android.com/tools/releases/platforms>`__.
 
-There are 4 supported architectures:
+There are 4 `supported ABIs <https://developer.android.com/ndk/guides/abis>`__. 
+Normalized according to the rules above, they are:
+
 * ``armeabi_v7a``
 * ``arm64_v8a``
 * ``x86``

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -196,14 +196,14 @@ macOS
 
 macOS uses the ``macosx`` family of tags (the ``x`` suffix is a historical
 artefact of Apple's official macOS naming scheme). The schema for compatibility
-tags is :file:`macosx_{x}_{y}_{arch}``, indicating that the wheel is compatible
+tags is :file:`macosx_{x}_{y}_{arch}`, indicating that the wheel is compatible
 with macOS ``x.y`` or later on the architecture ``arch``.
 
-The value of ``x`` and ``y`` correspond to the major and minor version number of
+The values of ``x`` and ``y`` correspond to the major and minor version number of
 the macOS release, respectively. They must both be positive integers, with the
 ``x`` value being ``>= 10``. The version number always includes a major *and*
 minor version, even if Apple's official version numbering only refers to
-the major value. For example, a ``macosx_11_0_arm64`` indicates compatibility
+the major value. For example, ``macosx_11_0_arm64`` indicates compatibility
 with macOS 11 or later.
 
 macOS binaries can be compiled for a single architecture, or can include support
@@ -238,8 +238,8 @@ Android uses the schema :file:`android_{api_level}_{abi}`, indicating compatibil
 with the given Android API level or later, on the given ABI. Android makes no
 distinction between physical devices and emulated devices.
 
-The API level should be a positive integer. Note that this value is the API
-level, and *not* the user-facing Android version. The release known as Android
+The API level should be a positive integer. This is *not* the same thing as
+the user-facing Android version. For example, the release known as Android
 12 (code named "Snow Cone") uses API level 31 or 32, depending on the specific
 Android version in use. Android's release documentation contains the `full list
 of Android versions and their corresponding API levels

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -196,20 +196,38 @@ macOS
 
 macOS uses the ``macosx`` family of tags (the ``x`` suffix is a historical
 artefact of Apple's official macOS naming scheme). The schema for compatibility
-tags is :file:`macosx_{x}_{y}_{arch}``, indicating that the wheel is compatible with
-macOS ``x.y`` or later on the architecture ``arch``. The version number always
-includes a major and minor version, even if Apple's official version numbering
-only refers to the major value. For example, a ``macosx_11_0_arm64`` indicates
-compatibility with macOS 11 or later, on arm64 (i.e., Apple Silicon) hardware.
+tags is :file:`macosx_{x}_{y}_{arch}``, indicating that the wheel is compatible
+with macOS ``x.y`` or later on the architecture ``arch``.
 
-macOS also supports the use of a combined, or "fat" architecture specification.
-For example, specifying an architecture of ``universal2`` indicates that
-binaries support *both* x86_64 *and* arm64.
+The value of ``x`` and ``y`` correspond to the major and minor version number of
+the macOS release, respectively. They must both be positive integers, with the
+``x`` value being ``>= 10``. The version number always includes a major *and*
+minor version, even if Apple's official version numbering only refers to
+the major value. For example, a ``macosx_11_0_arm64`` indicates compatibility
+with macOS 11 or later.
+
+macOS binaries can be compiled for a single architecture, or can include support
+for multiple architectures in the same binary (sometimes called "fat" binaries).
+To indicate support for a single architecture, the value of ``arch`` must match
+the value of :py:func:`sysconfig.get_platform()` on the system. To indicate
+support multiple architectures, the ``arch`` tag should be an identifier from
+the following list that describes the set of supported architectures:
+
+============== ========================================
+``arch``       Architectures supported
+============== ========================================
+``universal2`` ``arm64``, ``x86-64``
+``universal``  ``ppc64``, ``i386``, ``x86-64``
+``intel``      ``i386``, ``x86-64``
+``fat``        ``ppc``, ``ppc64``, ``i386``, ``x86-64``
+``fat32``      ``ppc``, ``i386``
+``fat64``      ``ppc64``, ``x86-64``
+============== ========================================
 
 The minimum supported macOS version may also be constrained by architecture. For
 example, macOS 11 (Big Sur) was the first release to support arm64. These
 additional constraints are enforced transparently by the macOS compilation
-toolchain when building a ``universal2`` binary.
+toolchain when building binaries that support multiple architectures.
 
 .. _android:
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -209,19 +209,19 @@ with macOS 11 or later.
 macOS binaries can be compiled for a single architecture, or can include support
 for multiple architectures in the same binary (sometimes called "fat" binaries).
 To indicate support for a single architecture, the value of ``arch`` must match
-the value of :py:func:`sysconfig.get_platform()` on the system. To indicate
+the value of :py:func:`platform.machine()` on the system. To indicate
 support multiple architectures, the ``arch`` tag should be an identifier from
 the following list that describes the set of supported architectures:
 
 ============== ========================================
 ``arch``       Architectures supported
 ============== ========================================
-``universal2`` ``arm64``, ``x86-64``
-``universal``  ``ppc64``, ``i386``, ``x86-64``
-``intel``      ``i386``, ``x86-64``
-``fat``        ``ppc``, ``ppc64``, ``i386``, ``x86-64``
+``universal2`` ``arm64``, ``x86_64``
+``universal``  ``ppc64``, ``i386``, ``x86_64``
+``intel``      ``i386``, ``x86_64``
+``fat``        ``ppc``, ``ppc64``, ``i386``, ``x86_64``
 ``fat32``      ``ppc``, ``i386``
-``fat64``      ``ppc64``, ``x86-64``
+``fat64``      ``ppc64``, ``x86_64``
 ============== ========================================
 
 The minimum supported macOS version may also be constrained by architecture. For
@@ -264,20 +264,31 @@ iOS
 ---
 
 iOS uses the schema :file:`ios_{x}_{y}_{arch}_{sdk}`, indicating compatibility with
-iOS ``x.y`` or later, on the ``arch`` architecture, using the ``sdk`` SDK. The
-version number always includes a major and minor version, even if Apple's
-official version numbering only refers to the major value.
+iOS ``x.y`` or later, on the ``arch`` architecture, using the ``sdk`` SDK.
 
-The iOS platform has two SDKs: ``iphoneos`` for physical devices; and
-``iphonesimulator`` for simulated devices. These SDKs have the same API surface,
-but are incompatible at the binary level, even if they are running on the same
-architecture. Code compiled for an arm64 simulator will not run on an arm64
-device.
+The value of ``x`` and ``y`` correspond to the major and minor version number of
+the iOS release, respectively. They must both be positive integers. The version
+number always includes a major *and* minor version, even if Apple's official
+version numbering only refers to the major value. For example, a
+``ios_13_0_arm64_iphonesimulator`` indicates compatibility with iOS 13 or later.
 
-The ``iphonesimulator`` SDK supports 2 architectures: ``arm64`` and ``x86_64``.
-The ``iphoneos`` SDK only supports the ``arm64`` architecture.
+The value of ``arch`` must match the value of :py:func:`platform.machine()` on
+the system.
 
-By default, Python is compiled with a minimum iOS compatibility version of 13.0.
+The value of ``sdk`` must be either ``iphoneos`` (for physical devices), or
+``iphonesimulator`` (for device simulators). These SDKs have the same API
+surface, but are incompatible at the binary level, even if they are running on
+the same CPU architecture. Code compiled for an arm64 simulator will not run on
+an arm64 device.
+
+The combination of :file:`{arch}_{sdk}` is referred to as the "multiarch". There
+are three possible values for multiarch:
+
+* ``arm64_iphoneos``, for physical iPhone/iPad devices. This includes every
+  iOS device manufactured since ~2015;
+* ``arm64_iphonesimulator``, for simulators running on Apple Silicon macOS
+  hardware; and
+* ``x86_64_iphonesimulator``, for simulators running on x86_64 hardware.
 
 Use
 ===

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -202,14 +202,12 @@ includes a major and minor version, even if Apple's official version numbering
 only refers to the major value. For example, a ``macosx_11_0_arm64`` indicates
 compatibility with macOS 11 or later, on arm64 (i.e., Apple Silicon) hardware.
 
-Recent macOS binaries distributed on Python.org are compiled with a minimum
-macOS compatibility version of 11.0, as macOS 11 (Big Sur) was the first release
-to support the ARM64 Apple Silicon architecture. Python binaries obtained from
-other sources may have a different compatibility version.
-
 macOS also supports the use of a combined, or "fat" architecture specification.
 For example, specifying an architecture of ``universal2`` indicates that
 binaries support *both* x86_64 *and* arm64.
+
+The minimum supported macOS version may also be constrained by architecture. For
+example, macOS 11 (Big Sur) was the first release to support arm64.
 
 .. _android:
 

--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -231,18 +231,18 @@ toolchain when building binaries that support multiple architectures.
 
 .. _android:
 
-android
+Android
 -------
 
-Android uses the schema ``android_<api_level>_<abi>``, indicating compatibility
+Android uses the schema :file:`android_{api_level}_{abi}`, indicating compatibility
 with the given Android API level or later, on the given ABI. Android makes no
 distinction between physical devices and emulated devices.
 
-Note that this tag schema uses the API level, which is a positive integer, not
-the user-facing Android version. The release known as Android 12 (code named "Snow
-Cone") uses API level 31 or 32, depending on the specific Android version in use.
-Android's release documentation contains the `full list of Android versions and
-their corresponding API levels
+The API level should be a positive integer. Note that this value is the API
+level, and *not* the user-facing Android version. The release known as Android
+12 (code named "Snow Cone") uses API level 31 or 32, depending on the specific
+Android version in use. Android's release documentation contains the `full list
+of Android versions and their corresponding API levels
 <https://developer.android.com/tools/releases/platforms>`__.
 
 There are 4 `supported ABIs <https://developer.android.com/ndk/guides/abis>`__.
@@ -253,8 +253,10 @@ Normalized according to the rules above, they are:
 * ``x86``
 * ``x86_64``
 
-By default, Python 3.13 is compiled using SDK 24 (i.e, Android 7); Python 3.14
-uses SDK 27 (i.e, Android 8.1).
+Virtually all current physical devices use one of the ARM architectures. ``x86``
+and ``x86_64`` are supported for use in the emulator. ``x86`` has not been
+supported as a development platform since 2020, and no new emulator images have
+been released since then.
 
 .. _ios:
 


### PR DESCRIPTION
Adds documentation for the iOS PEP 730, Android PEP 738 platform tags. 
Also adds documentation for macOS tags, given they have their own quirks (especially regarding the ``universal`` fat architecture specification).

Fixes #1801 
Fixes #1802


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1804.org.readthedocs.build/en/1804/

<!-- readthedocs-preview python-packaging-user-guide end -->