### PR TITLE
Changed the copyright date to auto update.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -1,6 +1,7 @@
 # -- Project information ---------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import datetime
 import os
 
 # Some options are only enabled for the main packaging.python.org deployment builds
@@ -13,7 +14,8 @@ RTD_CANONICAL_BUILD = (
 
 project = "Python Packaging User Guide"
 
-copyright = "2013–2020, PyPA"
+copyright = "2013–" + str(datetime.datetime.now().year) + ", PyPA"
+
 author = "Python Packaging Authority"
 
 # -- General configuration -------------------------------------------------------------


### PR DESCRIPTION
This is my first PR for pypa, so I'm happy to learn how to do things better. The change simply auto-updates the copyright year to the current year (local to the host).


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1809.org.readthedocs.build/en/1809/

<!-- readthedocs-preview python-packaging-user-guide end -->