### PR TITLE
Add anchor links for license and license-files

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -322,6 +322,8 @@ You can also specify the format explicitly, like this:
    readme = {file = "README.txt", content-type = "text/x-rst"}
 
 
+.. _license:
+
 ``license``
 -----------
 
@@ -385,6 +387,8 @@ field. Instead, you should use one of the :ref:`classifiers` starting with ``Lic
 license, both to avoid confusion and because some organizations avoid software
 whose license is unapproved.)
 
+
+.. _license-files:
 
 ``license-files``
 -----------------


### PR DESCRIPTION
Add anchor links for `license` and `license-files` to make cross-linking from other projects easier.

In particular, I'd like to cross reference https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files from the setuptools docs.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1816.org.readthedocs.build/en/1816/

<!-- readthedocs-preview python-packaging-user-guide end -->