### PR TITLE
Fix duplicate message in Japanese

### DIFF
--- a/locales/ja/LC_MESSAGES/messages.po
+++ b/locales/ja/LC_MESSAGES/messages.po
@@ -15095,27 +15095,6 @@ msgstr ""
 "アンパックされたアーカイブは、 ``distribution-1.0.dist-info/`` と (データ部分"
 "があれば) ``distribution-1.0.data/`` を含んでいます。"
 
-#: ../source/specifications/binary-distribution-format.rst:42
-#, fuzzy
-#| msgid ""
-#| "Move each subtree of ``distribution-1.0.data/`` onto its destination "
-#| "path. Each subdirectory of ``distribution-1.0.data/`` is a key into a "
-#| "dict of destination directories, such as ``distribution-1.0.data/(purelib|"
-#| "platlib|headers|scripts|data)``. The initially supported paths are taken "
-#| "from ``distutils.command.install``."
-msgid ""
-"Move each subtree of ``distribution-1.0.data/`` onto its destination path. "
-"Each subdirectory of ``distribution-1.0.data/`` is a key into a dict of "
-"destination directories, such as ``distribution-1.0.data/(purelib|platlib|"
-"headers|scripts|data)``. These subdirectories are :ref:`installation paths "
-"defined by sysconfig <python:installation_paths>`."
-msgstr ""
-"``distribution-1.0.data/`` の下の全てのサブツリーを、その目的地となるディレク"
-"トリパスに移動します。 ``distribution-1.0.data/(purelib|platlib|headers|"
-"scripts|data)`` のような ``distribution-1.0.data/`` の下のそれぞれのサブディ"
-"レクトリは、目的地となるディレクトリパスの辞書になっています。初期状態でサ"
-"ポートされているパスは ``distutils.command.install`` から取り込まれます。"
-
 #: ../source/specifications/binary-distribution-format.rst:48
 msgid ""
 "If applicable, update scripts starting with ``#!python`` to point to the "


### PR DESCRIPTION
Remove duplicated message, keeping the current one as available in Weblate.

Weblate has an [alert](https://hosted.weblate.org/projects/pypa/packaging-python-org/#alerts) saying that there are two equal messages in Japanese translation. See:

```
/home/weblate/data/vcs/pypa/packaging-python-org/locales/ja/LC_MESSAGES/messages.po:28729: duplicate message definition...
/home/weblate/data/vcs/pypa/packaging-python-org/locales/ja/LC_MESSAGES/messages.po:15112: ...this is the location of the first definition
msgmerge: found 1 fatal error
```

Looking at the translation file, I spotted the offending messages in line [15098](https://github.com/pypa/packaging.python.org/blob/cf3775cebb8f6973c372e7afe3fef02d7f03c6d0/locales/ja/LC_MESSAGES/messages.po#L15098) and in [28728](https://github.com/pypa/packaging.python.org/blob/cf3775cebb8f6973c372e7afe3fef02d7f03c6d0/locales/ja/LC_MESSAGES/messages.po#L28728). The first one is fuzzed up and the second is not.

It looks like the translation in the second string is the one in Weblate ([here](https://hosted.weblate.org/translate/pypa/packaging-python-org/ja/?q=%22Move+each+subtree+of+%60%60distribution-1.0.data%2F%60%60+onto+its+destination+path.+Each+subdirectory+of+%60%60distribution-1.0.data%2F%60%60+is+a+key+into+a+dict+of+destination+directories%2C+such+as+%60%60distribution-1.0.data%2F%28purelib%7Cplatlib%7Cheaders%7Cscripts%7Cdata%29%60%60.+These+subdirectories+are+%3Aref%3A%60installation+paths+defined+by+sysconfig+%3Cpython%3Ainstallation_paths%3E%60.%22&sort_by=-priority%2Cposition&checksum=#history)), so I'm suggesting here to remove the first occurrence.



<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1821.org.readthedocs.build/en/1821/

<!-- readthedocs-preview python-packaging-user-guide end -->