### PR TITLE
Specify SPDX license expression

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -468,8 +468,8 @@ License-Expression
 .. versionadded:: 2.4
 
 Text string that is a valid SPDX
-`license expression <https://peps.python.org/pep-0639/#term-license-expression>`__
-as `defined in PEP 639 <https://peps.python.org/pep-0639/#spdx>`__.
+:term:`license expression <License Expression>`,
+as specified in :doc:`/specifications/license-expression`.
 
 Examples::
 

--- a/source/specifications/license-expression.rst
+++ b/source/specifications/license-expression.rst
@@ -1,0 +1,56 @@
+==================
+License Expression
+==================
+
+:pep:`639` defined a new :ref:`pyproject.toml's license <pyproject-toml-license>`
+value and added a corresponding :ref:`core metadata License-Expression field
+<core-metadata-license-expression>`.
+This specification defines which license expressions are acceptable.
+
+
+Specification
+=============
+
+License can be defined as a text string that is a valid SPDX
+:term:`license expression <License Expression>`,
+as documented in the `SPDX specification <spdxpression_>`__,
+either Version 2.2 or a later compatible version.
+
+A license expression can use the following license identifiers:
+
+- Any SPDX-listed license short-form identifiers that are published in
+  the `SPDX License List <spdxlist_>`__,
+  version 3.17 or any later compatible version.
+
+- The custom ``LicenseRef-[idstring]`` string(s), where ``[idstring]`` is
+  a unique string containing letters, numbers, ``.`` and/or ``-``,
+  to identify licenses that are not included in the SPDX license list.
+  The custom identifiers must follow the SPDX specification,
+  `clause 10.1 <spdxcustom_>`__ of the given specification version.
+
+
+Examples of valid license expressions:
+
+.. code-block:: yaml
+
+    MIT
+    BSD-3-Clause
+    MIT AND (Apache-2.0 OR BSD-2-Clause)
+    MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
+    GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
+    LicenseRef-Special-License OR CC0-1.0 OR Unlicense
+    LicenseRef-Proprietary
+
+
+Examples of invalid license expressions:
+
+.. code-block:: yaml
+
+    Use-it-after-midnight  # No `LicenseRef` prefix
+    Apache-2.0 OR 2-BSD-Clause  # 2-BSD-Clause is not a valid SPDX identifier
+    LicenseRef-License with spaces  # spaces are not allowed
+    LicenseRef-License_with_underscores  # underscore are not allowed
+
+.. _spdxcustom: https://spdx.github.io/spdx-spec/v2.2.2/other-licensing-information-detected/
+.. _spdxlist: https://spdx.org/licenses/
+.. _spdxpression: https://spdx.github.io/spdx-spec/v2.2.2/SPDX-license-expressions/

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -254,7 +254,9 @@ The Python version requirements of the project.
 - Corresponding :ref:`core metadata <core-metadata>` field:
   :ref:`License-Expression <core-metadata-license-expression>`
 
-Text string that is a valid SPDX license expression as defined in :pep:`639`.
+Text string that is a valid SPDX
+:term:`license expression <License Expression>`,
+as specified in :doc:`/specifications/license-expression`.
 Tools SHOULD validate and perform case normalization of the expression.
 
 The table subkeys of the ``license`` key are deprecated.

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -259,8 +259,21 @@ Text string that is a valid SPDX
 as specified in :doc:`/specifications/license-expression`.
 Tools SHOULD validate and perform case normalization of the expression.
 
-The table subkeys of the ``license`` key are deprecated.
+Legacy specification
+''''''''''''''''''''
 
+- TOML_ type: table
+- Corresponding :ref:`core metadata <core-metadata>` field:
+  :ref:`License <core-metadata-license>`
+
+The table may have one of two keys. The ``file`` key has a string
+value that is a file path relative to ``pyproject.toml`` to the file
+which contains the license for the project. Tools MUST assume the
+file's encoding is UTF-8. The ``text`` key has a string value which is
+the license of the project.  These keys are mutually exclusive, so a
+tool MUST raise an error if the metadata specifies both keys.
+
+The table subkeys were deprecated by :pep:`639` in favor of the string value.
 
 .. _pyproject-toml-license-files:
 

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -267,7 +267,7 @@ Legacy specification
   :ref:`License <core-metadata-license>`
 
 The table may have one of two keys. The ``file`` key has a string
-value that is a file path relative to ``pyproject.toml`` to the file
+value that is a file path relative to :file:`pyproject.toml` to the file
 which contains the license for the project. Tools MUST assume the
 file's encoding is UTF-8. The ``text`` key has a string value which is
 the license of the project.  These keys are mutually exclusive, so a

--- a/source/specifications/section-distribution-metadata.rst
+++ b/source/specifications/section-distribution-metadata.rst
@@ -15,3 +15,4 @@ Package Distribution Metadata
    platform-compatibility-tags
    well-known-project-urls
    glob-patterns
+   license-expression


### PR DESCRIPTION
This brings the specification from PEP 639 body to packaging.python.org where it should be. 

yaml in the code block is to highlight the comments better in the rendered pages.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1838.org.readthedocs.build/en/1838/

<!-- readthedocs-preview python-packaging-user-guide end -->