### PR TITLE
Add psfhosted plausbile instance to analytics

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -75,7 +75,11 @@ _metrics_js_files = [
     (
         "https://plausible.io/js/script.js",
         {"data-domain": "packaging.python.org", "defer": "defer"},
-    )
+    ),
+    (
+        "https://analytics.python.org/js/script.js",
+        {"data-domain": "packaging.python.org", "defer": "defer"},
+    ),
 ]
 html_js_files = []
 if RTD_CANONICAL_BUILD:


### PR DESCRIPTION
I'm evaluating the self-hosted option on the psf infrastructure.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1842.org.readthedocs.build/en/1842/

<!-- readthedocs-preview python-packaging-user-guide end -->