### PR TITLE
remove plausible.io

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -73,11 +73,7 @@ html_last_updated_fmt = ""
 
 _metrics_js_files = [
     (
-        "https://plausible.io/js/script.js",
-        {"data-domain": "packaging.python.org", "defer": "defer"},
-    ),
-    (
-        "https://analytics.python.org/js/script.js",
+        "https://analytics.python.org/js/script.outbound-links.js",
         {"data-domain": "packaging.python.org", "defer": "defer"},
     ),
 ]


### PR DESCRIPTION
we're going to be migrating to self-hosted plausbile entirely now.

drop plausible.io script, and enable outbound links

stats are now available at https://analytics.python.org/packaging.python.org/ instead of the old url of https://plausible.io/packaging.python.org

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1850.org.readthedocs.build/en/1850/

<!-- readthedocs-preview python-packaging-user-guide end -->