### PR TITLE
Add PEP 770 to specifications

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -256,8 +256,8 @@ The .dist-info directory
 Subdirectories in :file:`.dist-info/`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Subdirectories under :file:`.dist-info` are reserved for future use.
-The following subdirectory names under :file:`.dist-info` are reserved for specific usage:
+Subdirectories under :file:`.dist-info/` are reserved for future use.
+The following subdirectory names under :file:`.dist-info/` are reserved for specific usage:
 
 ================= ==============
 Subdirectory name PEP / Standard
@@ -280,7 +280,7 @@ relative to the :file:`licenses/` directory.
 The :file:`.dist-info/sboms/` directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All files contained within the :file:`.dist-info/sboms` directory MUST
+All files contained within the :file:`.dist-info/sboms/` directory MUST
 be Software Bill-of-Materials (SBOM) files that describe software contained
 within the distribution archive.
 

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -253,6 +253,20 @@ The .dist-info directory
    installation will fail if any file in the archive is not both
    mentioned and correctly hashed in RECORD.
 
+Subdirectories in :file:`.dist-info/`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Subdirectories under `.dist-info` are reserved for future use.
+The following subdirectory names under `.dist-info` are reserved for specific usage:
+
+================= ==============
+Subdirectory name PEP / Standard
+================= ==============
+``licenses``      :pep:`639`
+``license_files`` :pep:`639`
+``LICENSES``      `REUSE licensing framework <https://reuse.software>`__
+``sboms``         :pep:`770`
+================= ==============
 
 The :file:`.dist-info/licenses/` directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,6 +277,12 @@ fields is specified, the :file:`.dist-info/` directory MUST contain a
 ``License-File`` fields in the :file:`METADATA` file at their respective paths
 relative to the :file:`licenses/` directory.
 
+The :file:`.dist-info/sboms/` directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All files contained within the :file:`.dist-info/sboms` directory MUST
+be Software Bill-of-Materials (SBOM) files that describe software contained
+within the distribution archive.
 
 The .data directory
 ^^^^^^^^^^^^^^^^^^^

--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -256,8 +256,8 @@ The .dist-info directory
 Subdirectories in :file:`.dist-info/`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Subdirectories under `.dist-info` are reserved for future use.
-The following subdirectory names under `.dist-info` are reserved for specific usage:
+Subdirectories under :file:`.dist-info` are reserved for future use.
+The following subdirectory names under :file:`.dist-info` are reserved for specific usage:
 
 ================= ==============
 Subdirectory name PEP / Standard

--- a/source/specifications/recording-installed-packages.rst
+++ b/source/specifications/recording-installed-packages.rst
@@ -239,7 +239,7 @@ Any files in this directory MUST be copied from wheels by the install tools.
 The :file:`sboms/` subdirectory
 ==================================
 
-All files contained within the :file:`.dist-info/sboms` directory MUST
+All files contained within the :file:`.dist-info/sboms/` directory MUST
 be Software Bill-of-Materials (SBOM) files that describe software contained
 within the installed package.
 Any files in this directory MUST be copied from wheels by the install tools.

--- a/source/specifications/recording-installed-packages.rst
+++ b/source/specifications/recording-installed-packages.rst
@@ -66,10 +66,11 @@ The ``METADATA`` file is mandatory.
 All other files may be omitted at the installing tool's discretion.
 Additional installer-specific files may be present.
 
-This :file:`.dist-info/` directory may contain the following directory, described in
+This :file:`.dist-info/` directory may contain the following directories, described in
 detail below:
 
 * :file:`licenses/`: contains license files.
+* :file:`sboms/`: contains Software Bill-of-Materials files (SBOMs).
 
 .. note::
 
@@ -232,6 +233,15 @@ fields is specified, the :file:`.dist-info/` directory MUST contain a :file:`lic
 subdirectory which MUST contain the files listed in the ``License-File`` fields in
 the :file:`METADATA` file at their respective paths relative to the
 :file:`licenses/` directory.
+Any files in this directory MUST be copied from wheels by the install tools.
+
+
+The :file:`sboms/` subdirectory
+==================================
+
+All files contained within the :file:`.dist-info/sboms` directory MUST
+be Software Bill-of-Materials (SBOM) files that describe software contained
+within the installed package.
 Any files in this directory MUST be copied from wheels by the install tools.
 
 


### PR DESCRIPTION
* Adds reservation of directory names under `.dist-info` and reserves a few names already in use.
* Adds description of `.dist-info/sboms` directory.

I wasn't sure whether to add a "guide" or not yet, as there aren't any especially "user-facing" ways to have an SBOM end up in this directory beyond your build backend/build tool supporting it. Should I leave that for a later task, then?

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1853.org.readthedocs.build/en/1853/

<!-- readthedocs-preview python-packaging-user-guide end -->