### PR TITLE
guides: remove manual Sigstore steps from publishing guide

### DIFF
--- a/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
+++ b/source/guides/github-actions-ci-cd-sample/publish-to-test-pypi.yml
@@ -51,49 +51,6 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    needs:
-    - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        "$GITHUB_REF_NAME"
-        --repo "$GITHUB_REPOSITORY"
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        "$GITHUB_REF_NAME" dist/**
-        --repo "$GITHUB_REPOSITORY"
-
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
     needs:

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -21,10 +21,10 @@ for temporarily storing and downloading the source packages.
    details of building platform specific projects. If you have binary
    components, check out :ref:`cibuildwheel`'s GitHub Action examples.
 
-Configuring trusted publishing
+Configuring Trusted Publishing
 ==============================
 
-This guide relies on PyPI's `trusted publishing`_ implementation to connect
+This guide relies on PyPI's `Trusted Publishing`_ implementation to connect
 to `GitHub Actions CI/CD`_. This is recommended for security reasons, since
 the generated tokens are created for each of your projects
 individually and expire automatically. Otherwise, you'll need to generate an
@@ -36,7 +36,7 @@ Since this guide will demonstrate uploading to both
 PyPI and TestPyPI, we'll need two trusted publishers configured.
 The following steps will lead you through creating the "pending" publishers
 for your new :term:`PyPI project <Project>`.
-However it is also possible to add `trusted publishing`_ to any
+However it is also possible to add `Trusted Publishing`_ to any
 pre-existing project, if you are its owner.
 
 .. attention::
@@ -134,7 +134,7 @@ provided by GitHub Actions. This also defines a GitHub Environment
 for the job to run in its context and a URL to be displayed in GitHub's
 UI nicely. Additionally, it allows acquiring an OpenID Connect token
 that the ``pypi-publish`` actions needs to implement secretless
-trusted publishing to PyPI.
+Trusted Publishing to PyPI.
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
@@ -152,46 +152,20 @@ Finally, add the following steps at the end:
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
    :language: yaml
    :start-after: id-token: write
-   :end-before:  github-release:
+   :end-before:  publish-to-testpypi:
 
 This step uses the `pypa/gh-action-pypi-publish`_ GitHub
 Action: after the stored distribution package has been
 downloaded by the `download-artifact`_ action, it uploads
 the contents of the ``dist/`` folder into PyPI unconditionally.
 
-Signing the distribution packages
-=================================
-
-The following job signs the distribution packages with `Sigstore`_,
-the same artifact signing system `used to sign CPython <https://www.python.org/download/sigstore/>`_.
-
-Firstly, it uses the `sigstore/gh-action-sigstore-python GitHub Action`_
-to sign the distribution packages. In the next step, an empty GitHub Release
-from the current tag is created using the ``gh`` CLI. Note this step can be further
-customised. See the `gh release documentation <https://cli.github.com/manual/gh_release>`_
-as a reference.
-
 .. tip::
 
-   You may need to manage your ``GITHUB_TOKEN`` permissions to
-   enable creating the GitHub Release. See the `GitHub
-   documentation <https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions>`_
-   for instructions. Specifically, the token needs the
-   ``contents: write`` permission.
-
-Finally, the signed distributions are uploaded to the GitHub Release.
-
-.. literalinclude:: github-actions-ci-cd-sample/publish-to-test-pypi.yml
-   :language: yaml
-   :start-at: github-release:
-   :end-before:  publish-to-testpypi
-
-
-.. note::
-
-   This is a replacement for GPG signatures, for which support has been
-   `removed from PyPI <https://blog.pypi.org/posts/2023-05-23-removing-pgp/>`_.
-   However, this job is not mandatory for uploading to PyPI and can be omitted.
+   Starting with version
+   `v1.11.0 <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0>`_,
+   `pypa/gh-action-pypi-publish`_ generates and uploads :pep:`740`-compatible
+   attestations for each distribution by default. No additional manual
+   signing steps are required.
 
 
 Separate workflow for publishing to TestPyPI
@@ -254,9 +228,6 @@ sure that your release pipeline remains healthy!
    https://github.com/actions/download-artifact
 .. _`upload-artifact`:
    https://github.com/actions/upload-artifact
-.. _Sigstore: https://www.sigstore.dev/
-.. _`sigstore/gh-action-sigstore-python GitHub Action`:
-   https://github.com/marketplace/actions/gh-action-sigstore-python
 .. _Secrets:
    https://docs.github.com/en/actions/reference/encrypted-secrets
-.. _trusted publishing: https://docs.pypi.org/trusted-publishers/
+.. _Trusted Publishing: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
These steps are superfluous now that gh-action-pypi-publish generates and uploads PEP 740-compatible attestations by default on its own.

(They also served a slightly different purpose than PEP 740 attestations, since they were never uploaded to PyPI and used a different format.)

Closes #1788.

+CC @webknjaz @di for review 🙂 