### PR TITLE
Add 'docs' to dependency groups example

### DIFF
--- a/source/specifications/dependency-groups.rst
+++ b/source/specifications/dependency-groups.rst
@@ -22,14 +22,16 @@ Specification
 Examples
 --------
 
-This is a simple table which shows a ``test`` group::
+This is a simple table which shows ``docs`` and ``test`` groups::
 
     [dependency-groups]
+    docs = ["sphinx"]
     test = ["pytest>7", "coverage"]
 
-and a similar table which defines ``test`` and ``coverage`` groups::
+and a similar table which defines ``docs``, ``test``, and ``coverage`` groups::
 
     [dependency-groups]
+    docs = ["sphinx"]
     coverage = ["coverage[toml]"]
     test = ["pytest>7", {include-group = "coverage"}]
 


### PR DESCRIPTION
This is a small example update based on some observed usage of Dependency Groups.
We wouldn't want to bloat the example, but many projects are using a `docs` group and this example therefore better exemplifies how Dependency Groups can be used to declare isolated/separate groups.

---

I argue for this change as net-good based on the fact that it shows that `docs` and `test` can be separate groups.


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1860.org.readthedocs.build/en/1860/

<!-- readthedocs-preview python-packaging-user-guide end -->