### PR TITLE
tags spec: clarify "sorted, set" to "sorted, collection"

### DIFF
--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -351,7 +351,7 @@ Compressed Tag Sets
 
 To allow for compact filenames of bdists that work with more than
 one compatibility tag triple, each tag in a filename can instead be a
-'.'-separated, sorted, set of tags.  For example, pip, a pure-Python
+'.'-separated, sorted, collection of tags.  For example, pip, a pure-Python
 package that is written to run under Python 2 and 3 with the same source
 code, could distribute a bdist with the tag ``py2.py3-none-any``.
 The full list of simple tags is::


### PR DESCRIPTION
This will hopefully clarify/eliminate a contradiction in terms in the current specification text: the current text says both "sorted" and "set", where "set" conventionally implies an unordered collection.

In context that *appears* to have not been the intention, since the context is the wheel filename encoding and not the internal (i.e. parsed) representation
of a wheel filename's tags.

For context: this came up recently due to a set of unexpected tool interactions: 

* A user's build backend would produce a given wheel filename
* `auditwheel` would *rewrite* that wheel filename's tags, without enforcing a particular order
* `pypi-attestations` would "ultranormalize" the wheel's tags for signing and verifying purposes, to make string comparisons between wheel filenames work correctly. This was overly aggressive, but undoing it also revealed more tag ordering issues throughout the ecosystem
* PyPA's `packaging` accepts any tag ordering via `parse_wheel_filename`, masking invalid tag orderings from other tools

xrefs:

* https://github.com/pypi/warehouse/issues/18128
* https://github.com/pypa/auditwheel/issues/583
* https://github.com/pypa/gh-action-pypi-publish/issues/365
* https://github.com/trailofbits/pypi-attestations/issues/123
* https://github.com/pypa/packaging/issues/909

CC @di 


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1869.org.readthedocs.build/en/1869/

<!-- readthedocs-preview python-packaging-user-guide end -->