### PR TITLE
Mention the metadata version at the top, and re-order the history

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -6,6 +6,8 @@
 Core metadata specifications
 ============================
 
+This page describes version 2.4, approved in August 2024.
+
 Fields defined in the following specification should be considered valid,
 complete and not subject to change. The required fields are:
 


### PR DESCRIPTION
This should make the spec's status and history clearer.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1871.org.readthedocs.build/en/1871/

<!-- readthedocs-preview python-packaging-user-guide end -->