### PR TITLE
Fix a small markup error in the contribute guide

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -103,7 +103,6 @@ If you are not familiar with reStructuredText (RST) syntax, please read `this gu
 before translating on Weblate.
 
 **Do not translate the text in reference directly**
-
   When translating the text in reference, please do not translate them directly.
 
   | Wrong: Translate the following text directly:


### PR DESCRIPTION
The "Do not translate ..." part shoule be a definition list, not a blockquote, like the rest of this page.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1874.org.readthedocs.build/en/1874/

<!-- readthedocs-preview python-packaging-user-guide end -->