### PR TITLE
Add RepoFlow to list of existing PyPI compatible repositories

### DIFF
--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -126,6 +126,12 @@ Existing projects
        <https://httpd.apache.org/docs/current/mod/mod_cache_disk.html>`_,
        you can cache requests to package indexes through an Apache server
 
+   * - `RepoFlow <https://www.repoflow.io>`_
+     - ✔
+     - ✔
+     - Modern package registry with PyPI upload and proxy support, available self-hosted or in the cloud.
+
+
 ----
 
 .. [1] For complete documentation of the simple repository protocol, see


### PR DESCRIPTION
Added RepoFlow to the comparison table in the "Hosting your own simple repository" guide.

RepoFlow is a modern package registry that supports PyPI uploads and proxying. It is available as both a cloud-hosted and self-hosted solution, and also supports other package types like npm, Docker, and Maven.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1876.org.readthedocs.build/en/1876/

<!-- readthedocs-preview python-packaging-user-guide end -->