### PR TITLE
Add "namespace package" to glossary

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -187,6 +187,13 @@ Glossary
         types: :term:`Pure Module`, or :term:`Extension Module`.
 
 
+    Namespace Package
+
+        A mechanism for splitting a single :term:`Import Package <Import Package>`
+        across multiple directories on disk. Can either be "explicit" or "implicit",
+        depending on the mechanism. Defined in :pep:`420`.
+
+
     Package Index
 
         A repository of distributions with a web interface to automate


### PR DESCRIPTION
I'm a masochist, so here I go mucking around in the world of namespace packages. Really, I just wanted to link to a definition in an upcoming blog post, and realized there wasn't one.

I'm not the best wordsmith so happy to take suggestions.

(I was thinking we _could_ include definitions for "explicit" or "implicit", but incremental improvement is still improvement)