### PR TITLE
Convert linkcheck_ignore entries to regexes

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -132,21 +132,21 @@ texinfo_documents = [
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 
 linkcheck_ignore = [
-    "http://localhost:\\d+",
-    "https://packaging.python.org/en/latest/specifications/schemas/.*",
-    "https://test.pypi.org/project/example-package-YOUR-USERNAME-HERE",
-    "https://pypi.org/manage/*",
-    "https://test.pypi.org/manage/*",
+    r"http://localhost:\d+",
+    r"https://packaging\.python\.org/en/latest/specifications/schemas/.*",
+    r"https://test\.pypi\.org/project/example-package-YOUR-USERNAME-HERE",
+    r"https://pypi\.org/manage/.*",
+    r"https://test\.pypi\.org/manage/.*",
     # Temporarily ignored. Ref:
     # https://github.com/pypa/packaging.python.org/pull/1308#issuecomment-1775347690
-    "https://www.breezy-vcs.org/*",
+    r"https://www\.breezy-vcs\.org/.*",
     # Ignore while StackOverflow is blocking GitHub CI. Ref:
     # https://github.com/pypa/packaging.python.org/pull/1474
-    "https://stackoverflow.com/*",
-    "https://pyscaffold.org/*",
-    "https://anaconda.org",
-    "https://www.cisa.gov/sbom",
-    "https://developers.redhat.com/products/softwarecollections/overview",
+    r"https://stackoverflow\.com/.*",
+    r"https://pyscaffold\.org/.*",
+    r"https://anaconda\.org",
+    r"https://www\.cisa\.gov/sbom",
+    r"https://developers\.redhat\.com/products/softwarecollections/overview",
     r"https://math-atlas\.sourceforge\.net/?",
     r"https://click\.palletsprojects\.com/.*",
     r"https://typer\.tiangolo\.com/.*",


### PR DESCRIPTION
As the title says, this PR converts `linkcheck_ignore` entries to regexes so that the URLs really only match exactly (otherwise, a dot is interpreted as "any character").

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1883.org.readthedocs.build/en/1883/

<!-- readthedocs-preview python-packaging-user-guide end -->