### PR TITLE
Add some more examples for the platform_machine environment marker

### DIFF
--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -260,7 +260,7 @@ an error like all other unknown variables.
    * - ``platform_machine``
      - :py:func:`platform.machine()`
      - String
-     - ``x86_64``
+     - ``x86_64``, ``aarch64``, ``arm64``
    * - ``platform_python_implementation``
      - :py:func:`platform.python_implementation()`
      - String


### PR DESCRIPTION
I was surprised to discover that Linux ARM machines report themselves as `aarch64`, but macOS ARM machines report themselves as `arm64`. Highlighting both of these possibilities in the table (in the same way that the examples for `platform_system` include `Java`) feels useful.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1904.org.readthedocs.build/en/1904/

<!-- readthedocs-preview python-packaging-user-guide end -->