### PR TITLE
Clarify that the `license` key in `pyprojcet.toml` should only be set if it is consistent across all distribution files

### DIFF
--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -259,6 +259,11 @@ Text string that is a valid SPDX
 as specified in :doc:`/specifications/license-expression`.
 Tools SHOULD validate and perform case normalization of the expression.
 
+This key should **only** be specified if the license expression for any
+and all distribution files generated from the ``pyproject.toml`` is the
+same as the one specified. If the license expression will differ then
+it should either be specified as dynamic or not set at all.
+
 Legacy specification
 ''''''''''''''''''''
 


### PR DESCRIPTION
This change is approved at https://discuss.python.org/t/split-from-pep-639-expressing-project-vs-distribution-licenses-post-pep-639-mod-titled/90314/179 .