### PR TITLE
Clarify throughout the docs that the `license` key in `pyproject.toml` is for the distribution

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -160,7 +160,7 @@ Glossary
 
         A string with valid SPDX license expression syntax,
         including one or more SPDX :term:`License Identifier`\(s),
-        which describes a :term:`Project`'s license(s)
+        which describes a :term:`Distribution Archive`'s license(s)
         and how they inter-relate.
         Examples:
         ``GPL-3.0-or-later``,

--- a/source/guides/licensing-examples-and-user-scenarios.rst
+++ b/source/guides/licensing-examples-and-user-scenarios.rst
@@ -6,8 +6,8 @@ Licensing examples and user scenarios
 =====================================
 
 
-:pep:`639` has specified the way to declare a project's license and paths to
-license files and other legally required information.
+:pep:`639` has specified the way to declare a :term:`Distribution Archive`'s
+license and paths to license files and other legally required information.
 This document aims to provide clear guidance how to migrate from the legacy
 to the standardized way of declaring licenses.
 Make sure your preferred build backend supports :pep:`639` before
@@ -53,7 +53,7 @@ Or, if the project used :file:`setup.cfg`, in its ``[metadata]`` table:
     [metadata]
     license = MIT
 
-The output Core Metadata for the distribution packages would then be:
+The output Core Metadata for the :term:`Distribution Package` would then be:
 
 .. code-block:: email
 
@@ -63,8 +63,9 @@ The output Core Metadata for the distribution packages would then be:
 The :file:`LICENSE` file would be stored at :file:`/setuptools-{VERSION}/LICENSE`
 in the sdist and :file:`/setuptools-{VERSION}.dist-info/licenses/LICENSE`
 in the wheel, and unpacked from there into the site directory (e.g.
-:file:`site-packages/`) on installation; :file:`/` is the root of the respective archive
-and ``{VERSION}`` the version of the Setuptools release in the Core Metadata.
+:file:`site-packages/`) on installation; :file:`/` is the root of the respective
+archive and ``{VERSION}`` the version of the Setuptools release in the Core
+Metadata.
 
 
 .. _licensing-example-advanced:
@@ -83,7 +84,7 @@ directories; specifically:
     ordered-set==3.1.1
     more_itertools==8.8.0
 
-The license expressions for these projects are:
+The appropriate license expressions are:
 
 .. code-block:: text
 
@@ -287,7 +288,7 @@ and make sure to remove any legacy ``license`` table subkeys or
 ``License ::`` classifiers. Your existing ``license`` value may already
 be valid as one (e.g. ``MIT``, ``Apache-2.0 OR BSD-2-Clause``, etc);
 otherwise, check the `SPDX license list <spdxlist_>`__ for the identifier
-that matches the license used in your project.
+that matches the license used.
 
 Make sure to list your license files under ``license-files``
 under ``[project]`` in :file:`pyproject.toml`
@@ -311,13 +312,12 @@ software, you can construct a license expression
 to describe the licenses involved and the relationship
 between them.
 
-In short, ``License-1 AND License-2`` mean that *both* licenses apply
-to your project, or parts of it (for example, you included a file
-under another license), and ``License-1 OR License-2`` means that
-*either* of the licenses can be used, at the user's option (for example,
-you want to allow users a choice of multiple licenses). You can use
-parenthesis (``()``) for grouping to form expressions that cover even the most
-complex situations.
+In short, ``License-1 AND License-2`` mean that *both* licenses apply, or parts
+of it (for example, you included a file under another license), and
+``License-1 OR License-2`` means that *either* of the licenses can be used, at
+the user's option (for example, you want to allow users a choice of multiple
+licenses). You can use parenthesis (``()``) for grouping to form expressions
+that cover even the most complex situations.
 
 In your project config file, enter your license expression under
 ``license`` (``[project]`` table of :file:`pyproject.toml`),

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -296,10 +296,10 @@ You can also specify the format explicitly, like this:
 ``license`` and ``license-files``
 ---------------------------------
 
-As per :pep:`639` licenses should be declared with two fields:
+As per :pep:`639`, licenses should be declared with two fields:
 
-- ``license`` is an :term:`SPDX license expression <License Expression>` consisting
-  of one or more :term:`license identifiers <License Identifier>`.
+- ``license`` is an :term:`SPDX license expression <License Expression>`
+  consisting of one or more :term:`license identifiers <License Identifier>`.
 - ``license-files`` is a list of license file glob patterns.
 
 A previous PEP had specified ``license`` to be a table with a ``file`` or a
@@ -350,10 +350,11 @@ As a general rule, it is a good idea to use a standard, well-known
 license, both to avoid confusion and because some organizations avoid software
 whose license is unapproved.
 
-If your project is licensed with a license that doesn't have an existing SPDX
-identifier, you can create a custom one in format ``LicenseRef-[idstring]``.
-The custom identifiers must follow the SPDX specification,
-`clause 10.1 <spdxcustomids_>`_ of the version 2.2 or any later compatible one.
+If your :term:`Distribution Archive` is licensed with a license that doesn't
+have an existing SPDX identifier, you can create a custom one in format
+``LicenseRef-[idstring]``. The custom identifiers must follow the SPDX
+specification, `clause 10.1 <spdxcustomids_>`_ of the version 2.2 or any later
+compatible one.
 
 .. code-block:: toml
 

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -220,7 +220,7 @@ following this tutorial.
   your package will work on. For a complete list of classifiers, see
   https://pypi.org/classifiers/.
 - ``license`` is the :term:`SPDX license expression <License Expression>` of
-  your package.
+  your :term:`Distribution Archive` files.
 - ``license-files`` is the list of glob paths to the license files,
   relative to the directory where :file:`pyproject.toml` is located.
 - ``urls`` lets you list any number of extra links to show on PyPI.
@@ -250,12 +250,12 @@ if you'd like.
 Creating a LICENSE
 ------------------
 
-It's important for every package uploaded to the Python Package Index to include
-a license. This tells users who install your package the terms under which they
-can use your package. For help picking a license, see
-https://choosealicense.com/. Once you have chosen a license, open
-:file:`LICENSE` and enter the license text. For example, if you had chosen the
-MIT license:
+It's important for every :term:`Distribution Archive` uploaded to the Python
+Package Index to include a license. This tells users who install your
+:term:`Distribution Archive` the terms under which they can use it. For help
+picking a license, see https://choosealicense.com/. Once you have chosen a
+license, open :file:`LICENSE` and enter the license text. For example, if you
+had chosen the MIT license:
 
 .. code-block:: text
 


### PR DESCRIPTION
Approved in https://discuss.python.org/t/split-from-pep-639-expressing-project-vs-distribution-licenses-post-pep-639-mod-titled/90314/179 .