### PR TITLE
Updates table to contain poetry-core version supporting PEP 639

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -319,7 +319,7 @@ backend>` now support the new format as shown in the following table.
      - 77.0.3
      - 3.12
      - 2.4.0
-     - `not yet <poetry-pep639-issue_>`_
+     - 2.2.0
      - 0.7.19
 
 
@@ -587,7 +587,6 @@ A full example
 .. _pypi-search-pip: https://pypi.org/search?q=pip
 .. _classifier-list: https://pypi.org/classifiers
 .. _requires-python-blog-post: https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
-.. _poetry-pep639-issue: https://github.com/python-poetry/poetry/issues/9670
 .. _pytest: https://pytest.org
 .. _pygments: https://pygments.org
 .. _rest: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html


### PR DESCRIPTION
I happened to notice that the latest version of poetry does indeed support PEP639 (See: https://python-poetry.org/history/#220---2025-09-14) so I figured this table should be updated 🙂 

FWIW I did also validate myself that the same dummy project build with poetry 2.1.4 and 2.2.0 result in slightly different PKG-INFO outputs as expected.

Old:
```
Metadata-Version: 2.3
License: MIT
```

New:
```
Metadata-Version: 2.4
License-Expression: MIT
```