### PR TITLE
Drop warehouse's intersphinx entry

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -210,7 +210,6 @@ intersphinx_mapping = {
     "tox": ("https://tox.wiki/en/latest/", None),
     "twine": ("https://twine.readthedocs.io/en/stable/", None),
     "virtualenv": ("https://virtualenv.pypa.io/en/stable/", None),
-    "warehouse": ("https://warehouse.pypa.io/", None),
 }
 
 # -- Options for todo extension --------------------------------------------------------


### PR DESCRIPTION
Warehouse is not referenced from these docs and their docs have moved to mkdocs-material.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1945.org.readthedocs.build/en/1945/

<!-- readthedocs-preview python-packaging-user-guide end -->