### PR TITLE
nox: allow passing arguments to linkcheck

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -89,6 +89,7 @@ def linkcheck(session):
         "--keep-going",  # be strict
         "source",  # where the rst files are located
         "build",  # where to put the check output
+        *session.posargs,
     )
 
 


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1949.org.readthedocs.build/en/1949/

<!-- readthedocs-preview python-packaging-user-guide end -->