### PR TITLE
Move get-pip.py warning above instructions to prevent accidental misuse

### DIFF
--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -133,6 +133,14 @@ standard library:
 
 If that still doesn't allow you to run ``python -m pip``:
 
+  .. warning::
+
+     Be cautious if you're using a Python install that's managed by your
+     operating system or another package manager. ``get-pip.py`` does not
+     coordinate with those tools, and may leave your system in an inconsistent
+     state. You can use ``python get-pip.py --prefix=/usr/local/`` to install
+     in ``/usr/local`` which is designed for locally-installed software.
+
 * Securely Download `get-pip.py
   <https://bootstrap.pypa.io/get-pip.py>`_ [1]_
 
@@ -140,14 +148,6 @@ If that still doesn't allow you to run ``python -m pip``:
   Additionally, it will install :ref:`setuptools` and :ref:`wheel` if they're
   not installed already.
 
-  .. warning::
-
-     Be cautious if you're using a Python install that's managed by your
-     operating system or another package manager. get-pip.py does not
-     coordinate with those tools, and may leave your system in an
-     inconsistent state. You can use ``python get-pip.py --prefix=/usr/local/``
-     to install in ``/usr/local`` which is designed for locally-installed
-     software.
 
 
 Ensure pip, setuptools, and wheel are up to date


### PR DESCRIPTION
This PR moves the existing warning about using ``get-pip.py`` so that it
appears *before* the installation steps.

Currently, the tutorial shows the instructions for downloading and running
``get-pip.py`` before the cautionary note, which may lead beginners to run
the command without seeing the warning first. Since this tutorial is aimed at
new Python users, placing the warning earlier helps prevent accidental misuse.

No content was changed—only the order—keeping the diff minimal and focused.


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1953.org.readthedocs.build/en/1953/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line

<!-- readthedocs-preview python-packaging-user-guide end -->