### PR TITLE
Specify arbitrary equality case insensitivity.

### DIFF
--- a/source/specifications/version-specifiers.rst
+++ b/source/specifications/version-specifiers.rst
@@ -1272,4 +1272,4 @@ History
 - August 2014: This specification was approved through :pep:`440`.
 - May 2025: Clarify that development releases are a form of pre-release when
   they are handled.
-- Nov 2025: Specify arbitrary equality case insensitivity.
+- Nov 2025: Make arbitrary equality case insensitivity explicit.


### PR DESCRIPTION
Following https://discuss.python.org/t/clarify-that-arbitrary-equality-is-supposed-to-be-case-insensitive/104885 specify that for ASCII letters arbitrary equality MUST be case insensitive.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1959.org.readthedocs.build/en/1959/

<!-- readthedocs-preview python-packaging-user-guide end -->