### PR TITLE
Add subheading for Build backends for extension modules

### DIFF
--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -109,6 +109,11 @@ Do **not** use :ref:`distutils`, which is deprecated, and has been removed from
 the standard library in Python 3.12, although it still remains available from
 setuptools.
 
+.. _extension-module-tool-recommendations:
+
+Build backends for extension modules
+------------------------------------
+
 For packages with :term:`extension modules <extension module>`, it is best to use
 a build system with dedicated support for the language the extension is written in,
 for example:


### PR DESCRIPTION
Dear PyPA,

May I link to this section? :)

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1972.org.readthedocs.build/en/1972/

<!-- readthedocs-preview python-packaging-user-guide end -->