### PR TITLE
Drop the opening note in pyproject-toml spec

### DIFF
--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -14,8 +14,6 @@
 The ``pyproject.toml`` file acts as a configuration file for packaging-related
 tools (as well as other tools).
 
-.. note:: This specification was originally defined in :pep:`518` and :pep:`621`.
-
 The ``pyproject.toml`` file is written in `TOML <https://toml.io>`_. Three
 tables are currently specified, namely
 :ref:`[build-system] <pyproject-build-system-table>`,


### PR DESCRIPTION
The history section covers this more accurately.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1973.org.readthedocs.build/en/1973/

<!-- readthedocs-preview python-packaging-user-guide end -->