### PR TITLE
fix: bitbucket org gone

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -287,8 +287,7 @@ Glossary
         PyPA is a working group that maintains many of the relevant
         projects in Python packaging. They maintain a site at
         :doc:`pypa.io <pypa:index>`, host projects on `GitHub
-        <https://github.com/pypa>`_ and `Bitbucket
-        <https://bitbucket.org/pypa>`_, and discuss issues on the
+        <https://github.com/pypa>`_, and discuss issues on the
         `distutils-sig mailing list
         <https://mail.python.org/mailman3/lists/distutils-sig.python.org/>`_
 	and `the Python Discourse forum <https://discuss.python.org/c/packaging>`__.


### PR DESCRIPTION
The bitbucket site is gone (https://bitbucket.org/pypa). I got a notice from bitbucket on Tuesday that anything inactive for 6 months would be deleted, so maybe that's what happened here? Anyway, this deletes the mention, which should fix our CI (link check job).


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1974.org.readthedocs.build/en/1974/

<!-- readthedocs-preview python-packaging-user-guide end -->