### PR TITLE
docs: fix links to Travis

### DIFF
--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -62,7 +62,7 @@ of many continuous-integration systems. There are two hosted services which
 when used in conjunction provide automated testing across Linux, Mac and
 Windows:
 
-  - `Travis CI <https://travis-ci.org>`_ provides both a Linux and a macOS
+  - `Travis CI <https://travis-ci.com>`_ provides both a Linux and a macOS
     environment. The Linux environment is Ubuntu 12.04 LTS Server Edition 64 bit
     while the macOS is 10.9.2 at the time of writing.
   - `Appveyor <https://www.appveyor.com/>`_ provides a Windows environment

--- a/source/guides/supporting-windows-using-appveyor.rst
+++ b/source/guides/supporting-windows-using-appveyor.rst
@@ -237,6 +237,6 @@ For reference, the SDK setup support script is listed here:
    :linenos:
 
 .. _Appveyor: https://www.appveyor.com/
-.. _Travis: https://travis-ci.org/
+.. _Travis: https://travis-ci.com/
 .. _GitHub: https://github.com
 .. _Bitbucket: https://bitbucket.org/


### PR DESCRIPTION
Travis moved a long time ago, and sometimes this triggers an error in the CI, go ahead and update the links. One of those pages hasn't been updated in over 10 years.


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1977.org.readthedocs.build/en/1977/

<!-- readthedocs-preview python-packaging-user-guide end -->