### PR TITLE
Clarify that TOML v1.0 is used for specs

### DIFF
--- a/source/specifications/inline-script-metadata.rst
+++ b/source/specifications/inline-script-metadata.rst
@@ -74,7 +74,7 @@ script type
 -----------
 
 The first type of metadata block is named ``script``, which contains
-script metadata (dependency data and tool configuration).
+script metadata (dependency data and tool configuration) formatted as TOML 1.0 text.
 
 This document MAY include the top-level fields ``dependencies`` and ``requires-python``,
 and MAY optionally include a ``[tool]`` table.
@@ -217,3 +217,4 @@ History
   block type was renamed to ``script``, and the ``[run]`` table was dropped,
   making the ``dependencies`` and ``requires-python`` keys
   top-level. Additionally, the specification is no longer provisional.
+- January 2026: Clarify that the ``script`` block is TOML 1.0 formatted text.

--- a/source/specifications/pylock-toml.rst
+++ b/source/specifications/pylock-toml.rst
@@ -50,7 +50,7 @@ file would be in the directory that held all the projects being locked.
 File Format
 -----------
 
-The format of the file is TOML_.
+The format of the file is TOML_ version 1.0.
 
 Tools SHOULD write their lock files in a consistent way to minimize noise in
 diff output. Keys in tables -- including the top-level table -- SHOULD be
@@ -826,6 +826,7 @@ History
 -------
 
 - April 2025: Initial version, approved via :pep:`751`.
+- January 2026: Clarify that the TOML format version is 1.0 .
 
 
 .. _Content-Length: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -16,7 +16,7 @@ tools (as well as other tools).
 
 .. note:: This specification was originally defined in :pep:`518` and :pep:`621`.
 
-The ``pyproject.toml`` file is written in `TOML <https://toml.io>`_. Three
+The ``pyproject.toml`` file is written in `TOML <https://toml.io>`_ version 1.0. Three
 tables are currently specified, namely
 :ref:`[build-system] <pyproject-build-system-table>`,
 :ref:`[project] <pyproject-project-table>` and
@@ -648,5 +648,7 @@ History
 
 - October 2025: The ``import-names`` and ``import-namespaces`` keys were added
   through :pep:`794`.
+
+- January 2026: Clarify that the TOML format version is 1.0 .
 
 .. _TOML: https://toml.io


### PR DESCRIPTION
- State "version 1.0" for pylock.toml and pyproject.toml
- State that "TOML 1.0" is used for script metadata

For motivation, see:

  https://discuss.python.org/t/adopting-toml-1-1/105624


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1987.org.readthedocs.build/en/1987/

<!-- readthedocs-preview python-packaging-user-guide end -->