### PR TITLE
Attempt to clarify environment marker evaluation

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -574,13 +574,13 @@ The format of a requirement string contains from one to four parts:
 * An environment marker after a semicolon. This means that the
   requirement is only needed in the specified conditions.
 
-See :ref:`dependency-specifiers` for full details of the allowed format.
-
 The project names should correspond to names as found
 on the `Python Package Index`_.
 
 Version specifiers must follow the rules described in
 :doc:`version-specifiers`.
+
+See :ref:`dependency-specifiers` for full details of the allowed format.
 
 Examples::
 

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -574,7 +574,7 @@ The format of a requirement string contains from one to four parts:
 * An environment marker after a semicolon. This means that the
   requirement is only needed in the specified conditions.
 
-See :pep:`508` for full details of the allowed format.
+See :ref:`dependency-specifiers` for full details of the allowed format.
 
 The project names should correspond to names as found
 on the `Python Package Index`_.

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -1071,6 +1071,9 @@ History
 - October 2025: Clarified that ``License-Expression`` applies to the containing
   distribution file and not the project itself.
 
+- January 2026: Replaced outdated direct reference to :pep:`508` with a
+  reference to :ref:`dependency-specifiers`.
+
 ----
 
 .. [1] reStructuredText markup:

--- a/source/specifications/dependency-groups.rst
+++ b/source/specifications/dependency-groups.rst
@@ -209,8 +209,8 @@ The output is therefore valid ``requirements.txt`` data.
         realized_group = []
         for item in raw_group:
             if isinstance(item, str):
-                # packaging.requirements.Requirement parsing ensures that this is a valid
-                # PEP 508 Dependency Specifier
+                # packaging.requirements.Requirement parsing ensures that this
+                # is a valid dependency specifier
                 # raises InvalidRequirement on failure
                 Requirement(item)
                 realized_group.append(item)

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -273,16 +273,18 @@ specifier, while locking and installation tools MAY either emit an error or else
 fall back to ``String`` field comparison logic if either the marker field value
 or the user supplied constant cannot be parsed as a valid version specifier.
 Note that ``in`` and ``not in`` containment checks are NOT valid for ``Version``
-fields.
+fields and publishing tools SHOULD emit an error, while locking and installation
+tools MAY treat them as always being False.
 
 For ``Version | String`` fields, comparison operations are defined as they are
-for ``Version`` fields. However, there is no expectation that the parsing of
-the marker field value or the user supplied constant as a valid version will
-succeed, so tools MUST fall back to processing the field as a ``String`` field.
-Alternatively, tools MAY unconditionally treat such fields as ``String`` fields.
-Accordingly, comparisons that rely on these fields being processed as
-``Version`` field SHOULD NOT be used in environment markers published to public
-index servers, but they may be appropriate in more constrained environments.
+for ``Version`` fields, while ``in`` and ``not in`` containment checks are
+defined as they are for ``String`` fields. However, there is no expectation
+that the parsing of the marker field value or the user supplied constant as a
+valid version will succeed, so tools MUST fall back to processing the field as
+a ``String`` field. Alternatively, tools MAY unconditionally treat such fields
+as ``String`` fields. Due to this potential for variation across clients,
+comparisons that rely on these fields being processed as ``Version`` fields
+SHOULD NOT be used in environment markers published to public index servers.
 
 Composing marker expressions
 ''''''''''''''''''''''''''''

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -243,7 +243,7 @@ The follow comparison operations are defined in the marker expression grammar:
 * ``<=`` (for example, ``python_version <= "3.10"``)
 * ``~=`` (for example, ``python_version ~= "3"``)
 * ``===`` (for example, ``implementation_version === "not.a.valid.version"``)
-* ``in`` (for example, ``"gui" in extras``)
+* ``in`` (for example, ``"gui" in extras``, ``"SMP" in platform_version``)
 * ``not in`` (for example, ``"dev" not in dependency_groups``)
 
 For ``String`` fields, ``==``, ``!=``, ``in``, and ``not in`` are defined as
@@ -272,12 +272,17 @@ emit an error if the user supplied constant cannot be parsed as a valid version
 specifier, while locking and installation tools MAY either emit an error or else
 fall back to ``String`` field comparison logic if either the marker field value
 or the user supplied constant cannot be parsed as a valid version specifier.
+Note that ``in`` and ``not in`` containment checks are NOT valid for ``Version``
+fields.
 
 For ``Version | String`` fields, comparison operations are defined as they are
 for ``Version`` fields. However, there is no expectation that the parsing of
 the marker field value or the user supplied constant as a valid version will
 succeed, so tools MUST fall back to processing the field as a ``String`` field.
 Alternatively, tools MAY unconditionally treat such fields as ``String`` fields.
+Accordingly, comparisons that rely on these fields being processed as
+``Version`` field SHOULD NOT be used in environment markers published to public
+index servers, but they may be appropriate in more constrained environments.
 
 Composing marker expressions
 ''''''''''''''''''''''''''''
@@ -286,8 +291,15 @@ More complex marker expressions may be composed using the ``and`` and ``or``
 logical operators. Parentheses may be used as necessary to control operand
 precedence (with all comparison operations having a higher precedence).
 
+For example::
+
+    sys_platform == "ios" or sys_platform == "darwin"
+    sys_platform == "linux" and "SMP" in platform_version
+    sys_platform == "darwin" and platform_version >= "12"
+
 Python's comparison chaining (such as ``3.4 < python_version < 3.9``) is NOT
-supported in environment markers.
+supported in environment markers (such expressions must instead be written out
+as two separate comparisons joined by ``and``).
 
 User supplied constants
 '''''''''''''''''''''''

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -297,7 +297,7 @@ For example::
 
     sys_platform == "ios" or sys_platform == "darwin"
     sys_platform == "linux" and "SMP" in platform_version
-    sys_platform == "darwin" and platform_version >= "12"
+    sys_platform == "darwin" and platform_release >= "12"
 
 Python's comparison chaining (such as ``3.4 < python_version < 3.9``) is NOT
 supported in environment markers (such expressions must instead be written out

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -218,7 +218,7 @@ Environment marker fields are each defined as one of the following types:
   :ref:`version specifier <version-specifiers>`. Publishing tools SHOULD emit
   an error if that is not the case, but installation tools MAY fall back to
   treating the field as a string field.
-* ``Version | String``: the contents of the field are expected to be a valid 
+* ``Version | String``: the contents of the field are expected to be a valid
   :ref:`version specifier <version-specifiers>` on some platforms, but an
   opaque string on others. The specifics of this distinction are field dependent
   and whether or not tools actually make the distinction will be tool dependent.

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -663,7 +663,8 @@ History
   tool behaviour recommendations for publishing tools vs installation tools.
   This brought the nominal specification into line with the way tools actually
   work. [#marker_comparison_logic]_
-- January 2026: fix outdated references inadvertently retained from :pep:`508`
+- January 2026: fix outdated references to other documents that were
+  inadvertently retained from :pep:`508`
 
 
 References

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -248,12 +248,14 @@ The follow comparison operations are defined in the marker expression grammar:
 
 For ``String`` fields, ``==``, ``!=``, ``in``, and ``not in`` are defined as
 they are for Python strings (case sensitive, with no value normalization of any
-kind). The use of ``~=`` or ``===`` with string fields is
-explicitly discouraged, and publishing tools SHOULD emit an error, while locking
-and installation tools MAY instead interpret them as equivalent to ``==``. The
-use of ordered comparisons (``<``, ``<=``, ``>``, ``>=``) with string fields is
-explicitly discouraged (as it makes no semantic sense in the packaging context),
-and publishing tools SHOULD emit an error, while locking and installation tools
+kind). The use of ``~=`` or ``===`` with string fields is explicitly
+discouraged and publishing tools SHOULD emit an error, index servers MAY
+disallow uploads containing such environment markers, while locking and
+installation tools MAY instead interpret them as equivalent to ``==``. The use
+of ordered comparisons (``<``, ``<=``, ``>``, ``>=``) with string fields is
+explicitly discouraged (as it makes no semantic sense in the packaging context)
+and publishing tools SHOULD emit an error, index servers MAY disallow uploads
+containing such environment markers, while locking and installation tools
 SHOULD implement the following behavior:
 
 * treat ``>=`` and ``<=`` as equivalent to ``==``
@@ -261,7 +263,11 @@ SHOULD implement the following behavior:
 
 For ``Set of String`` fields, as there is no marker syntax for set literals,
 the only valid operations are ``in`` and ``not in`` comparisons with a user
-supplied string literal as the left operand.
+supplied string literal as the left operand. Publishing tools SHOULD emit an
+error if environment markers attempt to use any other comparison operations on
+these fields and index servers MAY disallow uploads containing such environment
+markers, while locking and installation tools SHOULD treat such operations as
+always being False.
 
 For ``Version`` fields, the comparison operations are defined by the
 :ref:`Version specifier specification <version-specifiers>` when either both
@@ -269,22 +275,27 @@ the marker field value and the user supplied constant can be parsed as valid
 version specifiers or the ``===`` arbitrary equivalence comparison operator
 is used. When an operator other than ``===`` is used, publishing tools SHOULD
 emit an error if the user supplied constant cannot be parsed as a valid version
-specifier, while locking and installation tools MAY either emit an error or else
+specifier, index servers MAY disallow uploads containing such environment
+markers, while locking and installation tools MAY either emit an error or else
 fall back to ``String`` field comparison logic if either the marker field value
 or the user supplied constant cannot be parsed as a valid version specifier.
 Note that ``in`` and ``not in`` containment checks are NOT valid for ``Version``
-fields and publishing tools SHOULD emit an error, while locking and installation
+fields and publishing tools SHOULD emit an error, index servers MAY disallow
+uploads containing such environment markers, while locking and installation
 tools MAY treat them as always being False.
 
 For ``Version | String`` fields, comparison operations are defined as they are
 for ``Version`` fields, while ``in`` and ``not in`` containment checks are
-defined as they are for ``String`` fields. However, there is no expectation
-that the parsing of the marker field value or the user supplied constant as a
-valid version will succeed, so tools MUST fall back to processing the field as
-a ``String`` field. Alternatively, tools MAY unconditionally treat such fields
-as ``String`` fields. Due to this potential for variation across clients,
-comparisons that rely on these fields being processed as ``Version`` fields
-SHOULD NOT be used in environment markers published to public index servers.
+defined as they are for ``String`` fields. However, there is no consistent
+cross-platform expectation that the parsing of the marker field value or the
+user supplied constant as a valid version will succeed, so tools SHOULD fall
+back to processing the field as a ``String`` field if parsing either value as a
+version fails. Tools MAY emit a warning if the field is expected to contain a
+valid version on a given platform but does not in fact do so. Tools SHOULD NOT
+unconditionally treat such fields as ``String`` fields, as doing so may give
+incorrect answers for environment markers that are appropriately scoped
+to the relevant platforms before performing a version based comparison.
+
 
 Composing marker expressions
 ''''''''''''''''''''''''''''
@@ -323,8 +334,13 @@ contain non-ASCII text that users wish to perform comparisons against.
 Unknown marker fields
 '''''''''''''''''''''
 
-References to unknown marker fields MUST raise an error rather than resulting
-in a comparison that evaluates to True or False.
+References to unknown marker fields SHOULD raise an error rather than resulting
+in a comparison that evaluates to True or False. This is so that attempted
+installations involving unknown marker fields result in a clear installation
+failure, rather than an apparently successful installation that then fails at
+runtime due to missing dependencies (if the unknown marker is treated as
+False) or a potentially cryptic installation failure of a dependency that is
+not valid for the current platform (if the unknown marker is treated as True)
 
 Variables whose value cannot be calculated on a given Python implementation
 should evaluate to ``0`` for ``Version`` fields, and an empty string for all
@@ -345,7 +361,7 @@ of the following marker fields:
    * - Marker
      - Python equivalent
      - Type
-     - Sample values
+     - Sample values & notes
    * - ``os_name``
      - :py:data:`os.name`
      - String
@@ -353,64 +369,75 @@ of the following marker fields:
    * - ``sys_platform``
      - :py:data:`sys.platform`
      - String
-     - ``linux``, ``linux2``, ``darwin``, ``java1.8.0_51`` (note that "linux"
-       is from Python3 and "linux2" from Python2)
+     - ``linux``, ``win32``, ``darwin``, ``java1.8.0_51``
+       (note that this is the most well defined field for use when declaring
+       platform specific dependencies)
    * - ``platform_machine``
      - :py:func:`platform.machine()`
      - String
-     - ``x86_64``
+     - ``x86_64``, ``aarch64``, ``AMD64``, ``arm64``
+       (note that this value is provided by the operating system, so the same
+       CPU architecture may use different strings on different platforms)
    * - ``platform_python_implementation``
      - :py:func:`platform.python_implementation()`
      - String
-     - ``CPython``, ``Jython``
+     - ``CPython``, ``PyPy``, ``Jython``
    * - ``platform_release``
      - :py:func:`platform.release()`
      - Version | String
      - ``3.14.1-x86_64-linode39``, ``14.5.0``, ``1.8.0_51``
+       (may be a valid version field, for example on macOS/darwin)
    * - ``platform_system``
      - :py:func:`platform.system()`
      - String
      - ``Linux``, ``Windows``, ``Java``
    * - ``platform_version``
      - :py:func:`platform.version()`
-     - String
+     - Version | String
      - ``#1 SMP Fri Apr 25 13:07:35 EDT 2014``
        ``Java HotSpot(TM) 64-Bit Server VM, 25.51-b03, Oracle Corporation``
        ``Darwin Kernel Version 14.5.0: Wed Jul 29 02:18:53 PDT 2015; root:xnu-2782.40.9~2/RELEASE_X86_64``
+       ``13``
+       (may be a valid version field, for example on iOS or Android)
    * - ``python_version``
      - ``'.'.join(platform.python_version_tuple()[:2])``
      - :ref:`Version <version-specifiers>`
-     - ``3.4``, ``2.7``
+     - ``3.9``, ``3.15``
    * - ``python_full_version``
      - :py:func:`platform.python_version()`
      - :ref:`Version <version-specifiers>`
-     - ``3.4.0``, ``3.5.0b1``
+     - ``3.10.12``, ``3.15.0a1``
    * - ``implementation_name``
      - :py:data:`sys.implementation.name <sys.implementation>`
      - String
-     - ``cpython``
+     - ``cpython``, ``pypy``
    * - ``implementation_version``
      - see definition below
      - :ref:`Version <version-specifiers>`
-     - ``3.4.0``, ``3.5.0b1``
+     - ``3.10.12``, ``7.3.17``
+       (examples are for CPython and PyPy respectively)
    * - ``extra``
      - Used to indicate optional dependencies in project dependency metadata.
        An error except when defined by the context interpreting the
-       specifier. Publishing tools SHOULD permit use of this field.
+       specifier.
      - Special (see below)
      - ``toml``
+       (publishing tools SHOULD permit use of this field)
    * - ``extras``
      - Used to indicate optional public dependencies in lock files. An error
        except when defined by the context interpreting the specifier.
-       Publishing tools SHOULD NOT permit use of this field.
      - Set of strings
      - ``{"toml"}``
+       (publishing tools SHOULD NOT permit use of this field and index servers
+       SHOULD NOT accept uploads containing such environment markers)
    * - ``dependency_groups``
      - Used to indicate optional project internal dependencies in lock files.
        An error except when defined by the context interpreting the
-       specifier. Publishing tools SHOULD NOT permit use of this field.
+       specifier.
      - Set of strings
      - ``{"test"}``
+       (publishing tools SHOULD NOT permit use of this field and index servers
+       SHOULD NOT accept uploads containing such environment markers)
 
 For backwards compatibility with older locking and installation tools, the
 ``extras`` and ``dependency_groups`` fields are currently only considered
@@ -426,13 +453,14 @@ predates the addition of ``Set of strings`` as a defined marker field type.
 Accordingly, for this field only, ``extra == "name"`` is equivalent to
 ``"name" in extras``, while ``extra != "name"`` is equivalent to
 ``"name" not in extras``. Other comparison operations on ``extra`` are not
-defined and publishing tools SHOULD emit an error, while locking and
-installation tools may evaluate them as False. Unlike the newer ``extras``
-field, this field SHOULD be accepted by both publishing tools and index
-servers. Marker evaluation environments intended for project dependency
-declarations will typically need to handle evaluation of ``extra`` field
-comparisons, while other evaluations of environment markers will not generally
-need to do so.
+defined and publishing tools SHOULD emit an error, index servers MAY disallow
+uploads containing such environment markers, while locking and
+installation tools SHOULD evaluate them as False. Unlike the newer ``extras``
+field, environment markers using this field SHOULD be accepted by both
+publishing tools and index servers. Marker evaluation environments intended
+for project dependency declarations will typically need to handle evaluation
+of ``extra`` field comparisons, while other evaluations of environment markers
+will not generally need to do so.
 
 The ``implementation_version`` marker variable is derived from
 :py:data:`sys.implementation.version <sys.implementation>`:

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -383,7 +383,7 @@ of the following marker fields:
    * - ``platform_python_implementation``
      - :py:func:`platform.python_implementation()`
      - String
-     - ``CPython``, ``PyPy``, ``Jython``
+     - ``CPython``, ``PyPy``
    * - ``platform_release``
      - :py:func:`platform.release()`
      - Version | String

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -334,13 +334,15 @@ contain non-ASCII text that users wish to perform comparisons against.
 Unknown marker fields
 '''''''''''''''''''''
 
-References to unknown marker fields SHOULD raise an error rather than resulting
-in a comparison that evaluates to True or False. This is so that attempted
-installations involving unknown marker fields result in a clear installation
-failure, rather than an apparently successful installation that then fails at
-runtime due to missing dependencies (if the unknown marker is treated as
-False) or a potentially cryptic installation failure of a dependency that is
-not valid for the current platform (if the unknown marker is treated as True)
+References to unknown marker fields SHOULD render a package version ineligible
+for installation or inclusion in a locked dependency tree rather than resulting
+in a comparison that evaluates to True or False. This is so that published
+package versions with unknown marker fields are either ignored when resolving
+dependencies or emit a descriptive installation failure, rather than producing
+an apparently successful installation that then fails at runtime due to missing
+dependencies (if the unknown marker is treated as False) or a potentially
+cryptic installation failure of a dependency that is not valid for the
+current platform (if the unknown marker is treated as True).
 
 Variables whose value cannot be calculated on a given Python implementation
 should evaluate to ``0`` for ``Version`` fields, and an empty string for all

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -442,27 +442,39 @@ of the following marker fields:
        SHOULD NOT accept uploads containing such environment markers)
 
 For backwards compatibility with older locking and installation tools, the
-``extras`` and ``dependency_groups`` fields are currently only considered
-valid in :ref:`lock files <lock-file-spec>` (where they allow consumers of the
-lock file to selectively install optional parts of the locked dependency tree).
-Publishing tools SHOULD emit an error if projects attempt to use them in their
-published metadata, and index servers SHOULD NOT accept uploads referencing
+``extras`` and ``dependency_groups`` fields are currently only valid for use in
+``packages.marker`` fields in :ref:`lock files <lock-file-spec>`. For these
+comparisons, the ``extras`` and ``dependency_groups`` sets used for the marker
+evaluation refer to the *currently selected* extras and dependency groups when
+installing from the lock file, not the full set of defined extras and dependency
+groups listed in the corresponding top level lock file fields. The interface
+for selecting which extras and dependency groups to install is tool dependent.
+Publishing tools SHOULD emit an error if projects attempt to reference the
+``extras`` or ``dependency_groups`` fields in their published dependency
+declaration metadata, and index servers SHOULD NOT accept uploads referencing
 these fields. Outside lock file processing, marker evaluation environments
 DO NOT need to define these fields.
 
 The ``extra`` field is also special, as it expects set-like behaviour, but
 predates the addition of ``Set of strings`` as a defined marker field type.
-Accordingly, for this field only, ``extra == "name"`` is equivalent to
-``"name" in extras``, while ``extra != "name"`` is equivalent to
-``"name" not in extras``. Other comparison operations on ``extra`` are not
-defined and publishing tools SHOULD emit an error, index servers MAY disallow
-uploads containing such environment markers, while locking and
-installation tools SHOULD evaluate them as False. Unlike the newer ``extras``
-field, environment markers using this field SHOULD be accepted by both
-publishing tools and index servers. Marker evaluation environments intended
-for project dependency declarations will typically need to handle evaluation
-of ``extra`` field comparisons, while other evaluations of environment markers
-will not generally need to do so.
+Accordingly, ``extra == "name"`` in a dependency declaration is similar to
+``"name" in extras``, while ``extra != "name"`` is similar to
+``"name" not in extras``. For dependency marker evaluations, the set of extra
+names used for these comparisons is the full set of requested extras for *that
+particular package*, whether requested directly in a top level dependency
+declaration, or indirectly in a transitive dependency declaration. Other
+comparison operations on ``extra`` are not defined and publishing tools SHOULD
+emit an error, index servers MAY disallow uploads containing such environment
+markers, while locking and installation tools SHOULD evaluate them as False.
+
+Unlike the newer ``extras`` field, environment markers using this field SHOULD
+be accepted by both publishing tools and index servers. Marker evaluation
+environments intended for project dependency declarations will typically need
+to handle evaluation of ``extra`` field comparisons, while other evaluations
+of environment markers will not generally need to do so. The legacy ``extra``
+comparison syntax is NOT permitted in lock file ``packages.marker`` fields,
+and installation tools SHOULD reject lock files containing such comparisons as
+invalid.
 
 The ``implementation_version`` marker variable is derived from
 :py:data:`sys.implementation.version <sys.implementation>`:

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -106,8 +106,7 @@ Within a value, readers must accept and ignore spaces (including multiple
 consecutive spaces) before or after the colon, between the object reference and
 the left square bracket, between the extra names and the square brackets and
 colons delimiting them, and after the right square bracket. The syntax for
-extras is formally specified as part of :pep:`508` (as ``extras``) and
-restrictions on values specified in :pep:`685`.
+extras is formally specified in :ref:`dependency-specifiers`.
 For tools writing the file, it is recommended only to insert a space between the
 object reference and the left square bracket.
 

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -165,6 +165,8 @@ History
 - October 2017: This specification was written to formalize the existing
   entry points feature of setuptools (discussion_).
 
+- January 2026: Replaced outdated direct references to :pep:`508` and
+  :pep:`685` with a reference to :ref:`dependency-specifiers`.
 
 
 .. _discussion: https://mail.python.org/pipermail/distutils-sig/2017-October/031585.html

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -672,4 +672,7 @@ History
 - October 2025: The ``import-names`` and ``import-namespaces`` keys were added
   through :pep:`794`.
 
+- January 2026: Replaced outdated direct reference to :pep:`508` with a
+  reference to :ref:`dependency-specifiers`.
+
 .. _TOML: https://toml.io

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -449,35 +449,56 @@ be ambiguous in the face of ``[project.scripts]`` and
 
 
 .. _pyproject-toml-dependencies:
-.. _pyproject-toml-optional-dependencies:
 
-``dependencies``/``optional-dependencies``
-------------------------------------------
+``dependencies``
+----------------
 
-- TOML_ type: Array of :ref:`dependency-specifiers` strings (``dependencies``),
-  and a table with values of arrays of :ref:`dependency-specifiers` strings
-  (``optional-dependencies``)
+- TOML_ type: Array of :ref:`dependency specifier <dependency-specifiers>`
+  strings (``dependencies``)
 - Corresponding :ref:`core metadata <core-metadata>` field:
-  :ref:`Requires-Dist <core-metadata-requires-dist>` and
-  :ref:`Provides-Extra <core-metadata-provides-extra>`
+  :ref:`Requires-Dist <core-metadata-requires-dist>`
 
-The (optional) dependencies of the project.
+``dependencies`` lists the expected dependencies of the project as an
+array of strings.
 
-For ``dependencies``, it is a key whose value is an array of strings.
 Each string represents a dependency of the project and MUST be
-formatted as a valid :ref:`dependency-specifiers` string.
+formatted as a valid :ref:`dependency specifier <dependency-specifiers>`.
+
 Each string maps directly to a
 :ref:`Requires-Dist <core-metadata-requires-dist>` entry.
 
-For ``optional-dependencies``, it is a table where each key specifies
-an extra and whose value is an array of strings. The strings of the
-arrays must be valid :ref:`dependency-specifiers` strings.
+Dependencies listed in this array are always considered
+for installation, but may still contain environment markers that cause them
+to be skipped in some environments.
+
+
+.. _pyproject-toml-optional-dependencies:
+
+``optional-dependencies``
+-------------------------
+
+- TOML_ type: table with string keys mapping to arrays of
+  :ref:`dependency specifier <dependency-specifiers>` strings (``optional-dependencies``)
+- Corresponding :ref:`core metadata <core-metadata>` fields:
+  :ref:`Requires-Dist <core-metadata-requires-dist>` and
+  :ref:`Provides-Extra <core-metadata-provides-extra>`
+
+``optional-dependencies`` is a table where each key specifies
+an extra and whose value is an array of strings using the same format as the
+``dependencies`` array (the strings in the
+arrays must be valid :ref:`dependency specifiers <dependency-specifiers>`).
+
 The keys MUST be valid values
 for :ref:`Provides-Extra <core-metadata-provides-extra>`. Each value
 in the array thus becomes a corresponding
 :ref:`Requires-Dist <core-metadata-requires-dist>` entry for the
 matching :ref:`Provides-Extra <core-metadata-provides-extra>`
 metadata.
+
+The optionality of these dependencies is recorded by modifying the environment
+marker clause on the related ``Requires-Dist`` entries to check the extra name.
+Optional dependencies are thus only considered for installation if installation
+if the associated extra name is requested.
 
 
 .. _pyproject-toml-import-names:

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -454,8 +454,8 @@ be ambiguous in the face of ``[project.scripts]`` and
 ``dependencies``/``optional-dependencies``
 ------------------------------------------
 
-- TOML_ type: Array of :pep:`508` strings (``dependencies``), and a
-  table with values of arrays of :pep:`508` strings
+- TOML_ type: Array of :ref:`dependency-specifiers` strings (``dependencies``),
+  and a table with values of arrays of :ref:`dependency-specifiers` strings
   (``optional-dependencies``)
 - Corresponding :ref:`core metadata <core-metadata>` field:
   :ref:`Requires-Dist <core-metadata-requires-dist>` and
@@ -465,12 +465,14 @@ The (optional) dependencies of the project.
 
 For ``dependencies``, it is a key whose value is an array of strings.
 Each string represents a dependency of the project and MUST be
-formatted as a valid :pep:`508` string. Each string maps directly to
-a :ref:`Requires-Dist <core-metadata-requires-dist>` entry.
+formatted as a valid :ref:`dependency-specifiers` string.
+Each string maps directly to a
+:ref:`Requires-Dist <core-metadata-requires-dist>` entry.
 
 For ``optional-dependencies``, it is a table where each key specifies
 an extra and whose value is an array of strings. The strings of the
-arrays must be valid :pep:`508` strings. The keys MUST be valid values
+arrays must be valid :ref:`dependency-specifiers` strings.
+The keys MUST be valid values
 for :ref:`Provides-Extra <core-metadata-provides-extra>`. Each value
 in the array thus becomes a corresponding
 :ref:`Requires-Dist <core-metadata-requires-dist>` entry for the


### PR DESCRIPTION
Preparation for the release of packaging 25.1 revealed multiple deficiencies in the specification of environment marker evaluation. Review of the proposed amendments to resolve those deficiencies highlighted multiple other problems, including some dating from the original PEP 508 specification:

* other pages still referencing PEP 508 instead of the living spec
* direct reference to PEP 685 instead of the core metadata spec
* the "extra" special case not being properly defined
* lacking guidance to tool developers regarding what should be considered errors to disallow entirely vs issues to work around

Inspired by the initial PR at #1971

discuss.python.org thread: https://discuss.python.org/t/spec-change-bugfix-dependency-specifiers-simplification-pep-508

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1988.org.readthedocs.build/en/1988/

<!-- readthedocs-preview python-packaging-user-guide end -->