### PR TITLE
Ignore linkcheck 403s from docutils.sourceforge.io

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -157,6 +157,9 @@ linkcheck_ignore = [
     r"https://typer\.tiangolo\.com/.*",
     r"https://www.npmjs.com/.*",
     r"https://docutils\.sourceforge\.io/.*",
+    # Temporarily ignored due to expired TLS cert.
+    # Ref: https://github.com/pypa/packaging.python.org/issues/1998
+    r"https://blog\.ganssle\.io/.*",
 ]
 linkcheck_retries = 5
 # Ignore anchors for common targets when we know they likely won't be found


### PR DESCRIPTION
SourceForge appears to be sending HTTP 403s to the linkchecker, despite the links working just fine in a browser.

Unblocks #1996.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1997.org.readthedocs.build/en/1997/

<!-- readthedocs-preview python-packaging-user-guide end -->