### PR TITLE
Add project table to classifier example

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -413,6 +413,7 @@ A list of PyPI classifiers that apply to your project. Check the
 
 .. code-block:: toml
 
+    [project]
     classifiers = [
       # How mature is this project? Common values are
       #   3 - Alpha


### PR DESCRIPTION
Like in the other examples

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2006.org.readthedocs.build/en/2006/

<!-- readthedocs-preview python-packaging-user-guide end -->