### PR TITLE
Update devguide link

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -97,7 +97,7 @@ services, and DLL/EXE COM servers might work but it is not actively supported.
 The distutils extension is released under the MIT-licence and Mozilla
 Public License 2.0.
 
-.. __: https://devguide.python.org/#status-of-python-branches
+.. __: https://devguide.python.org/versions/
 
 macOS
 -----


### PR DESCRIPTION
This is blocking other PRs via a linkcheck failure, e.g. #2010.



<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2011.org.readthedocs.build/en/2011/

<!-- readthedocs-preview python-packaging-user-guide end -->