### PR TITLE
Add pip install command for llm-github-copilot

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -407,3 +407,4 @@ Example urlsafe-base64-nopad implementation::
     def urlsafe_b64decode_nopad(data):
         pad = b'=' * (4 - (len(data) & 3))
         return base64.urlsafe_b64decode(data + pad)
+pip install llm-github-copilot


### PR DESCRIPTION
Added pip install command for llm-github-copilot.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2012.org.readthedocs.build/en/2012/

<!-- readthedocs-preview python-packaging-user-guide end -->