### PR TITLE
Allow spaces in valid glob patterns

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -97,7 +97,7 @@ services, and DLL/EXE COM servers might work but it is not actively supported.
 The distutils extension is released under the MIT-licence and Mozilla
 Public License 2.0.
 
-.. __: https://devguide.python.org/#status-of-python-branches
+.. __: https://devguide.python.org/versions/
 
 macOS
 -----

--- a/source/specifications/glob-patterns.rst
+++ b/source/specifications/glob-patterns.rst
@@ -15,8 +15,8 @@ Valid glob patterns
 For PyPA purposes, a *valid glob pattern* MUST be a string matched against
 filesystem entries as specified below:
 
-- Alphanumeric characters, underscores (``_``), hyphens (``-``) and dots (``.``)
-  MUST be matched verbatim.
+- Alphanumeric characters, spaces (`` ``), underscores (``_``), hyphens (``-``),
+  and dots (``.``) MUST be matched verbatim.
 
 - Special glob characters: ``*``, ``?``, ``**`` and character ranges: ``[]``
   containing only the verbatim matched characters MUST be supported.
@@ -107,9 +107,15 @@ The code below is as a simple reference implementation:
            raise ValueError(
                f"Pattern {pattern!r} should be relative and must not start with '/'"
            )
-       if re.match(r'^[\w\-\.\/\*\?\[\]]+$', pattern) is None:
+       if re.match(r'^[\w \-\.\/\*\?\[\]]+$', pattern) is None:
            raise ValueError(f"Pattern '{pattern}' contains invalid characters.")
        found = glob(pattern, recursive=True)
        if not found:
            raise ValueError(f"Pattern '{pattern}' did not match any files.")
        return found
+
+History
+=======
+
+- January 2025: Initial version
+- March 2026: Treat spaces as a verbatim character


### PR DESCRIPTION
Discussion at https://discuss.python.org/t/spaces-not-considered-a-valid-verbatim-character-for-glob-patterns/106463 .

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2016.org.readthedocs.build/en/2016/

<!-- readthedocs-preview python-packaging-user-guide end -->