### PR TITLE
Clarify file name precedence for archive, sdist, and wheel specifications in pylock.toml

### DIFF
--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -62,9 +62,8 @@ of many continuous-integration systems. There are two hosted services which
 when used in conjunction provide automated testing across Linux, Mac and
 Windows:
 
-  - `Travis CI <https://travis-ci.com>`_ provides both a Linux and a macOS
-    environment. The Linux environment is Ubuntu 12.04 LTS Server Edition 64 bit
-    while the macOS is 10.9.2 at the time of writing.
+  - `GitHub Actions <https://docs.github.com/en/actions>`_ provides Windows,
+    Linux and a macOS environments.
   - `Appveyor <https://www.appveyor.com/>`_ provides a Windows environment
     (Windows Server 2012).
 
@@ -76,7 +75,7 @@ Windows:
     TODO How do we keep the Travis Linux and macOS versions up-to-date in this
     document?
 
-Both `Travis CI`_ and Appveyor_ require a `YAML
+Both `GitHub Actions`_ and Appveyor_ require a `YAML
 <https://yaml.org>`_-formatted file as specification for the instructions
 for testing. If any tests fail, the output log for that specific configuration
 can be inspected.

--- a/source/guides/supporting-windows-using-appveyor.rst
+++ b/source/guides/supporting-windows-using-appveyor.rst
@@ -20,12 +20,6 @@ Many projects are developed on Unix by default, and providing Windows support
 can be a challenge, because setting up a suitable Windows test environment is
 non-trivial, and may require buying software licenses.
 
-The Appveyor service is a continuous integration service, much like the
-better-known `GitHub Actions`_ service that is commonly used for testing by projects
-hosted on `GitHub`_. However, unlike Travis, the build workers on Appveyor are
-Windows hosts and have the necessary compilers installed to build Python
-extensions.
-
 Windows users typically do not have access to a C compiler, and therefore are
 reliant on projects that use C extensions distributing binary wheels on PyPI in
 order for the distribution to be installable via ``python -m pip install <dist>``. By
@@ -46,8 +40,7 @@ your project is hosted on one of those two services, setting up Appveyor
 integration is straightforward.
 
 Once you have set up your Appveyor account and added your project, Appveyor will
-automatically build your project each time a commit occurs. This behaviour will
-be familiar to users of Travis.
+automatically build your project each time a commit occurs.
 
 Adding Appveyor support to your project
 =======================================
@@ -179,7 +172,7 @@ other CI systems).
 
 2. When used interactively, ``tox`` allows you to run your tests against multiple
    environments (often, this means multiple Python versions). This feature is not as
-   useful in a CI environment like Travis or Appveyor, where all tests are run in
+   useful in a CI environment like Appveyor, where all tests are run in
    isolated environments for each configuration. As a result, projects often supply
    an argument ``-e ENVNAME`` to ``tox`` to specify which environment to use (there
    are default environments for most versions of Python).

--- a/source/guides/supporting-windows-using-appveyor.rst
+++ b/source/guides/supporting-windows-using-appveyor.rst
@@ -21,7 +21,7 @@ can be a challenge, because setting up a suitable Windows test environment is
 non-trivial, and may require buying software licenses.
 
 The Appveyor service is a continuous integration service, much like the
-better-known `Travis`_ service that is commonly used for testing by projects
+better-known `GitHub Actions`_ service that is commonly used for testing by projects
 hosted on `GitHub`_. However, unlike Travis, the build workers on Appveyor are
 Windows hosts and have the necessary compilers installed to build Python
 extensions.
@@ -237,6 +237,6 @@ For reference, the SDK setup support script is listed here:
    :linenos:
 
 .. _Appveyor: https://www.appveyor.com/
-.. _Travis: https://travis-ci.com/
 .. _GitHub: https://github.com
+.. _GitHub Actions: https://docs.github.com/en/actions
 .. _Bitbucket: https://bitbucket.org/

--- a/source/specifications/pylock-toml.rst
+++ b/source/specifications/pylock-toml.rst
@@ -449,7 +449,12 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 ``packages.archive.url``
 ''''''''''''''''''''''''
 
-See :ref:`pylock-packages-vcs-url`.
+- **Type**: string
+- **Required?**: if :ref:`pylock-packages-archive-path` is not specified
+- **Inspiration**: :ref:`direct-url-data-structure-archive`
+- The URL_ to the archive.
+- If :ref:`pylock-packages-archive-path` is also specified, the filename as
+  specified by this key takes precedence.
 
 
 .. _pylock-packages-archive-path:
@@ -457,7 +462,13 @@ See :ref:`pylock-packages-vcs-url`.
 ``packages.archive.path``
 '''''''''''''''''''''''''
 
-See :ref:`pylock-packages-vcs-path`.
+- **Type**: string
+- **Required?**: if :ref:`pylock-packages-archive-url` is not specified
+- **Inspiration**: :ref:`direct-url-data-structure-archive`
+- The path to the archive.
+- If a relative path is used it MUST be relative to the location of this file.
+- If the path is relative it MAY use POSIX-style path separators explicitly
+  for portability.
 
 
 .. _pylock-packages-archive-size:
@@ -554,6 +565,8 @@ See :ref:`pylock-packages-vcs-subdirectory`.
   the same value
 - **Inspiration**: PDM_, Poetry_, uv_
 - The file name of the :ref:`source-distribution-format-sdist` file.
+- If specified, this key's value takes precedence over the file name found in
+  either :ref:`pylock-packages-sdist-url` or :ref:`pylock-packages-sdist-path`.
 
 
 .. _pylock-packages-sdist-upload-time:
@@ -623,6 +636,8 @@ See :ref:`pylock-packages-archive-hashes`.
   the same value
 - **Inspiration**: PDM_, Poetry_, uv_
 - The file name of the :ref:`binary-distribution-format` file.
+- If specified, this key's value takes precedence over the file name found in
+  either :ref:`pylock-packages-sdist-url` or :ref:`pylock-packages-sdist-path`.
 
 
 .. _pylock-packages-wheels-upload-time:
@@ -826,6 +841,7 @@ History
 -------
 
 - April 2025: Initial version, approved via :pep:`751`.
+- March 2026: Clarify file name precedence for archives, sdists, and wheels.
 
 
 .. _Content-Length: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length

--- a/source/specifications/pylock-toml.rst
+++ b/source/specifications/pylock-toml.rst
@@ -637,7 +637,7 @@ See :ref:`pylock-packages-archive-hashes`.
 - **Inspiration**: PDM_, Poetry_, uv_
 - The file name of the :ref:`binary-distribution-format` file.
 - If specified, this key's value takes precedence over the file name found in
-  either :ref:`pylock-packages-sdist-url` or :ref:`pylock-packages-sdist-path`.
+  either :ref:`pylock-packages-wheels-url` or :ref:`pylock-packages-wheels-path`.
 
 
 .. _pylock-packages-wheels-upload-time:

--- a/source/specifications/pylock-toml.rst
+++ b/source/specifications/pylock-toml.rst
@@ -453,8 +453,6 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 - **Required?**: if :ref:`pylock-packages-archive-path` is not specified
 - **Inspiration**: :ref:`direct-url-data-structure-archive`
 - The URL_ to the archive.
-- If :ref:`pylock-packages-archive-path` is also specified, the filename as
-  specified by this key takes precedence.
 
 
 .. _pylock-packages-archive-path:
@@ -469,6 +467,8 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 - If a relative path is used it MUST be relative to the location of this file.
 - If the path is relative it MAY use POSIX-style path separators explicitly
   for portability.
+- If :ref:`pylock-packages-archive-url` is also specified, the filename as
+  specified by this key takes precedence.
 
 
 .. _pylock-packages-archive-size:


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2018.org.readthedocs.build/en/2018/

<!-- readthedocs-preview python-packaging-user-guide end -->