### PR TITLE
Improve pylock requires-python exemple

### DIFF
--- a/source/specifications/pylock-toml/pylock.example.toml
+++ b/source/specifications/pylock-toml/pylock.example.toml
@@ -1,6 +1,6 @@
 lock-version = '1.0'
 environments = ["sys_platform == 'win32'", "sys_platform == 'linux'"]
-requires-python = '== 3.12'
+requires-python = '== 3.12.*'
 created-by = 'mousebender'
 
 [[packages]]


### PR DESCRIPTION
Since `requires-python` is a version specifier, `==3.12` actually means `==3.12.0` which is not how one would intuitively interpret it.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2025.org.readthedocs.build/en/2025/

<!-- readthedocs-preview python-packaging-user-guide end -->