### PR TITLE
Remove kivy.org from linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -160,6 +160,8 @@ linkcheck_ignore = [
     # Temporarily ignored due to expired TLS cert.
     # Ref: https://github.com/pypa/packaging.python.org/issues/1998
     r"https://blog\.ganssle\.io/.*",
+    # Temporarily ignored due to expired TLS cert.
+    r"https://kivy.org/.*",
 ]
 linkcheck_retries = 2
 linkcheck_timeout = 30


### PR DESCRIPTION
The cert for kivy.org is expired, failing the mandatory linkcheck.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2034.org.readthedocs.build/en/2034/

<!-- readthedocs-preview python-packaging-user-guide end -->