### PR TITLE
Warn about artifact action behavior for wheel matrices

### DIFF
--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -107,6 +107,15 @@ build the distribution packages.
 First, we'll define the job for building the dist packages of
 your project and storing them for later use:
 
+.. warning::
+
+   This artifact configuration is intended for a single build job that uploads
+   one source distribution and one wheel. If you adapt it for several
+   platform-specific wheel jobs, use separate artifact names for each job and
+   adjust the download step accordingly. The v4+ artifact actions do not support
+   multiple jobs uploading to the same artifact; see
+   `actions/upload-artifact#472`_.
+
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-pypi.yml
    :language: yaml
    :start-at: jobs:
@@ -228,6 +237,8 @@ sure that your release pipeline remains healthy!
    https://github.com/actions/download-artifact
 .. _`upload-artifact`:
    https://github.com/actions/upload-artifact
+.. _`actions/upload-artifact#472`:
+   https://github.com/actions/upload-artifact/issues/472
 .. _Secrets:
    https://docs.github.com/en/actions/reference/encrypted-secrets
 .. _Trusted Publishing: https://docs.pypi.org/trusted-publishers/

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -111,7 +111,8 @@ your project and storing them for later use:
 
    If you adapt this workflow to build multiple platform-specific wheels, use
    uniquely named artifacts for each build job and adjust the download step
-   accordingly.
+   accordingly. The `cibuildwheel GitHub Actions examples`_ show a fuller
+   wheel matrix layout.
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-pypi.yml
    :language: yaml
@@ -237,3 +238,5 @@ sure that your release pipeline remains healthy!
 .. _Secrets:
    https://docs.github.com/en/actions/reference/encrypted-secrets
 .. _Trusted Publishing: https://docs.pypi.org/trusted-publishers/
+.. _`cibuildwheel GitHub Actions examples`:
+   https://cibuildwheel.pypa.io/en/latest/ci-services/#github-actions

--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -107,14 +107,11 @@ build the distribution packages.
 First, we'll define the job for building the dist packages of
 your project and storing them for later use:
 
-.. warning::
+.. tip::
 
-   This artifact configuration is intended for a single build job that uploads
-   one source distribution and one wheel. If you adapt it for several
-   platform-specific wheel jobs, use separate artifact names for each job and
-   adjust the download step accordingly. The v4+ artifact actions do not support
-   multiple jobs uploading to the same artifact; see
-   `actions/upload-artifact#472`_.
+   If you adapt this workflow to build multiple platform-specific wheels, use
+   uniquely named artifacts for each build job and adjust the download step
+   accordingly.
 
 .. literalinclude:: github-actions-ci-cd-sample/publish-to-pypi.yml
    :language: yaml
@@ -237,8 +234,6 @@ sure that your release pipeline remains healthy!
    https://github.com/actions/download-artifact
 .. _`upload-artifact`:
    https://github.com/actions/upload-artifact
-.. _`actions/upload-artifact#472`:
-   https://github.com/actions/upload-artifact/issues/472
 .. _Secrets:
    https://docs.github.com/en/actions/reference/encrypted-secrets
 .. _Trusted Publishing: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
Adds a warning before the artifact upload/download workflow example for people adapting the guide to several platform-specific wheel jobs.

The sample now uses current artifact actions rather than the older v3 versions mentioned in the issue, so this keeps the caution framed around the still-relevant v4+ behavior: don't have multiple wheel jobs upload to the same artifact name; give each job its own artifact and adjust downloads accordingly.

Checks:
- git diff --check
- uv run --with pre-commit pre-commit run --files source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
- uv run --with nox nox -s build

Fixes #1454


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2040.org.readthedocs.build/en/2040/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#checking-out-the-project-and-building-distributions

<!-- readthedocs-preview python-packaging-user-guide end -->