### PR TITLE
Add PyPI extlink alias

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ sphinx==7.2.6
 sphinx-autobuild==2021.3.14
 sphinx-inline-tabs==2023.4.21
 sphinx-copybutton==0.5.2
+sphinx-issues==5.0.1
 sphinx-toolbox==3.5.0
 sphinx-jsonschema==1.19.1

--- a/source/conf.py
+++ b/source/conf.py
@@ -28,6 +28,7 @@ root_doc = "index"
 
 extensions = [
     "pug_sphinx_extensions",
+    "sphinx_issues",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
@@ -194,13 +195,12 @@ github_repo_issues_url = f"{github_url}/{github_repo_slug}/issues"
 github_sponsors_url = f"{github_url}/sponsors"
 
 extlinks = {
-    "issue": (f"{github_repo_issues_url}/%s", "#%s"),
-    "pr": (f"{github_repo_url}/pull/%s", "PR #%s"),
-    "commit": (f"{github_repo_url}/commit/%s", "%s"),
     "gh": (f"{github_url}/%s", "GitHub: %s"),
-    "pypi": ("https://pypi.org/project/%s", "%s"),
-    "user": (f"{github_sponsors_url}/%s", "@%s"),
 }
+
+# -- Options for sphinx_issues --------------------------------------------------------
+
+issues_default_group_project = github_repo_slug
 
 # -- Options for intersphinx ----------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration

--- a/source/conf.py
+++ b/source/conf.py
@@ -198,6 +198,7 @@ extlinks = {
     "pr": (f"{github_repo_url}/pull/%s", "PR #%s"),
     "commit": (f"{github_repo_url}/commit/%s", "%s"),
     "gh": (f"{github_url}/%s", "GitHub: %s"),
+    "pypi": ("https://pypi.org/project/%s", "%s"),
     "user": (f"{github_sponsors_url}/%s", "@%s"),
 }
 

--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -57,7 +57,7 @@ Windows
 Pynsist
 ^^^^^^^
 
-`Pynsist <https://pypi.org/project/pynsist>`__ is a tool that bundles Python
+:pypi:`Pynsist <pynsist>` is a tool that bundles Python
 programs together with the Python-interpreter into a single installer based on
 NSIS. In most cases, packaging only requires the user to choose a version of
 the Python-interpreter and declare the dependencies of the program. The tool
@@ -88,7 +88,7 @@ Windows
 py2exe
 ^^^^^^
 
-`py2exe <https://pypi.org/project/py2exe/>`__ is a distutils extension which
+:pypi:`py2exe` is a distutils extension which
 allows to build standalone Windows executable programs (32-bit and 64-bit)
 from Python scripts. Python versions included in the official development
 cycle are supported (refers to `Status of Python branches`__). py2exe can
@@ -105,7 +105,7 @@ macOS
 py2app
 ^^^^^^
 
-`py2app <https://pypi.org/project/py2app/>`__ is a Python setuptools
+:pypi:`py2app` is a Python setuptools
 command which will allow you to make standalone macOS application
 bundles and plugins from Python scripts. Note that py2app MUST be used
 on macOS to build applications, it cannot create Mac applications on other
@@ -117,7 +117,7 @@ Unix (including Linux and macOS)
 pex
 ^^^
 
-`pex <https://pypi.org/project/pex/>`__ is  a library for generating .pex
+:pypi:`pex` is  a library for generating .pex
 (Python EXecutable) files which are executable Python environments in the
 spirit of virtualenvs. pex is an expansion upon the ideas outlined in :pep:`441`
 and makes the deployment of Python applications as simple as cp. pex files may

--- a/source/discussions/distribution-package-vs-import-package.rst
+++ b/source/discussions/distribution-package-vs-import-package.rst
@@ -57,7 +57,7 @@ install the PyPI package ``foo`` if you see ``import foo``; this may install an
 unintended, and potentially even malicious package.)
 
 A distribution package could provide an import package with a different
-name. An example of this is the popular Pillow_ library for image
+name. An example of this is the popular :pypi:`Pillow` library for image
 processing. Its distribution package name is ``Pillow``, but it provides
 the import package ``PIL``. This is for historical reasons: Pillow
 started as a fork of the PIL library, thus it kept the import name
@@ -72,7 +72,7 @@ Import packages with the same name can be provided by several
 distribution packages. Again, forks are a common reason for this.
 
 Conversely, a distribution package can provide several import packages,
-although this is less common. An example is the attrs_ distribution
+although this is less common. An example is the :pypi:`attrs` distribution
 package, which provides both an ``attrs`` import package with a newer
 API, and an ``attr`` import package with an older but supported API.
 
@@ -106,5 +106,3 @@ precise rules are given in the :ref:`name normalization specification
 
 .. _distro: https://en.wikipedia.org/wiki/Linux_distribution
 .. _PyPI: https://pypi.org
-.. _Pillow: https://pypi.org/project/Pillow
-.. _attrs: https://pypi.org/project/attrs

--- a/source/discussions/downstream-packaging.rst
+++ b/source/discussions/downstream-packaging.rst
@@ -126,8 +126,8 @@ in their installed packages. This has the added advantage of permitting users to
 run tests after installing them, for example to check for regressions
 after upgrading a dependency. Yet another approach is to split tests or test
 data into a separate Python package. Such an approach was taken by
-the cryptography_ project, with the large test vectors being split
-to cryptography-vectors_ package.
+the :pypi:`cryptography` project, with the large test vectors being split
+to :pypi:`cryptography-vectors` package.
 
 A good idea is to use your source distribution in the release workflow.
 For example, the :ref:`build` tool does exactly that — it first builds a source
@@ -351,9 +351,9 @@ Some specific suggestions are:
   of the installed package!
 
 - Make the test suite work offline. Mock network interactions, using
-  packages such as responses_ or vcrpy_. If that is not possible, make it
+  packages such as :pypi:`responses` or :pypi:`vcrpy`. If that is not possible, make it
   possible to easily disable the tests using Internet access, e.g. via a pytest_
-  marker. Use pytest-socket_ to verify that your tests work offline. This
+  marker. Use :pypi:`pytest-socket` to verify that your tests work offline. This
   often makes your own test workflows faster and more reliable as well.
 
 - Make your tests work without a specialized setup, or perform the necessary
@@ -389,14 +389,14 @@ Some specific suggestions are:
 
 - If your test suite takes significant time to run, support testing
   in parallel. Downstreams often maintain a large number of packages,
-  and testing them all takes a lot of time. Using pytest-xdist_ can help them
+  and testing them all takes a lot of time. Using :pypi:`pytest-xdist` can help them
   avoid bottlenecks.
 
 - Ideally, support running your test suite via ``pytest``. pytest_ has many
   command-line arguments that are truly helpful to downstreams, such as
   the ability to conveniently deselect tests, rerun flaky tests
-  (via pytest-rerunfailures_), add a timeout to prevent tests from hanging
-  (via pytest-timeout_) or run tests in parallel (via pytest-xdist_).
+  (via :pypi:`pytest-rerunfailures`), add a timeout to prevent tests from hanging
+  (via :pypi:`pytest-timeout`) or run tests in parallel (via :pypi:`pytest-xdist`).
   Note that test suites don't need to be *written* with ``pytest`` to be
   *executed* with ``pytest``: ``pytest`` is able to find and execute almost
   all test cases that are compatible with the standard library's ``unittest``
@@ -468,14 +468,6 @@ as well. Some specific suggestions are:
   to make it easier to cherry-pick changes to earlier releases when necessary.
 
 
-.. _responses: https://pypi.org/project/responses/
-.. _vcrpy: https://pypi.org/project/vcrpy/
-.. _pytest-socket: https://pypi.org/project/pytest-socket/
-.. _pytest-xdist: https://pypi.org/project/pytest-xdist/
 .. _pytest: https://pytest.org/
-.. _pytest-rerunfailures: https://pypi.org/project/pytest-rerunfailures/
-.. _pytest-timeout: https://pypi.org/project/pytest-timeout/
 .. _Django: https://www.djangoproject.com/
 .. _NumPy: https://numpy.org/
-.. _cryptography: https://pypi.org/project/cryptography/
-.. _cryptography-vectors: https://pypi.org/project/cryptography-vectors/

--- a/source/flow.rst
+++ b/source/flow.rst
@@ -68,11 +68,8 @@ format`_.
 At a minimum, the :file:`pyproject.toml` file needs a ``[build-system]`` table
 specifying your build tool. There are many build tools available, including
 but not limited to :ref:`flit`, :ref:`hatch`, :ref:`pdm`, :ref:`poetry`,
-:ref:`setuptools`, `trampolim`_, and `whey`_. Each tool's documentation will
+:ref:`setuptools`, :pypi:`trampolim`, and :pypi:`whey`. Each tool's documentation will
 show what to put in the ``[build-system]`` table.
-
-.. _trampolim: https://pypi.org/project/trampolim/
-.. _whey: https://pypi.org/project/whey/
 
 For example, here is a table for using :ref:`hatch`:
 

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -19,7 +19,7 @@ Using naming convention
 
 If all of the plugins for your application follow the same naming convention,
 you can use :func:`pkgutil.iter_modules` to discover all of the top-level
-modules that match the naming convention. For example, `Flask`_ uses the
+modules that match the naming convention. For example, :pypi:`Flask` uses the
 naming convention ``flask_{plugin_name}``. If you wanted to automatically
 discover all of the Flask plugins installed:
 
@@ -35,7 +35,7 @@ discover all of the Flask plugins installed:
         if name.startswith('flask_')
     }
 
-If you had both the `Flask-SQLAlchemy`_ and `Flask-Talisman`_ plugins installed
+If you had both the :pypi:`Flask-SQLAlchemy` and :pypi:`Flask-Talisman <flask-talisman>` plugins installed
 then ``discovered_plugins`` would be:
 
 .. code-block:: python
@@ -48,11 +48,6 @@ then ``discovered_plugins`` would be:
 Using naming convention for plugins also allows you to query
 the Python Package Index's :ref:`simple repository API <simple-repository-api>`
 for all packages that conform to your naming convention.
-
-.. _Flask: https://pypi.org/project/Flask/
-.. _Flask-SQLAlchemy: https://pypi.org/project/Flask-SQLAlchemy/
-.. _Flask-Talisman: https://pypi.org/project/flask-talisman
-
 
 Using namespace packages
 ========================

--- a/source/guides/dropping-older-python-versions.rst
+++ b/source/guides/dropping-older-python-versions.rst
@@ -129,10 +129,9 @@ Each version compatibility change should have its own release.
 
 .. tip::
 
-        When dropping a Python version, it might also be rewarding to upgrade the project's code syntax generally, apart from updating the versions used in visible places (like the testing environment). Tools like pyupgrade_ or `ruff <https://docs.astral.sh/ruff/linter/>`_ can automate some of this work.
+        When dropping a Python version, it might also be rewarding to upgrade the project's code syntax generally, apart from updating the versions used in visible places (like the testing environment). Tools like :pypi:`pyupgrade` or `ruff <https://docs.astral.sh/ruff/linter/>`_ can automate some of this work.
 
 .. _discourse-discussion: https://discuss.python.org/t/requires-python-upper-limits/12663
-.. _pyupgrade: https://pypi.org/project/pyupgrade/
 .. _dependency-management: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#python-requirement
 
 .. [#] Support for the Metadata 1.2 specification has been added in Pip 9.0.

--- a/source/guides/installing-using-pip-and-virtual-environments.rst
+++ b/source/guides/installing-using-pip-and-virtual-environments.rst
@@ -201,7 +201,7 @@ Install a package
 ~~~~~~~~~~~~~~~~~
 
 For example, let's install the
-`Requests`_ library from the :term:`Python Package Index (PyPI)`:
+:pypi:`Requests <requests>` library from the :term:`Python Package Index (PyPI)`:
 
 .. tab:: Unix/macOS
 
@@ -231,9 +231,6 @@ pip should download requests and all of its dependencies and install them:
       Using cached idna-2.6-py2.py3-none-any.whl
     Installing collected packages: chardet, urllib3, certifi, idna, requests
     Successfully installed certifi-2017.7.27.1 chardet-3.0.4 idna-2.6 requests-2.18.4 urllib3-1.22
-
-.. _Requests: https://pypi.org/project/requests/
-
 
 Install a specific package version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -86,18 +86,18 @@ with a single-source strategy, there are a number of options.
 Tools for single-source Python packages
 ----------------------------------------
 
-`six <https://pypi.org/project/six/>`_ is a tool developed by Benjamin Peterson
-for wrapping over the differences between Python 2 and Python 3. The six_
+:pypi:`six` is a tool developed by Benjamin Peterson
+for wrapping over the differences between Python 2 and Python 3. The :pypi:`six`
 package has enjoyed widespread use and may be regarded as a reliable way to
 write a single-source Python module that can be use in both Python 2 and 3.
-The six_ module can be used from as early as Python 2.5. A tool called
-`modernize <https://pypi.org/project/modernize>`_, developed by Armin
+The :pypi:`six` module can be used from as early as Python 2.5. A tool called
+:pypi:`modernize`, developed by Armin
 Ronacher, can be used to automatically apply the code modifications provided
-by six_.
+by :pypi:`six`.
 
-Similar to six_, `python-future <http://python-future.org/overview.html>`_ is
+Similar to :pypi:`six`, `python-future <http://python-future.org/overview.html>`_ is
 a package that provides a compatibility layer between Python 2 and Python 3
-source code; however, unlike six_, this package aims to provide
+source code; however, unlike :pypi:`six`, this package aims to provide
 interoperability between Python 2 and Python 3 with a language syntax that
 matches one of the two Python versions: one may
 use
@@ -107,12 +107,12 @@ use
 
 Because of the bi-directionality, python-future_ offers a pathway to
 converting a Python 2 package to Python 3 syntax module-by-module. However, in
-contrast to six_, python-future_ is supported only from Python 2.6. Similar to
-modernize_ for six_, python-future_ comes with two scripts called ``futurize``
+contrast to :pypi:`six`, python-future_ is supported only from Python 2.6. Similar to
+:pypi:`modernize` for :pypi:`six`, python-future_ comes with two scripts called ``futurize``
 and ``pasteurize`` that can be applied to either a Python 2 module or a Python
 3 module respectively.
 
-Use of six_ or python-future_ adds an additional runtime dependency to your
+Use of :pypi:`six` or python-future_ adds an additional runtime dependency to your
 package: with python-future_, the ``futurize`` script can be called with the
 ``--stage1`` option to apply only the changes that Python 2.6+ already
 provides for forward-compatibility to Python 3. Any remaining compatibility

--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -74,11 +74,11 @@ in alphabetical order:
 - :doc:`Flit-core <flit:pyproject_toml>` -- developed with but separate from :ref:`Flit`.
   A minimal and opinionated build backend. It does not support plugins.
 
-- Hatchling_ -- developed with but separate from :ref:`Hatch`. Supports plugins.
+- :pypi:`Hatchling <hatchling>` -- developed with but separate from :ref:`Hatch`. Supports plugins.
 
 - PDM-backend_ -- developed with but separate from :ref:`PDM`. Supports plugins.
 
-- Poetry-core_ -- developed with but separate from :ref:`Poetry`. Supports
+- :pypi:`Poetry-core <poetry-core>` -- developed with but separate from :ref:`Poetry`. Supports
   plugins.
 
   Unlike other backends on this list, Poetry-core does not support the standard
@@ -185,6 +185,4 @@ alphabetical order:
 - :doc:`tox <tox:index>`.
 
 
-.. _hatchling: https://pypi.org/project/hatchling/
 .. _pdm-backend: https://backend.pdm-project.org
-.. _poetry-core: https://pypi.org/project/poetry-core/

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -255,7 +255,7 @@ an email address.
 ---------------
 
 This should be a one-line description of your project, to show as the "headline"
-of your project page on PyPI (`example <pypi-pip_>`_), and other places such as
+of your project page on PyPI (:pypi:`example <pip>`), and other places such as
 lists of search results (`example <pypi-search-pip_>`_).
 
 .. code-block:: toml
@@ -585,7 +585,6 @@ A full example
 .. _gfm: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 .. _setuptools: https://setuptools.pypa.io
 .. _poetry: https://python-poetry.org
-.. _pypi-pip: https://pypi.org/project/pip
 .. _pypi-search-pip: https://pypi.org/search?q=pip
 .. _classifier-list: https://pypi.org/classifiers
 .. _requires-python-blog-post: https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -21,7 +21,7 @@ bandersnatch
 `Docs <https://bandersnatch.readthedocs.io>`__ |
 `Issues <https://github.com/pypa/bandersnatch/issues>`__ |
 `GitHub <https://github.com/pypa/bandersnatch>`__ |
-`PyPI <https://pypi.org/project/bandersnatch>`__
+:pypi:`PyPI <bandersnatch>`
 
 ``bandersnatch`` is a PyPI mirroring client designed to efficiently
 create a complete mirror of the contents of PyPI. Organizations thus
@@ -39,7 +39,7 @@ build
 :any:`Docs <build:index>` |
 `Issues <https://github.com/pypa/build/issues>`__ |
 `GitHub <https://github.com/pypa/build>`__ |
-`PyPI <https://pypi.org/project/build>`__
+:pypi:`PyPI <build>`
 
 ``build`` is a :pep:`517` compatible Python package builder. It provides a CLI to
 build packages, as well as a Python API.
@@ -53,7 +53,7 @@ cibuildwheel
 `Docs <https://cibuildwheel.readthedocs.io/>`__ |
 `Issues <https://github.com/pypa/cibuildwheel/issues>`__ |
 `GitHub <https://github.com/pypa/cibuildwheel>`__ |
-`PyPI <https://pypi.org/project/cibuildwheel>`__ |
+:pypi:`PyPI <cibuildwheel>` |
 `Discussions <https://github.com/pypa/cibuildwheel/discussions>`__ |
 `Discord #cibuildwheel <https://discord.com/invite/pypa>`__
 
@@ -68,7 +68,7 @@ distlib
 :doc:`Docs <distlib:index>` |
 `Issues <https://github.com/pypa/distlib/issues>`__ |
 `GitHub <https://github.com/pypa/distlib>`__ |
-`PyPI <https://pypi.org/project/distlib>`__
+:pypi:`PyPI <distlib>`
 
 ``distlib`` is a library which implements low-level functions that
 relate to packaging and distribution of Python software.  ``distlib``
@@ -117,7 +117,7 @@ flit
 
 `Docs <https://flit.readthedocs.io/en/latest/>`__ |
 `Issues <https://github.com/pypa/flit/issues>`__ |
-`PyPI <https://pypi.org/project/flit>`__
+:pypi:`PyPI <flit>`
 
 Flit provides a simple way to create and upload pure Python packages and
 modules to PyPI.  It focuses on `making the easy things easy <flit-rationale_>`_
@@ -143,7 +143,7 @@ hatch
 
 `Docs <https://hatch.pypa.io/latest/>`__ |
 `GitHub <https://github.com/pypa/hatch>`__ |
-`PyPI <https://pypi.org/project/hatch>`__
+:pypi:`PyPI <hatch>`
 
 Hatch is a unified command-line tool meant to conveniently manage
 dependencies and environment isolation for Python developers. Python
@@ -159,7 +159,7 @@ packaging
 :doc:`Docs <packaging:index>` |
 `Issues <https://github.com/pypa/packaging/issues>`__ |
 `GitHub <https://github.com/pypa/packaging>`__ |
-`PyPI <https://pypi.org/project/packaging>`__
+:pypi:`PyPI <packaging>`
 
 Core utilities for Python packaging used by :ref:`pip` and :ref:`setuptools`.
 
@@ -188,7 +188,7 @@ pip
 `Docs <https://pip.pypa.io/>`__ |
 `Issues <https://github.com/pypa/pip/issues>`__ |
 `GitHub <https://github.com/pypa/pip>`__ |
-`PyPI <https://pypi.org/project/pip/>`__
+:pypi:`PyPI <pip>`
 
 The most popular tool for installing Python packages, and the one
 included with modern versions of Python.
@@ -206,7 +206,7 @@ Pipenv
 :doc:`Docs <pipenv:index>` |
 `Source <https://github.com/pypa/pipenv>`__ |
 `Issues <https://github.com/pypa/pipenv/issues>`__ |
-`PyPI <https://pypi.org/project/pipenv>`__
+:pypi:`PyPI <pipenv>`
 
 Pipenv is a project that aims to bring the best of all packaging worlds to the
 Python world. It harnesses :ref:`Pipfile`, :ref:`pip`, and :ref:`virtualenv`
@@ -237,7 +237,7 @@ pipx
 
 `Docs <https://pipx.pypa.io/>`__ |
 `GitHub <https://github.com/pypa/pipx>`__ |
-`PyPI <https://pypi.org/project/pipx/>`__
+:pypi:`PyPI <pipx>`
 
 pipx is a tool to install and run Python command-line applications without
 causing dependency conflicts with other packages installed on the system.
@@ -258,7 +258,7 @@ readme_renderer
 ===============
 
 `GitHub and docs <https://github.com/pypa/readme_renderer/>`__ |
-`PyPI <https://pypi.org/project/readme-renderer/>`__
+:pypi:`PyPI <readme-renderer>`
 
 ``readme_renderer`` is a library that package developers use to render
 their user documentation (README) files into HTML from markup
@@ -276,7 +276,7 @@ Setuptools
 `Docs <https://setuptools.readthedocs.io/en/latest/>`__ |
 `Issues <https://github.com/pypa/setuptools/issues>`__ |
 `GitHub <https://github.com/pypa/setuptools>`__ |
-`PyPI <https://pypi.org/project/setuptools>`__
+:pypi:`PyPI <setuptools>`
 
 Setuptools (which includes ``easy_install``) is a collection of
 enhancements to the Python distutils that allow you to more easily
@@ -289,8 +289,7 @@ trove-classifiers
 =================
 
 `Issues <https://github.com/pypa/trove-classifiers/issues>`__ | `GitHub
-<https://github.com/pypa/trove-classifiers>`__ | `PyPI
-<https://pypi.org/project/trove-classifiers/>`__
+<https://github.com/pypa/trove-classifiers>`__ | :pypi:`PyPI <trove-classifiers>`
 
 trove-classifiers is the canonical source for `classifiers on PyPI
 <https://pypi.org/classifiers/>`_, which project maintainers use to
@@ -316,7 +315,7 @@ twine
 `Docs <https://twine.readthedocs.io/en/latest/>`__ |
 `Issues <https://github.com/pypa/twine/issues>`__ |
 `GitHub <https://github.com/pypa/twine>`__ |
-`PyPI <https://pypi.org/project/twine>`__
+:pypi:`PyPI <twine>`
 
 Twine is the primary tool developers use to upload packages to the
 Python Package Index or other Python package indexes. It is a
@@ -333,7 +332,7 @@ virtualenv
 `Docs <https://virtualenv.pypa.io/en/stable/index.html>`__ |
 `Issues <https://github.com/pypa/virtualenv/issues>`__ |
 `GitHub <https://github.com/pypa/virtualenv>`__ |
-`PyPI <https://pypi.org/project/virtualenv/>`__
+:pypi:`PyPI <virtualenv>`
 
 virtualenv is a tool for creating isolated Python :term:`Virtual Environments
 <Virtual Environment>`, like :ref:`venv`. Unlike :ref:`venv`, virtualenv can
@@ -366,7 +365,7 @@ wheel
 `Docs <https://wheel.readthedocs.io/en/latest/>`__ |
 `Issues <https://github.com/pypa/wheel/issues>`__ |
 `GitHub <https://github.com/pypa/wheel>`__ |
-`PyPI <https://pypi.org/project/wheel>`__
+:pypi:`PyPI <wheel>`
 
 Primarily, the wheel project offers the ``bdist_wheel`` :ref:`setuptools` extension for
 creating :term:`wheel distributions <Wheel>`.  Additionally, it offers its own
@@ -390,7 +389,7 @@ buildout
 
 `Docs <http://www.buildout.org/en/latest/>`__ |
 `Issues <https://bugs.launchpad.net/zc.buildout>`__ |
-`PyPI <https://pypi.org/project/zc.buildout>`__ |
+:pypi:`PyPI <zc.buildout>` |
 `GitHub <https://github.com/buildout/buildout/>`__
 
 Buildout is a Python-based build system for creating, assembling and deploying
@@ -436,7 +435,7 @@ devpi
 
 `Docs <http://doc.devpi.net/latest/>`__ |
 :gh:`Issues <devpi/devpi/issues>` |
-`PyPI <https://pypi.org/project/devpi>`__
+:pypi:`PyPI <devpi>`
 
 devpi features a powerful PyPI-compatible server and PyPI proxy cache
 with a complementary command line tool to drive packaging, testing and
@@ -452,7 +451,7 @@ dumb-pypi
 =========
 
 `GitHub <https://github.com/chriskuehl/dumb-pypi>`__ |
-`PyPI <https://pypi.org/project/dumb-pypi>`__
+:pypi:`PyPI <dumb-pypi>`
 
 dumb-pypi is a simple :term:`package index <Package Index>` static file site
 generator, which then must be hosted by a static file webserver to become the
@@ -465,7 +464,7 @@ enscons
 
 :gh:`Source <dholth/enscons>` |
 :gh:`Issues <dholth/enscons/issues>` |
-`PyPI <https://pypi.org/project/enscons>`__
+:pypi:`PyPI <enscons>`
 
 Enscons is a Python packaging tool based on `SCons`_. It builds
 :ref:`pip`-compatible source distributions and wheels without using
@@ -486,7 +485,7 @@ Flask-Pypi-Proxy
 
 `Docs <https://flask-pypi-proxy.readthedocs.io>`__ |
 :gh:`GitHub <tzulberti/Flask-PyPi-Proxy>` |
-`PyPI <https://pypi.org/project/Flask-Pypi-Proxy/>`__
+:pypi:`PyPI <Flask-Pypi-Proxy>`
 
 .. warning:: Not maintained, project archived
 
@@ -565,7 +564,7 @@ pdm
 
 `Docs <https://pdm.fming.dev/>`__ |
 `GitHub <https://github.com/pdm-project/pdm/>`__ |
-`PyPI <https://pypi.org/project/pdm>`__
+:pypi:`PyPI <pdm>`
 
 PDM is a modern Python package manager. It uses :term:`pyproject.toml` to store
 project metadata as defined in :pep:`621`.
@@ -577,7 +576,7 @@ pex
 
 `Docs <https://pex.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/pantsbuild/pex/>`__ |
-`PyPI <https://pypi.org/project/pex>`__
+:pypi:`PyPI <pex>`
 
 Pex is a tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
@@ -595,7 +594,7 @@ pip-tools
 
 `Docs <https://pip-tools.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/jazzband/pip-tools/>`__ |
-`PyPI <https://pypi.org/project/pip-tools/>`__
+:pypi:`PyPI <pip-tools>`
 
 pip-tools is a suite of tools meant for Python system administrators
 and release managers who particularly want to keep their builds
@@ -612,7 +611,7 @@ pip2pi
 =========
 
 :gh:`GitHub <wolever/pip2pi>` |
-`PyPI <https://pypi.org/project/pip2pi/>`__
+:pypi:`PyPI <pip2pi>`
 
 pip2pi is a :term:`package index <Package Index>` server where specific
 packages are manually synchronised.
@@ -639,7 +638,7 @@ poetry
 
 `Docs <https://python-poetry.org/>`__ |
 `GitHub <https://github.com/python-poetry/poetry>`__ |
-`PyPI <https://pypi.org/project/poetry/>`__
+:pypi:`PyPI <poetry>`
 
 poetry is a command-line tool to handle dependency installation and
 isolation as well as building and packaging of Python packages. It
@@ -654,7 +653,7 @@ proxpi
 ======
 
 :gh:`GitHub <EpicWink/proxpi>` |
-`PyPI <https://pypi.org/project/proxpi/>`__
+:pypi:`PyPI <proxpi>`
 
 proxpi is a simple :term:`package index <Package Index>` which proxies PyPI
 and other indexes with caching.
@@ -666,7 +665,7 @@ Pulp-python
 
 `Docs <https://docs.pulpproject.org/pulp_python/>`__ |
 :gh:`GitHub <pulp/pulp_python>` |
-`PyPI <https://pypi.org/project/pulp-python/>`__
+:pypi:`PyPI <pulp-python>`
 
 Pulp-python is the Python :term:`package index <Package Index>` plugin for
 `Pulp <https://pulpproject.org/>`_. Pulp-python supports mirrors backed by
@@ -680,7 +679,7 @@ PyPI Cloud
 
 `Docs <https://pypicloud.readthedocs.io/>`__ |
 :gh:`GitHub <stevearc/pypicloud>` |
-`PyPI <https://pypi.org/project/pypicloud/>`__
+:pypi:`PyPI <pypicloud>`
 
 .. warning:: Not maintained, project archived
 
@@ -695,7 +694,7 @@ pypiprivate
 ===========
 
 :gh:`GitHub <helpshift/pypiprivate>` |
-`PyPI <https://pypi.org/project/pypiprivate/>`__
+:pypi:`PyPI <pypiprivate>`
 
 pypiprivate serves a local (or `AWS S3`_-hosted) directory of packages as a
 :term:`package index <Package Index>`.
@@ -706,7 +705,7 @@ pypiserver
 ==========
 
 `GitHub <https://github.com/pypiserver/pypiserver>`__ |
-`PyPI <https://pypi.org/project/pypiserver/>`__
+:pypi:`PyPI <pypiserver>`
 
 pypiserver is a minimalist application that serves as a private Python
 :term:`package index <Package Index>` (from a local directory) within
@@ -723,7 +722,7 @@ PyScaffold
 
 `Docs <https://pyscaffold.org>`__ |
 `GitHub <https://github.com/pyscaffold/pyscaffold>`__ |
-`PyPI <https://pypi.org/project/pyscaffold/>`__
+:pypi:`PyPI <pyscaffold>`
 
 PyScaffold is a project generator for bootstrapping Python packages,
 ready to be shared on PyPI and installable via :ref:`pip`.
@@ -739,7 +738,7 @@ pywharf
 =======
 
 :gh:`GitHub <pywharf/pywharf>` |
-`PyPI <https://pypi.org/project/pywharf>`__
+:pypi:`PyPI <pywharf>`
 
 .. warning:: Not maintained, project archived
 
@@ -753,15 +752,14 @@ scikit-build
 
 `Docs <https://scikit-build.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/scikit-build/scikit-build/>`__ |
-`PyPI <https://pypi.org/project/scikit-build>`__
+:pypi:`PyPI <scikit-build>`
 
 Scikit-build is a :ref:`setuptools` wrapper for CPython that builds
 C/C++/Fortran/Cython extensions It uses
-`cmake <https://pypi.org/project/cmake>`__ (available on PyPI) to provide
+:pypi:`cmake` (available on PyPI) to provide
 better support for additional compilers, build systems, cross compilation, and
 locating dependencies and their associated build requirements. To speed up and
-parallelize the build of large projects, the user can install `ninja
-<https://pypi.org/project/ninja>`__ (also available on PyPI).
+parallelize the build of large projects, the user can install :pypi:`ninja` (also available on PyPI).
 
 .. _scikit-build-core:
 
@@ -770,11 +768,10 @@ scikit-build-core
 
 `Docs <https://scikit-build-core.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/scikit-build/scikit-build-core/>`__ |
-`PyPI <https://pypi.org/project/scikit-build-core>`__
+:pypi:`PyPI <scikit-build-core>`
 
 Scikit-build-core is a build backend for CPython C/C++/Fortran/Cython
-extensions.  It enables users to write extensions with `cmake
-<https://pypi.org/project/cmake>`__ (available on PyPI) to provide better
+extensions.  It enables users to write extensions with :pypi:`cmake` (available on PyPI) to provide better
 support for additional compilers, build systems, cross compilation, and
 locating dependencies and their associated build requirements. CMake/Ninja
 are automatically downloaded from PyPI if not available on the system.
@@ -786,7 +783,7 @@ shiv
 
 `Docs <https://shiv.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/linkedin/shiv>`__ |
-`PyPI <https://pypi.org/project/shiv/>`__
+:pypi:`PyPI <shiv>`
 
 shiv is a command line utility for building fully self contained
 Python zipapps as outlined in :pep:`441`, but with all their
@@ -799,7 +796,7 @@ simpleindex
 ===========
 
 :gh:`GitHub <uranusjr/simpleindex>` |
-`PyPI <https://pypi.org/project/simpleindex/>`__
+:pypi:`PyPI <simpleindex>`
 
 simpleindex is a :term:`package index <Package Index>` which routes URLs to
 multiple package indexes (including PyPI), serves local (or cloud-hosted,
@@ -834,7 +831,7 @@ uv
 
 `Docs <https://docs.astral.sh/uv/>`__ |
 `GitHub <https://github.com/astral-sh/uv>`__ |
-`PyPI <https://pypi.org/project/uv/>`__
+:pypi:`PyPI <uv>`
 
 A Python package and project manager, written in Rust for high performance. It
 supports creating and managing virtual environments, installing packages,
@@ -847,7 +844,7 @@ zest.releaser
 
 `Docs <https://zestreleaser.readthedocs.io/en/latest/>`__ |
 `GitHub <https://github.com/zestsoftware/zest.releaser/>`__ |
-`PyPI <https://pypi.org/project/zest.releaser/>`__
+:pypi:`PyPI <zest.releaser>`
 
 ``zest.releaser`` is a Python package release tool providing an
 abstraction layer on top of :ref:`twine`. Python developers use

--- a/source/news.rst
+++ b/source/news.rst
@@ -7,49 +7,49 @@ News
 
 September 2019
 --------------
-- Added a guide about publishing dists via GitHub Actions. (:pr:`647`)
+- Added a guide about publishing dists via GitHub Actions. (:pr:`PR #647 <647>`)
 
 August 2019
 -----------
-- Updated to use :file:`python3 -m` when installing pipx. (:pr:`631`)
+- Updated to use :file:`python3 -m` when installing pipx. (:pr:`PR #631 <631>`)
 
 July 2019
 ---------
-- Marked all PEP numbers with the :pep: role. (:pr:`629`)
-- Upgraded Sphinx version and removed pypa.io intersphinx. (:pr:`625`)
-- Mentioned :file:`find_namespace_packages`. (:pr:`622`)
-- Updated directory layout examples for consistency. (:pr:`611`)
-- Updated Bandersnatch link to GitHub. (:pr:`623`)
+- Marked all PEP numbers with the :pep: role. (:pr:`PR #629 <629>`)
+- Upgraded Sphinx version and removed pypa.io intersphinx. (:pr:`PR #625 <625>`)
+- Mentioned :file:`find_namespace_packages`. (:pr:`PR #622 <622>`)
+- Updated directory layout examples for consistency. (:pr:`PR #611 <611>`)
+- Updated Bandersnatch link to GitHub. (:pr:`PR #623 <623>`)
 
 June 2019
 ---------
-- Fixed some typos. (:pr:`620`)
+- Fixed some typos. (:pr:`PR #620 <620>`)
 
 May 2019
 --------
-- Added :file:`python_requires` usage to packaging tutorial. (:pr:`613`)
-- Added a MANIFEST.in guide page. (:pr:`609`)
+- Added :file:`python_requires` usage to packaging tutorial. (:pr:`PR #613 <613>`)
+- Added a MANIFEST.in guide page. (:pr:`PR #609 <609>`)
 
 April 2019
 ----------
-- Added a mention for :file:`shiv` in the key projects section. (:pr:`608`)
-- Reduced emphasis on virtualenv. (:pr:`606`)
+- Added a mention for :file:`shiv` in the key projects section. (:pr:`PR #608 <608>`)
+- Reduced emphasis on virtualenv. (:pr:`PR #606 <606>`)
 
 March 2019
 ----------
-- Moved single-sourcing guide version option to Python 3. (:pr:`605`)
-- Covered RTD details for contributing. (:pr:`600`)
+- Moved single-sourcing guide version option to Python 3. (:pr:`PR #605 <605>`)
+- Covered RTD details for contributing. (:pr:`PR #600 <600>`)
 
 February 2019
 -------------
-- Elaborate upon the differences between the tutorial and the real packaging process. (:pr:`602`)
-- Added instructions to install Python CLI applications. (:pr:`594`)
+- Elaborate upon the differences between the tutorial and the real packaging process. (:pr:`PR #602 <602>`)
+- Added instructions to install Python CLI applications. (:pr:`PR #594 <594>`)
 
 January 2019
 ------------
-- Added :file:`--no-deps` to the packaging tutorial. (:pr:`593`)
-- Updated Sphinx and Nox. (:pr:`591`)
-- Referenced Twine from Python3. (:pr:`581`)
+- Added :file:`--no-deps` to the packaging tutorial. (:pr:`PR #593 <593>`)
+- Updated Sphinx and Nox. (:pr:`PR #591 <591>`)
+- Referenced Twine from Python3. (:pr:`PR #581 <581>`)
 
 December 2018
 -------------
@@ -57,178 +57,178 @@ December 2018
 
 November 2018
 -------------
-- Removed landing page link to PyPI migration guide. (:pr:`575`)
-- Changed bumpversion to bump2version. (:pr:`572`)
-- Added single-sourcing package version example. (:pr:`573`)
-- Added a guide for creating documentation. (:pr:`568`)
+- Removed landing page link to PyPI migration guide. (:pr:`PR #575 <575>`)
+- Changed bumpversion to bump2version. (:pr:`PR #572 <572>`)
+- Added single-sourcing package version example. (:pr:`PR #573 <573>`)
+- Added a guide for creating documentation. (:pr:`PR #568 <568>`)
 
 October 2018
 ------------
-- Updated Nox package name. (:pr:`566`)
-- Mentioned Sphinx extensions in guides. (:pr:`562`)
+- Updated Nox package name. (:pr:`PR #566 <566>`)
+- Mentioned Sphinx extensions in guides. (:pr:`PR #562 <562>`)
 
 September 2018
 --------------
-- Added a section on checking RST markup. (:pr:`554`)
-- Updated user installs page. (:pr:`558`)
-- Updated Google BigQuery urls. (:pr:`556`)
-- Replaced tar command with working command. (:pr:`552`)
-- Changed to double quotes in the pip install SomeProject==1.4. (:pr:`550`)
+- Added a section on checking RST markup. (:pr:`PR #554 <554>`)
+- Updated user installs page. (:pr:`PR #558 <558>`)
+- Updated Google BigQuery urls. (:pr:`PR #556 <556>`)
+- Replaced tar command with working command. (:pr:`PR #552 <552>`)
+- Changed to double quotes in the pip install SomeProject==1.4. (:pr:`PR #550 <550>`)
 
 August 2018
 -----------
-- Removed the recommendation to store passwords in cleartext. (:pr:`546`)
-- Moved the Overview to a task based lead in along with the others. (:pr:`540`)
-- Updated Python version supported by virtualenv. (:pr:`538`)
-- Added outline/rough draft of new Overview page. (:pr:`519`)
+- Removed the recommendation to store passwords in cleartext. (:pr:`PR #546 <546>`)
+- Moved the Overview to a task based lead in along with the others. (:pr:`PR #540 <540>`)
+- Updated Python version supported by virtualenv. (:pr:`PR #538 <538>`)
+- Added outline/rough draft of new Overview page. (:pr:`PR #519 <519>`)
 
 July 2018
 ---------
 
-- Improved binary extension docs. (:pr:`531`)
-- Added scikit-build to key projects. (:pr:`530`)
+- Improved binary extension docs. (:pr:`PR #531 <531>`)
+- Added scikit-build to key projects. (:pr:`PR #530 <530>`)
 
 June 2018
 ---------
 
-- Fixed categories of interop PEP for pypa.io. (:pr:`527`)
-- Updated Markdown descriptions explanation. (:pr:`522`)
+- Fixed categories of interop PEP for pypa.io. (:pr:`PR #527 <527>`)
+- Updated Markdown descriptions explanation. (:pr:`PR #522 <522>`)
 
 May 2018
 --------
 
-- Noted issues with Provides-Dist and Obsoletes-Dist. (:pr:`513`)
-- Removed outdated warning about Python version mixing with Pipenv. (:pr:`501`)
-- Simplified packaging tutorial. (:pr:`498`)
-- Updated Windows users instructions for clarity. (:pr:`493`)
-- Updated the license section description for completeness. (:pr:`492`)
-- Added specification-style document to contributing section. (:pr:`489`)
-- Added documentation types to contributing guide. (:pr:`485`)
+- Noted issues with Provides-Dist and Obsoletes-Dist. (:pr:`PR #513 <513>`)
+- Removed outdated warning about Python version mixing with Pipenv. (:pr:`PR #501 <501>`)
+- Simplified packaging tutorial. (:pr:`PR #498 <498>`)
+- Updated Windows users instructions for clarity. (:pr:`PR #493 <493>`)
+- Updated the license section description for completeness. (:pr:`PR #492 <492>`)
+- Added specification-style document to contributing section. (:pr:`PR #489 <489>`)
+- Added documentation types to contributing guide. (:pr:`PR #485 <485>`)
 
 April 2018
 ----------
 
-- Added README guide. (:pr:`461`)
-- Updated instructions and status for PyPI launch. (:pr:`475`)
-- Added instructions for Warehouse. (:pr:`471`)
-- Removed GPG references from publishing tutorial. (:pr:`466`)
-- Added 'What’s in which Python 3.4–3.6?'. (:pr:`468`)
-- Added a guide for phasing out Python versions. (:pr:`459`)
-- Made default Description-Content-Type variant GFM. (:pr:`462`)
+- Added README guide. (:pr:`PR #461 <461>`)
+- Updated instructions and status for PyPI launch. (:pr:`PR #475 <475>`)
+- Added instructions for Warehouse. (:pr:`PR #471 <471>`)
+- Removed GPG references from publishing tutorial. (:pr:`PR #466 <466>`)
+- Added 'What’s in which Python 3.4–3.6?'. (:pr:`PR #468 <468>`)
+- Added a guide for phasing out Python versions. (:pr:`PR #459 <459>`)
+- Made default Description-Content-Type variant GFM. (:pr:`PR #462 <462>`)
 
 March 2018
 ----------
 
-- Updated "installing scientific packages". (:pr:`455`)
-- Added :file:`long_description_content_type` to follow PEP 556. (:pr:`457`)
-- Clarified a long description classifier on pypi.org. (:pr:`456`)
-- Updated Core Metadata spec to follow PEP 556. (:pr:`412`)
+- Updated "installing scientific packages". (:pr:`PR #455 <455>`)
+- Added :file:`long_description_content_type` to follow PEP 556. (:pr:`PR #457 <457>`)
+- Clarified a long description classifier on pypi.org. (:pr:`PR #456 <456>`)
+- Updated Core Metadata spec to follow PEP 556. (:pr:`PR #412 <412>`)
 
 February 2018
 -------------
 
-- Added python3-venv and python3-pip to Debian installation instructions. (:pr:`445`)
-- Updated PyPI migration info. (:pr:`439`)
-- Added a warning about managing multiple versions with pipenv. (:pr:`430`)
-- Added example of multiple emails to Core Metadata. (:pr:`429`)
-- Added explanation of "legacy" in test.pypi.org/legacy. (:pr:`426`)
+- Added python3-venv and python3-pip to Debian installation instructions. (:pr:`PR #445 <445>`)
+- Updated PyPI migration info. (:pr:`PR #439 <439>`)
+- Added a warning about managing multiple versions with pipenv. (:pr:`PR #430 <430>`)
+- Added example of multiple emails to Core Metadata. (:pr:`PR #429 <429>`)
+- Added explanation of "legacy" in test.pypi.org/legacy. (:pr:`PR #426 <426>`)
 
 January 2018
 ------------
 
-- Added a link to PyPI's list of classifiers. (:pr:`425`)
-- Updated README.rst explanation. (:pr:`419`)
+- Added a link to PyPI's list of classifiers. (:pr:`PR #425 <425>`)
+- Updated README.rst explanation. (:pr:`PR #419 <419>`)
 
 December 2017
 -------------
 
-- Replaced :file:`~` with :file:`$HOME` in guides and tutorials.  (:pr:`418`)
-- Noted which fields can be used with environment markers. (:pr:`416`)
-- Updated Requires-Python section. (:pr:`414`)
-- Added news page. (:pr:`404`)
+- Replaced :file:`~` with :file:`$HOME` in guides and tutorials.  (:pr:`PR #418 <418>`)
+- Noted which fields can be used with environment markers. (:pr:`PR #416 <416>`)
+- Updated Requires-Python section. (:pr:`PR #414 <414>`)
+- Added news page. (:pr:`PR #404 <404>`)
 
 November 2017
 -------------
 
-- Introduced a new dependency management tutorial based on Pipenv. (:pr:`402`)
+- Introduced a new dependency management tutorial based on Pipenv. (:pr:`PR #402 <402>`)
 - Updated the *Single Sourcing Package Version* tutorial to reflect pip's current
-  strategy. (:pr:`400`)
-- Added documentation about the ``py_modules`` argument to ``setup``. (:pr:`398`)
-- Simplified the wording for the :file:`manifest.in` section. (:pr:`395`)
+  strategy. (:pr:`PR #400 <400>`)
+- Added documentation about the ``py_modules`` argument to ``setup``. (:pr:`PR #398 <398>`)
+- Simplified the wording for the :file:`manifest.in` section. (:pr:`PR #395 <395>`)
 
 October 2017
 ------------
 
-- Added a specification for the :file:`entry_points.txt` file. (:pr:`398`)
-- Created a new guide for managing packages using ``pip`` and ``virtualenv``. (:pr:`385`)
-- Split the specifications page into multiple pages. (:pr:`386`)
+- Added a specification for the :file:`entry_points.txt` file. (:pr:`PR #398 <398>`)
+- Created a new guide for managing packages using ``pip`` and ``virtualenv``. (:pr:`PR #385 <385>`)
+- Split the specifications page into multiple pages. (:pr:`PR #386 <386>`)
 
 September 2017
 --------------
 
 - Encouraged using ``readme_renderer`` to validate :file:`README.rst`.
-  (:pr:`379`)
-- Recommended using the ``--user-base`` option. (:pr:`374`)
+  (:pr:`PR #379 <379>`)
+- Recommended using the ``--user-base`` option. (:pr:`PR #374 <374>`)
 
 August 2017
 -----------
 
-- Added a new, experimental tutorial on installing packages using ``Pipenv``. (:pr:`369`)
-- Added a new guide on how to use ``TestPyPI``. (:pr:`366`)
-- Added :file:`pypi.org` as a term. (:pr:`365`)
+- Added a new, experimental tutorial on installing packages using ``Pipenv``. (:pr:`PR #369 <369>`)
+- Added a new guide on how to use ``TestPyPI``. (:pr:`PR #366 <366>`)
+- Added :file:`pypi.org` as a term. (:pr:`PR #365 <365>`)
 
 July 2017
 ---------
 
-- Added ``flit`` to the key projects list. (:pr:`358`)
-- Added ``enscons`` to the list of key projects. (:pr:`357`)
-- Updated this guide's ``readme`` with instructions on how to build the guide locally. (:pr:`356`)
-- Made the new ``TestPyPI`` URL more visible, adding note to homepage about pypi.org. (:pr:`354`)
-- Added a note about the removal of the explicit registration API. (:pr:`347`)
+- Added ``flit`` to the key projects list. (:pr:`PR #358 <358>`)
+- Added ``enscons`` to the list of key projects. (:pr:`PR #357 <357>`)
+- Updated this guide's ``readme`` with instructions on how to build the guide locally. (:pr:`PR #356 <356>`)
+- Made the new ``TestPyPI`` URL more visible, adding note to homepage about pypi.org. (:pr:`PR #354 <354>`)
+- Added a note about the removal of the explicit registration API. (:pr:`PR #347 <347>`)
 
 June 2017
 ---------
 
-- Added a document on migrating uploads to :file:`PyPI.org`. (:pr:`339`)
-- Added documentation for ``python_requires``. (:pr:`338`)
-- Added a note about PyPI migration in the *Tool Recommendations* tutorial. (:pr:`335`)
-- Added a note that :file:`manifest.in` does not affect wheels. (:pr:`332`)
-- Added a license section to the distributing guide. (:pr:`331`)
-- Expanded the section on the ``name`` argument. (:pr:`329`)
-- Adjusted the landing page. (:pr:`327`, :pr:`326`, :pr:`324`)
-- Updated to Sphinx 1.6.2. (:pr:`323`)
-- Switched to the PyPA theme. (:pr:`305`)
-- Re-organized the documentation into the new structure. (:pr:`318`)
+- Added a document on migrating uploads to :file:`PyPI.org`. (:pr:`PR #339 <339>`)
+- Added documentation for ``python_requires``. (:pr:`PR #338 <338>`)
+- Added a note about PyPI migration in the *Tool Recommendations* tutorial. (:pr:`PR #335 <335>`)
+- Added a note that :file:`manifest.in` does not affect wheels. (:pr:`PR #332 <332>`)
+- Added a license section to the distributing guide. (:pr:`PR #331 <331>`)
+- Expanded the section on the ``name`` argument. (:pr:`PR #329 <329>`)
+- Adjusted the landing page. (:pr:`PR #327 <327>`, :pr:`PR #326 <326>`, :pr:`PR #324 <324>`)
+- Updated to Sphinx 1.6.2. (:pr:`PR #323 <323>`)
+- Switched to the PyPA theme. (:pr:`PR #305 <305>`)
+- Re-organized the documentation into the new structure. (:pr:`PR #318 <318>`)
 
 May 2017
 --------
 
-- Added documentation for the ``Description-Content-Type`` field. (:pr:`258`)
-- Added contributor and style guide. (:pr:`307`)
-- Documented ``pip`` and ``easy_install``'s differences for per-project indexes. (:pr:`233`)
+- Added documentation for the ``Description-Content-Type`` field. (:pr:`PR #258 <258>`)
+- Added contributor and style guide. (:pr:`PR #307 <307>`)
+- Documented ``pip`` and ``easy_install``'s differences for per-project indexes. (:pr:`PR #233 <233>`)
 
 April 2017
 ----------
 
-- Added travis configuration for testing pull requests. (:pr:`300`)
-- Mentioned the requirement of the ``wheel`` package for creating wheels (:pr:`299`)
-- Removed the ``twine register`` reference in the *Distributing Packages* tutorial. (:pr:`271`)
-- Added a topic on plugin discovery. (:pr:`294`, :pr:`296`)
-- Added a topic on namespace packages. (:pr:`290`)
-- Added documentation explaining prominently how to install ``pip`` in ``/usr/local``. (:pr:`230`)
-- Updated development mode documentation to mention that order of local packages matters. (:pr:`208`)
-- Convert readthedocs link for their ``.org`` -> ``.io`` migration for hosted projects (:pr:`239`)
+- Added travis configuration for testing pull requests. (:pr:`PR #300 <300>`)
+- Mentioned the requirement of the ``wheel`` package for creating wheels (:pr:`PR #299 <299>`)
+- Removed the ``twine register`` reference in the *Distributing Packages* tutorial. (:pr:`PR #271 <271>`)
+- Added a topic on plugin discovery. (:pr:`PR #294 <294>`, :pr:`PR #296 <296>`)
+- Added a topic on namespace packages. (:pr:`PR #290 <290>`)
+- Added documentation explaining prominently how to install ``pip`` in ``/usr/local``. (:pr:`PR #230 <230>`)
+- Updated development mode documentation to mention that order of local packages matters. (:pr:`PR #208 <208>`)
+- Convert readthedocs link for their ``.org`` -> ``.io`` migration for hosted projects (:pr:`PR #239 <239>`)
 - Swapped order of :file:`setup.py` arguments for the upload command, as order
-  is significant. (:pr:`260`)
-- Explained how to install from unsupported sources using a helper application. (:pr:`289`)
+  is significant. (:pr:`PR #260 <260>`)
+- Explained how to install from unsupported sources using a helper application. (:pr:`PR #289 <289>`)
 
 
 March 2017
 ----------
 
-- Covered ``manylinux1`` in *Platform Wheels*. (:pr:`283`)
+- Covered ``manylinux1`` in *Platform Wheels*. (:pr:`PR #283 <283>`)
 
 February 2017
 -------------
 
-- Added :pep:`518`. (:pr:`281`)
+- Added :pep:`518`. (:pr:`PR #281 <281>`)

--- a/source/overview.rst
+++ b/source/overview.rst
@@ -96,16 +96,15 @@ go to the :ref:`source-distribution-format` specification to learn more.
 
 If you rely on any non-Python code, or non-Python packages (such as
 `libxml2 <https://en.wikipedia.org/wiki/Libxml2>`_ in the case of
-`lxml <https://pypi.org/project/lxml/>`_, or BLAS libraries in the
-case of `numpy <https://pypi.org/project/numpy>`_), you will need to
+:pypi:`lxml`, or BLAS libraries in the
+case of :pypi:`numpy`), you will need to
 use the format detailed in the next section, which also has many
 advantages for pure-Python libraries.
 
 .. note:: Python and PyPI support multiple distributions providing
    different implementations of the same package. For instance the
-   unmaintained-but-seminal `PIL distribution
-   <https://pypi.org/project/PIL/>`_ provides the PIL package, and so
-   does `Pillow <https://pypi.org/project/Pillow/>`_, an
+   unmaintained-but-seminal :pypi:`PIL distribution <PIL>` provides the PIL package, and so
+   does :pypi:`Pillow`, an
    actively-maintained fork of PIL!
 
    This Python packaging superpower makes it possible for Pillow to be
@@ -308,7 +307,7 @@ A selection of Python freezers:
 * `py2exe <http://www.py2exe.org/>`_ - Windows only
 * `py2app <https://py2app.readthedocs.io/en/latest/>`_ - Mac only
 * `osnap <https://github.com/jamesabel/osnap>`_ - Windows and Mac
-* `pynsist <https://pypi.org/project/pynsist/>`_ - Windows only
+* :pypi:`pynsist` - Windows only
 
 Most of the above imply single-user deployments. For multi-component
 server applications, see :gh:`Chef Omnibus

--- a/source/specifications/pylock-toml.rst
+++ b/source/specifications/pylock-toml.rst
@@ -82,7 +82,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: Array of strings
 - **Required?**: no
-- **Inspiration**: uv_
+- **Inspiration**: :pypi:`uv`
 - A list of :ref:`dependency-specifiers-environment-markers` for
   which the lock file is considered compatible with.
 - Tools SHOULD write exclusive/non-overlapping environment markers to ease in
@@ -96,7 +96,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: string
 - **Required?**: no
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - Specifies the :ref:`core-metadata-requires-python` for the minimum
   Python version compatible for any environment supported by the lock file
   (i.e. the minimum viable Python version for the lock file).
@@ -153,7 +153,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: Array of strings
 - **Required?**: no; defaults to ``[]``
-- **Inspiration**: Poetry_, PDM_
+- **Inspiration**: :pypi:`Poetry <poetry>`, :pypi:`PDM <pdm>`
 - The name of synthetic dependency groups to represent what should be installed
   by default (e.g. what
   :ref:`[project.dependencies] <pyproject-toml-dependencies>` implicitly
@@ -187,7 +187,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: array of tables
 - **Required?**: yes
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - An array containing all packages that *may* be installed.
 - Packages MAY be listed multiple times with varying data, but all packages to
   be installed MUST narrow down to a single entry at install time.
@@ -228,7 +228,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: string
 - **Required?**: no
-- **Inspiration**: PDM_
+- **Inspiration**: :pypi:`PDM <pdm>`
 - The
   :ref:`environment marker <dependency-specifiers-environment-markers>`
   which specify when the package should be installed.
@@ -253,7 +253,7 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 
 - **Type**: array of tables
 - **Required?**: no
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - Records the other entries in :ref:`pylock-packages` which are direct
   dependencies of this package.
 - Each entry is a table which contains the minimum information required to tell
@@ -478,7 +478,7 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 
 - **Type**: integer
 - **Required?**: no
-- **Inspiration**: uv_, :ref:`simple-repository-api`
+- **Inspiration**: :pypi:`uv`, :ref:`simple-repository-api`
 - The size of the archive file.
 - Tools SHOULD provide the file size when reasonably possible (e.g. the file
   size is available via the Content-Length_ header from a HEAD_ HTTP request).
@@ -503,7 +503,7 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 
 - **Type**: Table of strings
 - **Required?**: yes
-- **Inspiration**: PDM_, Poetry_, uv_, :ref:`simple-repository-api`
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`, :ref:`simple-repository-api`
 - A table listing known hash values of the file where the key is the hash
   algorithm and the value is the hash value.
 - The table MUST contain at least one entry.
@@ -528,7 +528,7 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 
 - **Type**: string
 - **Required?**: no
-- **Inspiration**: uv_
+- **Inspiration**: :pypi:`uv`
 - The base URL for the package index from :ref:`simple-repository-api`
   where the sdist and/or wheels were found (e.g. ``https://pypi.org/simple/``).
 - When possible, this SHOULD be specified to assist with generating
@@ -546,7 +546,7 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 - **Type**: table
 - **Required?**: no; mutually-exclusive with :ref:`pylock-packages-vcs`,
   :ref:`pylock-packages-directory`, and :ref:`pylock-packages-archive`
-- **Inspiration**: uv_
+- **Inspiration**: :pypi:`uv`
 - Details of a :ref:`source-distribution-format-sdist` for the
   package.
 - Tools MAY choose to not support sdist files, both from a locking
@@ -563,7 +563,7 @@ See :ref:`pylock-packages-vcs-subdirectory`.
 - **Required?**: no, not when the last component of
   :ref:`pylock-packages-sdist-path`/ :ref:`pylock-packages-sdist-url` would be
   the same value
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - The file name of the :ref:`source-distribution-format-sdist` file.
 - If specified, this key's value takes precedence over the file name found in
   either :ref:`pylock-packages-sdist-url` or :ref:`pylock-packages-sdist-path`.
@@ -618,7 +618,7 @@ See :ref:`pylock-packages-archive-hashes`.
 - **Type**: array of tables
 - **Required?**: no; mutually-exclusive with :ref:`pylock-packages-vcs`,
   :ref:`pylock-packages-directory`, and :ref:`pylock-packages-archive`
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - For recording the wheel files as specified by
   :ref:`binary-distribution-format` for the package.
 - Tools MUST support wheel files, both from a locking and installation
@@ -634,7 +634,7 @@ See :ref:`pylock-packages-archive-hashes`.
 - **Required?**: no, not when the last component of
   :ref:`pylock-packages-wheels-path`/ :ref:`pylock-packages-wheels-url` would be
   the same value
-- **Inspiration**: PDM_, Poetry_, uv_
+- **Inspiration**: :pypi:`PDM <pdm>`, :pypi:`Poetry <poetry>`, :pypi:`uv`
 - The file name of the :ref:`binary-distribution-format` file.
 - If specified, this key's value takes precedence over the file name found in
   either :ref:`pylock-packages-wheels-url` or :ref:`pylock-packages-wheels-path`.
@@ -847,12 +847,8 @@ History
 .. _Content-Length: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
 .. _Dependabot: https://docs.github.com/en/code-security/dependabot
 .. _HEAD: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD
-.. _PDM: https://pypi.org/project/pdm/
-.. _pip-tools: https://pypi.org/project/pip-tools/
-.. _Poetry: https://pypi.org/project/poetry/
 .. _requirements file:
 .. _requirements files: https://pip.pypa.io/en/stable/reference/requirements-file-format/
 .. _software bill of materials: https://www.cisa.gov/sbom
 .. _TOML: https://toml.io/
-.. _uv: https://pypi.org/project/uv/
 .. _URL: https://url.spec.whatwg.org/

--- a/source/specifications/pypirc.rst
+++ b/source/specifications/pypirc.rst
@@ -46,7 +46,7 @@ Each section describing a repository defines three fields:
 .. warning::
 
     Be aware that this stores your password in plain text. For better security,
-    consider an alternative like `keyring`_, setting environment variables, or
+    consider an alternative like :pypi:`keyring`, setting environment variables, or
     providing the password on the command line.
 
     Otherwise, set the permissions on :file:`.pypirc` so that only you can view
@@ -55,8 +55,6 @@ Each section describing a repository defines three fields:
     .. code-block:: bash
 
         chmod 600 ~/.pypirc
-
-.. _keyring: https://pypi.org/project/keyring/
 
 Common configurations
 =====================
@@ -134,7 +132,7 @@ example of a :file:`$HOME/.pypirc` for PyPI, TestPyPI, and a private repository:
 .. warning::
 
     Instead of using the ``password`` field, consider saving your API tokens
-    and passwords securely using `keyring`_ (which is installed by Twine):
+    and passwords securely using :pypi:`keyring` (which is installed by Twine):
 
     .. code-block:: bash
 

--- a/source/tutorials/managing-dependencies.rst
+++ b/source/tutorials/managing-dependencies.rst
@@ -70,7 +70,7 @@ tutorial) and run:
     cd myproject
     pipenv install requests
 
-Pipenv will install the `Requests`_ library and create a ``Pipfile``
+Pipenv will install the :pypi:`Requests <requests>` library and create a ``Pipfile``
 for you in your project's directory. The :ref:`Pipfile` is used to track which
 dependencies your project needs in case you need to re-install them, such as
 when you share your project with others. You should get output similar to this
@@ -101,9 +101,6 @@ when you share your project with others. You should get output similar to this
     Successfully installed certifi-2017.7.27.1 chardet-3.0.4 idna-2.6 requests-2.18.4 urllib3-1.22
 
     Adding requests to Pipfile's [packages]...
-
-.. _Requests: https://pypi.org/project/requests/
-
 
 Using installed packages
 ------------------------


### PR DESCRIPTION
Adds the requested PyPI extlinks alias, so docs can use the :pypi: role for links to project pages.

I kept this to the alias itself and did not do any broad link rewrite in the same change.

Checks:
- git diff --check
- uv run --with pre-commit pre-commit run --files source/conf.py
- uv run --with nox nox -s build

Fixes #1370


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2041.org.readthedocs.build/en/2041/

<!-- readthedocs-preview python-packaging-user-guide end -->