### PR TITLE
Document whitespace in quoted dependency specifiers

### DIFF
--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -128,6 +128,10 @@ Whitespace
 Non line-breaking whitespace is mostly optional with no semantic meaning. The
 sole exception is detecting the end of a URL requirement.
 
+When a dependency specifier is written as a quoted string, authors may keep
+optional whitespace for readability, such as around version specifiers and
+version clauses.
+
 .. _dependency-specifiers-names:
 
 Names


### PR DESCRIPTION
Closes #1226.

Adds a short note that quoted dependency specifier strings may keep optional whitespace for readability.

Checks: uv run --with pre-commit pre-commit run --files source/specifications/dependency-specifiers.rst; uv run --with nox nox -s build

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2044.org.readthedocs.build/en/2044/

<!-- readthedocs-preview python-packaging-user-guide end -->