### PR TITLE
Mention local version upload restriction

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -511,6 +511,10 @@ distribution file(s) to upload.
   is cleaned on a semi regular basis. See :ref:`using-test-pypi` on
   how to setup your configuration in order to use it.
 
+.. note:: Public package indexes such as PyPI do not allow
+  :ref:`local version identifiers <local-version-identifiers>`. Use a public
+  version identifier before uploading distributions to PyPI.
+
 .. warning:: In other resources you may encounter references to using
   ``python setup.py register`` and ``python setup.py upload``. These methods
   of registering and uploading a package are **strongly discouraged** as it may


### PR DESCRIPTION
Closes #578.

Adds a short note in the PyPI upload section that public indexes do not allow local version identifiers.

Checks: pre-commit on the changed file; nox -s build.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2046.org.readthedocs.build/en/2046/

<!-- readthedocs-preview python-packaging-user-guide end -->