### PR TITLE
Link invalid authentication help

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -414,6 +414,11 @@ After the command completes, you should see output similar to this:
     Uploading example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
     100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.8/6.8 kB • 00:00 • ?
 
+.. tip::
+
+   If Twine reports an invalid username or password, see PyPI's
+   `help on invalid authentication errors <https://pypi.org/help/#invalid-auth>`_.
+
 Once uploaded, your package should be viewable on TestPyPI; for example:
 ``https://test.pypi.org/project/example_package_YOUR_USERNAME_HERE``.
 


### PR DESCRIPTION
Closes #977.

Adds a short tip near the Twine upload output that links to PyPI's invalid authentication help.

Checks: pre-commit on the changed file; nox -s build.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2047.org.readthedocs.build/en/2047/

<!-- readthedocs-preview python-packaging-user-guide end -->