### PR TITLE
Document pip index configuration migration

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -135,6 +135,12 @@ Downloading packages
 
 ``pypi.org`` is the default host for downloading packages.
 
+If downloads still use the old ``pypi.python.org`` host, check whether a
+:file:`pip.conf` file or the ``PIP_INDEX_URL`` environment variable overrides
+pip's default index URL. See pip's
+:ref:`configuration documentation <pip:config-file>` for the locations and
+available settings.
+
 Managing published packages and releases
 ----------------------------------------
 


### PR DESCRIPTION
Closes #463.

Adds a short note to the PyPI.org migration guide about checking pip configuration when downloads still use the old host.

Checks: pre-commit on the changed file; nox -s build.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2048.org.readthedocs.build/en/2048/

<!-- readthedocs-preview python-packaging-user-guide end -->