### PR TITLE
Fix formatting for urlsafe-base64-nopad example

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -396,7 +396,9 @@ History
 Appendix
 ========
 
-Example urlsafe-base64-nopad implementation::
+Example urlsafe-base64-nopad implementation:
+
+.. code-block:: python
 
     # urlsafe-base64-nopad for Python 3
     import base64


### PR DESCRIPTION
The current page is highlighted as `text`, so an explicit `code-block` directive is required.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2050.org.readthedocs.build/en/2050/

<!-- readthedocs-preview python-packaging-user-guide end -->