### PR TITLE
Clarify that yoda dependency specifiers are not allowed

### DIFF
--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -93,9 +93,8 @@ environments::
                      'implementation_name' | 'implementation_version' |
                      'extra' | 'extras' | 'dependency_groups' # ONLY when defined by a containing layer
                      )
-    marker_var    = wsp* (env_var | python_str)
-    marker_expr   = marker_var marker_op marker_var
-                  | wsp* '(' marker wsp* ')'
+    marker_expr   = env_var wsp* marker_op wsp* python_str
+                  | '(' marker ')'
     marker_and    = marker_expr wsp* 'and' marker_expr
                   | marker_expr
     marker_or     = marker_and wsp* 'or' marker_and
@@ -523,8 +522,7 @@ The complete parsley grammar::
                      'implementation_name' | 'implementation_version' |
                      'extra' | 'extras' | 'dependency_groups' # ONLY when defined by a containing layer
                      ):varname -> lookup(varname)
-    marker_var    = wsp* (env_var | python_str)
-    marker_expr   = marker_var:l marker_op:o marker_var:r -> (o, l, r)
+    marker_expr   = wsp* env_var:l wsp* marker_op:o wsp* python_str:r -> (o, l, r)
                   | wsp* '(' marker:m wsp* ')' -> m
     marker_and    = marker_expr:l wsp* 'and' marker_expr:r -> ('and', l, r)
                   | marker_expr:m -> m
@@ -630,6 +628,9 @@ A test program - if the grammar is in a string ``grammar``:
         "name@http://foo.com",
         "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
         "name[quux, strange];python_version<'2.7' and platform_version=='2'",
+        "name; python_version > '3.10'",
+        # Yoda specifiers are rejected
+        # "name; '3.10' < python_version",
         "name; os_name=='a' or os_name=='b'",
         # Should parse as (a and b) or c
         "name; os_name=='a' and os_name=='b' or os_name=='c'",
@@ -707,6 +708,8 @@ History
   work. [#marker_comparison_logic]_
 - January 2026: fix outdated references to other documents that were
   inadvertently retained from :pep:`508`
+- May 2026: Clarify that Yoda specifiers like ``'3.10' < python_version`` are not
+  allowed.
 
 
 References


### PR DESCRIPTION
The current Dependency Specifiers specification has grammar that would allow for a "Yoda specifiers", where the left hand side and right hand side of a marker expression could be flipped. There was a discussion about this on DPO: https://discuss.python.org/t/implementation-of-swapped-marker-order/107060. However, looking closer at the specification, these expressions are not in any of the examples or description. This PR is to clarify the grammar which was made too accommodating of this syntax.

The motivation of making this change it to provide a public function in the packaging library in order to walk a tree of markers. I'm currently using a private method for marker translation for conda-pypi, and I opened a PR to try to add this public method: https://github.com/pypa/packaging/pull/1145.

Beyond that motivation, this clarification is being made for the following reasons:

1. In practice, this is not used by the Python ecosystem and has never been supported in the packaging library.
2. For users in the ecosystem, ensuring that the syntax is consistent is easier to comprehend.
3. For tool implementers, supporting this syntax is very complex. In order to try to comply with the current grammar, uv implemented partial support. However, there is valid logic like `'3.13.*' == python_full_version` that isn't supported due to parsing complexities.
4. It also ensure that environment variables are compared against values consistently, right now the grammar would allow for two environment variables to be compared directly which wasn't the intent of the specification.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2051.org.readthedocs.build/en/2051/

<!-- readthedocs-preview python-packaging-user-guide end -->