### PR TITLE
Add extension module helper links

### DIFF
--- a/source/guides/packaging-binary-extensions.rst
+++ b/source/guides/packaging-binary-extensions.rst
@@ -404,6 +404,16 @@ a Debian system, see the following articles:
 * `Releasing the gil <https://thomasnyberg.com/releasing_the_gil.html>`_
 * `Writing cpython extension modules using C++ <https://thomasnyberg.com/cpp_extension_modules.html>`_
 
+Extension module helper guides
+------------------------------
+
+Additional extension module guides are available from:
+
+* `Python Extension Patterns <https://pythonextensionpatterns.readthedocs.io/en/latest/index.html>`_,
+  which covers common patterns for CPython extension modules.
+* `py3c <https://py3c.readthedocs.io/en/latest/>`_, which provides helper
+  APIs for extension modules that need to support both Python 2 and Python 3.
+
 Additional considerations for binary wheels
 -------------------------------------------
 


### PR DESCRIPTION
Adds the Python Extension Patterns and py3c docs to the binary extension guide's additional resources.

Closes #325.

Checks:
- `uv run --with pre-commit pre-commit run --files source/guides/packaging-binary-extensions.rst`
- `uv run --with nox nox -s build`

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2053.org.readthedocs.build/en/2053/

<!-- readthedocs-preview python-packaging-user-guide end -->