### PR TITLE
Check new links against linkcheck baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,54 @@ jobs:
         run: |
           python -m pip install --upgrade nox virtualenv
 
+      - name: Restore linkcheck baseline
+        id: restore-linkcheck-baseline
+        if: matrix.noxenv == 'linkcheck'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .linkcheck-cache/output.json
+          key: linkcheck-output-${{ github.event.repository.default_branch }}-${{ github.sha }}
+          restore-keys: |
+            linkcheck-output-${{ github.event.repository.default_branch }}-
+
       - name: Nox ${{ matrix.noxenv }}
         env:
           # Authenticate github.com requests during linkcheck to avoid rate limits.
           GITHUB_TOKEN: ${{ matrix.noxenv == 'linkcheck' && github.token || '' }}
+          LINKCHECK_BASELINE_JSON: >-
+            ${{
+              matrix.noxenv == 'linkcheck' &&
+              github.event_name == 'pull_request' &&
+              '.linkcheck-cache/output.json' ||
+              ''
+            }}
         run: |
           python -m nox -s ${{ matrix.noxenv }}
+
+      - name: Store linkcheck baseline
+        if: >-
+          ${{
+            matrix.noxenv == 'linkcheck' &&
+            github.event_name != 'pull_request' &&
+            github.ref_name == github.event.repository.default_branch &&
+            hashFiles('build/output.json') != ''
+          }}
+        run: |
+          mkdir -p .linkcheck-cache
+          cp build/output.json .linkcheck-cache/output.json
+
+      - name: Save linkcheck baseline
+        if: >-
+          ${{
+            matrix.noxenv == 'linkcheck' &&
+            github.event_name != 'pull_request' &&
+            github.ref_name == github.event.repository.default_branch &&
+            hashFiles('.linkcheck-cache/output.json') != ''
+          }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .linkcheck-cache/output.json
+          key: linkcheck-output-${{ github.event.repository.default_branch }}-${{ github.sha }}
 
 
   check:

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,8 +1,10 @@
 # -- Project information ---------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import json
 import os
 import pathlib
+import re
 import sys
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -163,6 +165,30 @@ linkcheck_ignore = [
     # Temporarily ignored due to expired TLS cert.
     r"https://kivy.org/.*",
 ]
+
+
+def _load_linkcheck_baseline(path):
+    baseline_path = pathlib.Path(path)
+    if not baseline_path.is_file():
+        return []
+
+    patterns = set()
+    for line in baseline_path.read_text(encoding="utf-8").splitlines():
+        try:
+            output = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        uri = output.get("uri")
+        if isinstance(uri, str) and uri:
+            patterns.add(rf"^{re.escape(uri)}$")
+
+    return sorted(patterns)
+
+
+if _baseline := os.getenv("LINKCHECK_BASELINE_JSON"):
+    linkcheck_ignore.extend(_load_linkcheck_baseline(_baseline))
+
 linkcheck_retries = 2
 linkcheck_timeout = 30
 # Ignore anchors for common targets when we know they likely won't be found


### PR DESCRIPTION
Fixes #2037.

This caches the linkcheck JSON output from main branch runs and uses it as a baseline on pull requests, so known URLs can be ignored while newly added links still get checked.

Checks:
- Parsed workflow YAML with PyYAML
- Exercised the baseline loader with sample JSONL
- uv run --with pre-commit pre-commit run --files .github/workflows/test.yml source/conf.py
- uv run --with nox nox -s build
- py -m py_compile source\conf.py
- git diff --check

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2056.org.readthedocs.build/en/2056/

<!-- readthedocs-preview python-packaging-user-guide end -->