### PR TITLE
sdist: fix normative language around pax

### DIFF
--- a/source/specifications/source-distribution-format.rst
+++ b/source/specifications/source-distribution-format.rst
@@ -74,7 +74,7 @@ at their respective paths relative to the root directory of the sdist
 No other content of a sdist is required or defined. Build systems can store
 whatever information they need in the sdist to build the project.
 
-The tarball should use the modern POSIX.1-2001 pax tar format, which specifies
+The tarball must use the modern POSIX.1-2001 pax tar format, which specifies
 UTF-8 based file names. In particular, source distribution files must be readable
 using the standard library tarfile module with the open flag 'r:gz'.
 


### PR DESCRIPTION
PEP 625 says:

> An sdist must be a gzipped tar archive in pax format, that is able to be extracted by the standard library tarfile module with the open flag 'r:gz'.

...but the living spec used the weaker "should" instead. This fixes it.

CCing some parties I suspect would be interested: @konstin @emmatyping

Other relevant refs:

- https://github.com/PyO3/maturin/issues/3195
- https://github.com/composefs/tar-rs/issues/318

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2058.org.readthedocs.build/en/2058/

<!-- readthedocs-preview python-packaging-user-guide end -->