### PR TITLE
Clarify installed package usage step

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -456,6 +456,9 @@ something like this:
    example package doesn't have any dependencies, it's a good practice to avoid
    installing dependencies when using TestPyPI.
 
+Using your newly installed package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 You can test that it was installed correctly by importing the package.
 Make sure you're still in your virtual environment, then run Python:
 


### PR DESCRIPTION
Fixes #1929.

Summary:
- add a small heading before the package import check

Checks:
- uv run --with pre-commit pre-commit run --files source/tutorials/packaging-projects.rst
- uv run --with nox nox -s build
- git diff --check

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2059.org.readthedocs.build/en/2059/

<!-- readthedocs-preview python-packaging-user-guide end -->