### PR TITLE
Clarify script entry point targets

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -208,9 +208,10 @@ In this example, after installing your project, a ``spam-cli`` command
 will be available. Executing this command will do the equivalent of
 ``import sys; from spam import main_cli; sys.exit(main_cli())``.
 
-Script entry points must use the ``module:object`` form. The object
-reference should point to a function that can be called with no arguments,
-not to a module by itself.
+Script entry points are written as :ref:`object references <entry-points>`,
+such as ``importable.module`` or ``importable.module:object.attr``. For
+script commands, the object reference should usually point to a callable object
+that can be called with no arguments, rather than to a module by itself.
 
 On Windows, scripts packaged this way need a terminal, so if you launch
 them from within a graphical application, they will make a terminal pop

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -208,6 +208,10 @@ In this example, after installing your project, a ``spam-cli`` command
 will be available. Executing this command will do the equivalent of
 ``import sys; from spam import main_cli; sys.exit(main_cli())``.
 
+Script entry points must use the ``module:object`` form. The object
+reference should point to a function that can be called with no arguments,
+not to a module by itself.
+
 On Windows, scripts packaged this way need a terminal, so if you launch
 them from within a graphical application, they will make a terminal pop
 up. To prevent this from happening, use the ``[project.gui-scripts]``


### PR DESCRIPTION
Fixes #1993.

Summary:
- clarify that script entry points need a module:object target

Checks:
- uv run --with pre-commit pre-commit run --files source/guides/writing-pyproject-toml.rst
- uv run --with nox nox -s build
- git diff --check

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2060.org.readthedocs.build/en/2060/

<!-- readthedocs-preview python-packaging-user-guide end -->