### PR TITLE
Fix platform-compatibility-tags.rst macOS arch table typo.

### DIFF
--- a/source/specifications/platform-compatibility-tags.rst
+++ b/source/specifications/platform-compatibility-tags.rst
@@ -226,7 +226,7 @@ the following list that describes the set of supported architectures:
 ``universal``  ``i386``, ``ppc``, ``ppc64``, ``x86_64``
 ``intel``      ``i386``, ``x86_64``
 ``fat``        ``i386``, ``ppc``
-``fat3``       ``i386``, ``ppc``, ``x86_64``
+``fat32``      ``i386``, ``ppc``, ``x86_64``
 ``fat64``      ``ppc64``, ``x86_64``
 ============== ========================================
 


### PR DESCRIPTION
Someone is wrong, and I expect packaging is de-facto right since its code well used in the wild: https://github.com/pypa/packaging/blob/a9f77f8269d6897a3dbf28f2c0129a354478d5de/src/packaging/tags.py#L543-L548

If packaging is actually wrong here, I can go over there and submit a PR.