### PR TITLE
Removes reference to withdrawn PEP 459

### DIFF
--- a/source/specifications/version-specifiers.rst
+++ b/source/specifications/version-specifiers.rst
@@ -172,9 +172,6 @@ identified by the public version identifier, but contains additional changes
 indexing and hosting upstream projects, it MUST NOT allow the use of local
 version identifiers.
 
-Source distributions using a local version identifier SHOULD provide the
-``python.integrator`` extension metadata (as defined in :pep:`459`).
-
 
 Final releases
 --------------


### PR DESCRIPTION
Removes outdated recommendation to use `python.integrator` for local version identifier metadata.
Resolves #1503

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2064.org.readthedocs.build/en/2064/

<!-- readthedocs-preview python-packaging-user-guide end -->