### PR TITLE
Check newly added links in PR linkcheck runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,38 @@ jobs:
         run: |
           python -m pip install --upgrade nox virtualenv
 
+      - name: Restore linkcheck baseline
+        if: matrix.noxenv == 'linkcheck' && github.event_name == 'pull_request'
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .linkcheck-baseline/output.json
+          key: linkcheck-output-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            linkcheck-output-
+
       - name: Nox ${{ matrix.noxenv }}
         env:
           # Authenticate github.com requests during linkcheck to avoid rate limits.
           GITHUB_TOKEN: ${{ matrix.noxenv == 'linkcheck' && github.token || '' }}
+          # Ignore links that were already reported by the baseline linkcheck run.
+          LINKCHECK_IGNORE_FILE: >-
+            ${{ matrix.noxenv == 'linkcheck' && '.linkcheck-baseline/output.json' || '' }}
         run: |
           python -m nox -s ${{ matrix.noxenv }}
+
+      - name: Prepare linkcheck baseline
+        if: matrix.noxenv == 'linkcheck' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p .linkcheck-baseline
+          cp build/output.json .linkcheck-baseline/output.json
+
+      - name: Save linkcheck baseline
+        if: matrix.noxenv == 'linkcheck' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .linkcheck-baseline/output.json
+          key: linkcheck-output-${{ github.sha }}
 
 
   check:

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,8 +1,10 @@
 # -- Project information ---------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import json
 import os
 import pathlib
+import re
 import sys
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -163,6 +165,20 @@ linkcheck_ignore = [
     # Temporarily ignored due to expired TLS cert.
     r"https://kivy.org/.*",
 ]
+
+if _linkcheck_ignore_file := os.getenv("LINKCHECK_IGNORE_FILE"):
+    linkcheck_ignore_path = pathlib.Path(_linkcheck_ignore_file)
+    if linkcheck_ignore_path.is_file():
+        with linkcheck_ignore_path.open(encoding="utf-8") as linkcheck_ignore_file:
+            for line in linkcheck_ignore_file:
+                try:
+                    linkcheck_entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if linkcheck_uri := linkcheck_entry.get("uri"):
+                    linkcheck_ignore.append(rf"^{re.escape(linkcheck_uri)}$")
+
 linkcheck_retries = 2
 linkcheck_timeout = 30
 # Ignore anchors for common targets when we know they likely won't be found


### PR DESCRIPTION
## Summary
- Allow source/conf.py to read a linkcheck JSONL baseline and ignore previously reported URLs.
- Restore the cached baseline for PR linkcheck runs so newly added links remain checked.
- Save the latest baseline from successful main-branch linkcheck runs.

Closes #2037

## Validation
- git diff --check
- python -m py_compile source/conf.py
- Parsed .github/workflows/test.yml with PyYAML
- Ran a small JSONL parsing smoke test for the baseline ignore logic

Note: full nox/actionlint checks were not run locally because those tools are not installed here.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2067.org.readthedocs.build/en/2067/

<!-- readthedocs-preview python-packaging-user-guide end -->