### PR TITLE
Mention stale pip index configuration during PyPI migration

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -135,6 +135,12 @@ Downloading packages
 
 ``pypi.org`` is the default host for downloading packages.
 
+If your installer still tries to download from ``pypi.python.org``, check your
+pip configuration files and the ``PIP_INDEX_URL`` environment variable for an
+old ``index-url`` setting such as ``https://pypi.python.org/pypi/``. Remove
+that override, or replace it with ``https://pypi.org/simple/``. You can run
+``python -m pip config debug`` to see which configuration files pip is reading.
+
 Managing published packages and releases
 ----------------------------------------
 


### PR DESCRIPTION
## Summary
- Add a heads-up to the PyPI.org migration guide about stale pip index configuration.
- Mention both pip config files and PIP_INDEX_URL, and point readers to pip config debug.

Closes #463

## Validation
- git diff --check

Note: full nox checks were not run locally because nox is not installed here.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2068.org.readthedocs.build/en/2068/

<!-- readthedocs-preview python-packaging-user-guide end -->