### PR TITLE
Clarify tests directory convention

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -103,6 +103,9 @@ Creating a test directory
 -------------------------
 
 :file:`tests/` is a placeholder for test files. Leave it empty for now.
+The plural name is a common convention for Python projects. Some packaging
+tools may mention older :file:`test/` patterns when describing source
+distribution defaults, but this tutorial uses :file:`tests/` consistently.
 
 
 .. _choosing-build-backend:


### PR DESCRIPTION
## Summary
- clarify that `tests/` is the convention used by the packaging tutorial
- note that older packaging defaults may still mention singular `test/` patterns

Closes #1165.

## Validation
- `git diff --check`


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2069.org.readthedocs.build/en/2069/

<!-- readthedocs-preview python-packaging-user-guide end -->