### PR TITLE
Document publishing job boundary

### DIFF
--- a/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
+++ b/source/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.rst
@@ -131,6 +131,16 @@ So add this to the steps list:
    :start-at: Install pypa/build
    :end-before: publish-to-pypi
 
+.. important::
+
+   Keep building distributions and publishing them in separate jobs. The
+   publishing jobs in this guide intentionally do not check out your project or
+   run build commands. Instead, they only download the distribution files
+   produced by the build job and upload them to the package index. Combining
+   the build and publish steps in the same job is unsupported because it gives
+   the publishing job access to project code and its build-time dependencies
+   while it also has permission to mint publishing credentials.
+
 Defining a workflow job environment
 ===================================
 


### PR DESCRIPTION
## Summary

- add an explicit note that build and publish steps should remain in separate jobs
- clarify that the publishing job intentionally avoids checkout/build commands
- explain why combining the jobs is unsupported for this trusted publishing workflow

## Why

The guide currently shows separate jobs, but the security boundary can be missed by readers adapting the workflow. This makes the intended structure clearer near the workflow example.

## Validation

- `sphinx-build --color --keep-going -j auto -b html -n -W source build`
- `git diff --check`


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2070.org.readthedocs.build/en/2070/

<!-- readthedocs-preview python-packaging-user-guide end -->