### PR TITLE
docs: update bandersnatch mirror notes

### DIFF
--- a/source/guides/index-mirrors-and-caches.rst
+++ b/source/guides/index-mirrors-and-caches.rst
@@ -66,7 +66,8 @@ Existing projects
      - ✔
      - ✔
      -
-     -
+     - complete PyPI mirror; supports filtering via plugins and filesystem or
+       S3-compatible storage backends
 
    * - :ref:`simpleindex`
      -


### PR DESCRIPTION
Closes #1083

## Summary
- Update the Bandersnatch row in the mirrors and caches guide
- Mention current capabilities around filtering plugins and filesystem or S3-compatible storage backends

## Checks
- `git diff --check`
- `python -m sphinx -b html -n -W --keep-going -d <tmp-doctrees> source <tmp-build>`

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2072.org.readthedocs.build/en/2072/

<!-- readthedocs-preview python-packaging-user-guide end -->