### PR TITLE
docs: warn about data_files usage

### DIFF
--- a/source/guides/distributing-packages-using-setuptools.rst
+++ b/source/guides/distributing-packages-using-setuptools.rst
@@ -250,6 +250,13 @@ For more information, see :std:doc:`Including Data Files
 
     data_files=[('my_data', ['data/data_file'])],
 
+.. warning::
+
+  ``data_files`` is a legacy installation mechanism and is deprecated in
+  setuptools' declarative configuration. Prefer :ref:`Package Data` for files
+  that belong inside an import package, and reserve ``data_files`` for
+  last-resort cases that need to place files outside Python packages.
+
 Although configuring :ref:`Package Data` is sufficient for most needs, in some
 cases you may need to place data files *outside* of your :term:`packages
 <Import Package>`.  The ``data_files`` directive allows you to do that.


### PR DESCRIPTION
Closes #1089

## Summary
- Add a warning to the setuptools distribution guide that `data_files` is a legacy/deprecated mechanism
- Point readers toward package data for files that belong inside import packages

## Checks
- `git diff --check`
- `python -m sphinx -b html -n -W --keep-going -d <tmp-doctrees> source <tmp-build>`

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2073.org.readthedocs.build/en/2073/

<!-- readthedocs-preview python-packaging-user-guide end -->