### PR TITLE
Add a Sphinx label for the `.dist-info/sboms/` section

### DIFF
--- a/source/specifications/binary-distribution-format.rst
+++ b/source/specifications/binary-distribution-format.rst
@@ -276,6 +276,8 @@ fields is specified, the :file:`.dist-info/` directory MUST contain a
 ``License-File`` fields in the :file:`METADATA` file at their respective paths
 relative to the :file:`licenses/` directory.
 
+.. _dist-info-sbom-directory:
+
 The :file:`.dist-info/sboms/` directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
We want to link to this from [PEP 770](https://peps.python.org/pep-0770/), but there's currently no concrete label here for us to target. See discussion [here](https://github.com/python/peps/pull/4986/changes#r3415541752).

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2075.org.readthedocs.build/en/2075/

<!-- readthedocs-preview python-packaging-user-guide end -->