### PR TITLE
Integrate sphinx-issues; convert inline PyPI URLs to :pypi:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx-inline-tabs==2023.4.21
 sphinx-copybutton==0.5.2
 sphinx-toolbox==3.5.0
 sphinx-jsonschema==1.19.1
+sphinx-issues==5.0.1

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_toolbox.collapse",
     "sphinx-jsonschema",
+    "sphinx_issues",
 ]
 
 nitpicky = True
@@ -194,12 +195,16 @@ github_repo_issues_url = f"{github_url}/{github_repo_slug}/issues"
 github_sponsors_url = f"{github_url}/sponsors"
 
 extlinks = {
-    "issue": (f"{github_repo_issues_url}/%s", "#%s"),
-    "pr": (f"{github_repo_url}/pull/%s", "PR #%s"),
-    "commit": (f"{github_repo_url}/commit/%s", "%s"),
     "gh": (f"{github_url}/%s", "GitHub: %s"),
-    "user": (f"{github_sponsors_url}/%s", "@%s"),
 }
+
+# -- Options for sphinx_issues -------------------------------------------------------
+# https://github.com/sloria/sphinx-issues#installation-and-configuration
+# Provides the :issue:, :pr:, :commit:, :user:, and :pypi: roles.
+
+issues_github_path = github_repo_slug
+# Preserve the previous `user` role behaviour, which pointed at GitHub Sponsors.
+issues_user_uri = f"{github_sponsors_url}/{{user}}"
 
 # -- Options for intersphinx ----------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration

--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -57,7 +57,7 @@ Windows
 Pynsist
 ^^^^^^^
 
-`Pynsist <https://pypi.org/project/pynsist>`__ is a tool that bundles Python
+:pypi:`Pynsist` is a tool that bundles Python
 programs together with the Python-interpreter into a single installer based on
 NSIS. In most cases, packaging only requires the user to choose a version of
 the Python-interpreter and declare the dependencies of the program. The tool
@@ -88,7 +88,7 @@ Windows
 py2exe
 ^^^^^^
 
-`py2exe <https://pypi.org/project/py2exe/>`__ is a distutils extension which
+:pypi:`py2exe` is a distutils extension which
 allows to build standalone Windows executable programs (32-bit and 64-bit)
 from Python scripts. Python versions included in the official development
 cycle are supported (refers to `Status of Python branches`__). py2exe can
@@ -105,7 +105,7 @@ macOS
 py2app
 ^^^^^^
 
-`py2app <https://pypi.org/project/py2app/>`__ is a Python setuptools
+:pypi:`py2app` is a Python setuptools
 command which will allow you to make standalone macOS application
 bundles and plugins from Python scripts. Note that py2app MUST be used
 on macOS to build applications, it cannot create Mac applications on other
@@ -117,7 +117,7 @@ Unix (including Linux and macOS)
 pex
 ^^^
 
-`pex <https://pypi.org/project/pex/>`__ is  a library for generating .pex
+:pypi:`pex` is  a library for generating .pex
 (Python EXecutable) files which are executable Python environments in the
 spirit of virtualenvs. pex is an expansion upon the ideas outlined in :pep:`441`
 and makes the deployment of Python applications as simple as cp. pex files may

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -757,11 +757,11 @@ scikit-build
 
 Scikit-build is a :ref:`setuptools` wrapper for CPython that builds
 C/C++/Fortran/Cython extensions It uses
-`cmake <https://pypi.org/project/cmake>`__ (available on PyPI) to provide
+:pypi:`cmake` (available on PyPI) to provide
 better support for additional compilers, build systems, cross compilation, and
 locating dependencies and their associated build requirements. To speed up and
-parallelize the build of large projects, the user can install `ninja
-<https://pypi.org/project/ninja>`__ (also available on PyPI).
+parallelize the build of large projects, the user can install
+:pypi:`ninja` (also available on PyPI).
 
 .. _scikit-build-core:
 
@@ -773,8 +773,8 @@ scikit-build-core
 `PyPI <https://pypi.org/project/scikit-build-core>`__
 
 Scikit-build-core is a build backend for CPython C/C++/Fortran/Cython
-extensions.  It enables users to write extensions with `cmake
-<https://pypi.org/project/cmake>`__ (available on PyPI) to provide better
+extensions.  It enables users to write extensions with
+:pypi:`cmake` (available on PyPI) to provide better
 support for additional compilers, build systems, cross compilation, and
 locating dependencies and their associated build requirements. CMake/Ninja
 are automatically downloaded from PyPI if not available on the system.

--- a/source/overview.rst
+++ b/source/overview.rst
@@ -96,8 +96,8 @@ go to the :ref:`source-distribution-format` specification to learn more.
 
 If you rely on any non-Python code, or non-Python packages (such as
 `libxml2 <https://en.wikipedia.org/wiki/Libxml2>`_ in the case of
-`lxml <https://pypi.org/project/lxml/>`_, or BLAS libraries in the
-case of `numpy <https://pypi.org/project/numpy>`_), you will need to
+:pypi:`lxml`, or BLAS libraries in the
+case of :pypi:`numpy`), you will need to
 use the format detailed in the next section, which also has many
 advantages for pure-Python libraries.
 
@@ -105,7 +105,7 @@ advantages for pure-Python libraries.
    different implementations of the same package. For instance the
    unmaintained-but-seminal `PIL distribution
    <https://pypi.org/project/PIL/>`_ provides the PIL package, and so
-   does `Pillow <https://pypi.org/project/Pillow/>`_, an
+   does :pypi:`Pillow`, an
    actively-maintained fork of PIL!
 
    This Python packaging superpower makes it possible for Pillow to be
@@ -308,7 +308,7 @@ A selection of Python freezers:
 * `py2exe <http://www.py2exe.org/>`_ - Windows only
 * `py2app <https://py2app.readthedocs.io/en/latest/>`_ - Mac only
 * `osnap <https://github.com/jamesabel/osnap>`_ - Windows and Mac
-* `pynsist <https://pypi.org/project/pynsist/>`_ - Windows only
+* :pypi:`pynsist` - Windows only
 
 Most of the above imply single-user deployments. For multi-component
 server applications, see :gh:`Chef Omnibus


### PR DESCRIPTION
Closes #1370.

Integrates sphinx-issues so the `:pypi:` role is available, per @webknjaz's feedback. The existing `issue`/`pr`/`commit`/`user` extlinks are moved over to sphinx-issues as well; `gh` stays in extlinks since sphinx-issues doesn't provide it.

Also converts ten inline `pypi.org/project` URLs in three files to use `:pypi:`, only in places where the visible link text already matched the project name.

One side effect to flag: `:pr:` usages in `news.rst` now render as `(#N)` instead of `(PR #N)`. sphinx-issues 5.0.1 restricts `issues_pr_prefix` to `#`, `@`, or `!`, so the previous prefix can't be configured. Same end state as [pypa/pip#12616](https://github.com/pypa/pip/pull/12616). Happy to convert the 109 `:pr:` lines to inline links if you'd rather preserve the prose.