### PR TITLE
chore: use non-legacy hook name for ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,5 +39,5 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.10
   hooks:
-    - id: ruff
+    - id: ruff-check
     - id: ruff-format


### PR DESCRIPTION
Noticed this warning in the pre-commit output. Switching to the non-legacy hook name.


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2083.org.readthedocs.build/en/2083/

<!-- readthedocs-preview python-packaging-user-guide end -->