### PR TITLE
docs: fix link to activestate python

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -148,6 +148,8 @@ linkcheck_ignore = [
     # Ignore while StackOverflow is blocking GitHub CI. Ref:
     # https://github.com/pypa/packaging.python.org/pull/1474
     r"https://stackoverflow\.com/.*",
+    # Cloudflare challenge blocks automated link checking.
+    r"https://clickpy\.clickhouse\.com/$",
     r"https://pyscaffold\.org/.*",
     r"https://anaconda\.org",
     r"https://www\.cisa\.gov/sbom",

--- a/source/overview.rst
+++ b/source/overview.rst
@@ -279,7 +279,7 @@ A similar model involves installing an alternative Python
 distribution, but does not support arbitrary operating system-level
 packages:
 
-* `ActiveState ActivePython <https://www.activestate.com/products/python/>`_
+* `ActiveState ActivePython <https://www.activestate.com/platform/supported-languages/python>`_
 * `WinPython <http://winpython.github.io/>`_
 
 .. _bringing-your-own-python:


### PR DESCRIPTION
As far as I can tell, this is roughly the equivalent link now.

Fixes the broken linkcheck (the old page is a 404).


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2084.org.readthedocs.build/en/2084/

<!-- readthedocs-preview python-packaging-user-guide end -->