### PR TITLE
 Ban negative extras (`extra !=` markers)

### DIFF
--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -708,6 +708,8 @@ History
   work. [#marker_comparison_logic]_
 - January 2026: fix outdated references to other documents that were
   inadvertently retained from :pep:`508`
+- July 2026: Explain that ``extra != "name"`` is not (properly) supported
+  (https://discuss.python.org/t/ban-negative-extras-for-extras-marker/108022/24)
 
 
 References

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -458,13 +458,15 @@ DO NOT need to define these fields.
 The ``extra`` field is also special, as it expects set-like behaviour, but
 predates the addition of ``Set of strings`` as a defined marker field type.
 It only supports one operation, ``extra == "name"``, which is similar to
-``"name" in extras``. For dependency marker evaluations, the set of extra
-names used for these comparisons is the full set of requested extras for *that
-particular package*, whether requested directly in a top level dependency
-declaration, or indirectly in a transitive dependency declaration. Other
-comparison operations on ``extra`` are not defined and publishing tools SHOULD
-emit an error, index servers MAY disallow uploads containing such environment
-markers, while locking and installation tools SHOULD evaluate them as False.
+``"name" in extras``. ``extra != "name"`` SHOULD NOT be used anymore and MAY
+be rejected or evaluated to false. For dependency marker evaluations, the set
+of extra names used for these comparisons is the full set of requested extras
+for *that particular package*, whether requested directly in a top level
+dependency declaration, or indirectly in a transitive dependency declaration.
+Other comparison operations on ``extra`` are not defined and publishing tools
+SHOULD emit an error, index servers MAY disallow uploads containing such
+environment markers, while locking and installation tools SHOULD evaluate them
+as False.
 
 Unlike the newer ``extras`` field, environment markers using this field SHOULD
 be accepted by both publishing tools and index servers. Marker evaluation

--- a/source/specifications/dependency-specifiers.rst
+++ b/source/specifications/dependency-specifiers.rst
@@ -457,9 +457,8 @@ DO NOT need to define these fields.
 
 The ``extra`` field is also special, as it expects set-like behaviour, but
 predates the addition of ``Set of strings`` as a defined marker field type.
-Accordingly, ``extra == "name"`` in a dependency declaration is similar to
-``"name" in extras``, while ``extra != "name"`` is similar to
-``"name" not in extras``. For dependency marker evaluations, the set of extra
+It only supports one operation, ``extra == "name"``, which is similar to
+``"name" in extras``. For dependency marker evaluations, the set of extra
 names used for these comparisons is the full set of requested extras for *that
 particular package*, whether requested directly in a top level dependency
 declaration, or indirectly in a transitive dependency declaration. Other


### PR DESCRIPTION
Negative extras (`extra !=`) are currently technically allowed in the grammar, but they behave strangely: `extra !=` means that package could transitively remove a package from selection through activating an extra. This turns incremental resolution into a global problem: We can't exit a resolution with a conflict when we've exhausted all versions in range including backtracking, we also have to exhaustively search for any package version that may activate the extra which deactivates the `extra !=` requirement which is part of the conflict. This would be fatal to resolver complexity and performance, preventing most of the short-circuiting that makes resolving tractable.

Much weirder, with negative extras, adding a new dependency can make a previously impossible resolution solvable:

```
[project]
name = "foo"
version = "0.1.0"
dependencies = [
  "numpy >2",
  "numpy <2; extra != 'old-science'",
]
```

Only by adding a package with `Requires-Dist: foo[old-science]`, this resolves.

Using PEP 621, users only get positive extras: `project.optional-dependencies.foo` gets translated into a conjunction of `extra == "foo"` with each requirement's marker.

While this may look like a breaking change, it only clarifies the current state of support in tools. From [pip not supporting it](https://github.com/pypa/pip/issues/14139) and [uv not supporting it](https://github.com/astral-sh/uv/issues/20107), we know it is not currently used and safe to remove. This solves the [confusion for users who want to use negative extras for conflicting packages](https://github.com/astral-sh/uv/issues/20107).

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2085.org.readthedocs.build/en/2085/

<!-- readthedocs-preview python-packaging-user-guide end -->