### PR TITLE
Document self-referential extras now that pip officially supports it

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -175,6 +175,22 @@ Each of the keys defines a "packaging extra". In the example above, one
 could use, e.g., ``pip install your-project-name[gui]`` to install your
 project with GUI support, adding the PyQt5 dependency.
 
+.. _self-referential-extras:
+
+You can also define an extra that refers back to the same project with
+other extras. This is useful for convenience extras that combine several
+optional features without duplicating their dependency lists:
+
+.. code-block:: toml
+
+   all = ["your-project-name[gui, cli]"]
+
+Installing ``your-project-name[all]`` then installs both the ``gui`` and
+``cli`` dependencies. You can also list extras separately, for example
+``["your-project-name[gui]", "your-project-name[cli]"]``. The name in the
+requirement must match the project's ``name`` field. Installers such as
+:ref:`pip` and :ref:`uv` support this pattern already (pip since v21.2).
+
 
 .. _requires-python:
 .. _python_requires:
@@ -555,6 +571,7 @@ A full example
      "rich",
      "click",
    ]
+   all = ["spam-eggs[gui, cli]"]
 
    [project.urls]
    Homepage = "https://example.com"

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -189,7 +189,8 @@ Installing ``your-project-name[all]`` then installs both the ``gui`` and
 ``cli`` dependencies. You can also list extras separately, for example
 ``["your-project-name[gui]", "your-project-name[cli]"]``. The name in the
 requirement must match the project's ``name`` field. Installers such as
-:ref:`pip` and :ref:`uv` support this pattern already (pip since v21.2).
+:ref:`pip` and :ref:`uv` support this pattern already (pip since 
+`version 21.2 <https://pip.pypa.io/en/latest/reference/requirement-specifiers/#self-referential-extras>`_).
 
 
 .. _requires-python:

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -177,20 +177,28 @@ project with GUI support, adding the PyQt5 dependency.
 
 .. _self-referential-extras:
 
-You can also define an extra that refers back to the same project with
+You can also define an extra that refers back to the current project with
 other extras. This is useful for convenience extras that combine several
-optional features without duplicating their dependency lists:
+optional features (such as an ``all`` extra hosting dependencies from both
+``gui`` and ``cli``):
 
 .. code-block:: toml
 
-   all = ["your-project-name[gui, cli]"]
+    all = ["your-project-name[gui, cli]"]
 
-Installing ``your-project-name[all]`` then installs both the ``gui`` and
-``cli`` dependencies. You can also list extras separately, for example
-``["your-project-name[gui]", "your-project-name[cli]"]``. The name in the
-requirement must match the project's ``name`` field. Installers such as
-:ref:`pip` and :ref:`uv` support this pattern already (pip since
-`version 21.2 <https://pip.pypa.io/en/latest/reference/requirement-specifiers/#self-referential-extras>`_).
+The combined extra does not need its own manually maintained copy of each
+referenced extra's dependencies, which can otherwise fall out of sync after
+a few years of maintenance and bug fixes:
+
+.. code-block:: toml
+
+    gui = ["PyQt5"]
+    cli = [
+      "rich>=14.2",   # version range is added after last "all" extra update
+      "textual",      # dependency newly added since last "all" extra update
+      "click",
+    ]
+    all = ["PyQt5", "rich", "click"]
 
 
 .. _requires-python:

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -189,7 +189,7 @@ Installing ``your-project-name[all]`` then installs both the ``gui`` and
 ``cli`` dependencies. You can also list extras separately, for example
 ``["your-project-name[gui]", "your-project-name[cli]"]``. The name in the
 requirement must match the project's ``name`` field. Installers such as
-:ref:`pip` and :ref:`uv` support this pattern already (pip since 
+:ref:`pip` and :ref:`uv` support this pattern already (pip since
 `version 21.2 <https://pip.pypa.io/en/latest/reference/requirement-specifiers/#self-referential-extras>`_).
 
 

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -200,7 +200,7 @@ a few years of maintenance and bug fixes:
     ]
     all = ["PyQt5", "rich", "click"]
 
-Most installers and dependency managers now support this kind of extra, including
+Most package managers now support this kind of extra, including
 :ref:`pip`, :ref:`uv`, :ref:`poetry`, :ref:`hatch`, :ref:`pdm` and :ref:`pipenv`.
 
 .. _requires-python:

--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -200,6 +200,8 @@ a few years of maintenance and bug fixes:
     ]
     all = ["PyQt5", "rich", "click"]
 
+Most installers and dependency managers now support this kind of extra, including
+:ref:`pip`, :ref:`uv`, :ref:`poetry`, :ref:`hatch`, :ref:`pdm` and :ref:`pipenv`.
 
 .. _requires-python:
 .. _python_requires:

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -498,6 +498,13 @@ marker clause on the related ``Requires-Dist`` entries to check the extra name.
 Optional dependencies are thus only considered for installation if installation
 if the associated extra name is requested.
 
+A dependency specifier in an extra MAY name the project itself with other extras
+(for example, ``all = ["spam[gui, cli]"]``). That way a combined extra does not
+need its own manually maintained copy of each referenced extra's dependencies,
+which can otherwise fall out of sync. Installers that support self-referential
+extras will be able to install the union of these extras' dependencies. See
+:ref:`self-referential extras <self-referential-extras>` for examples.
+
 
 .. _pyproject-toml-import-names:
 

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -498,13 +498,10 @@ marker clause on the related ``Requires-Dist`` entries to check the extra name.
 Optional dependencies are thus only considered for installation if installation
 if the associated extra name is requested.
 
-A dependency specifier in an extra MAY name the project itself with other extras
-(for example, ``all = ["spam[gui, cli]"]``). That way a combined extra does not
-need its own manually maintained copy of each referenced extra's dependencies,
-which can otherwise fall out of sync. Installers that support self-referential
-extras will be able to install the union of these extras' dependencies. See
-:ref:`self-referential extras <self-referential-extras>` for examples.
-
+Dependency specifiers in an extra may self-reference other extras from the
+current project (e.g. ``all = ["your-project-name[gui, cli]"]``). See
+:ref:`self-referential extras <self-referential-extras>` for an example.
+Several installers including :ref:`pip` and :ref:`uv` support this pattern.
 
 .. _pyproject-toml-import-names:
 

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -501,7 +501,8 @@ if the associated extra name is requested.
 Dependency specifiers in an extra may self-reference other extras from the
 current project (e.g. ``all = ["your-project-name[gui, cli]"]``). See
 :ref:`self-referential extras <self-referential-extras>` for an example.
-Several installers including :ref:`pip` and :ref:`uv` support this pattern.
+Most installers and dependency managers now support this kind of extra, including
+:ref:`pip`, :ref:`uv`, :ref:`poetry`, :ref:`hatch`, :ref:`pdm` and :ref:`pipenv`.
 
 .. _pyproject-toml-import-names:
 

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -501,7 +501,7 @@ if the associated extra name is requested.
 Dependency specifiers in an extra may self-reference other extras from the
 current project (e.g. ``all = ["your-project-name[gui, cli]"]``). See
 :ref:`self-referential extras <self-referential-extras>` for an example.
-Most installers and dependency managers now support this kind of extra, including
+Most package managers now support this kind of extra, including
 :ref:`pip`, :ref:`uv`, :ref:`poetry`, :ref:`hatch`, :ref:`pdm` and :ref:`pipenv`.
 
 .. _pyproject-toml-import-names:

--- a/source/specifications/pyproject-toml.rst
+++ b/source/specifications/pyproject-toml.rst
@@ -678,4 +678,7 @@ History
 - January 2026: Replaced outdated direct reference to :pep:`508` with a
   reference to :ref:`dependency-specifiers`.
 
+- August 2026: Document self-referential extra as a supported feature by many
+  modern package managers of Python.
+
 .. _TOML: https://toml.io


### PR DESCRIPTION
Using [self-referential extras](https://pip.pypa.io/en/latest/reference/requirement-specifiers/#self-referential-extras) is a more preferable pattern than to manually write, for example, an `all` extra for all dependencies combined (which is both tedious and easy to fall out of sync with reality).

Following https://github.com/pypa/pip/pull/14157, this is now a documented and tested feature of `pip` (supported unofficially since v21.2).

> __Update__: created a test repo for which package manager currently supports installing with self-referential extras: https://github.com/Trenza1ore/Self-Referential-Extras

Closes #2086

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2087.org.readthedocs.build/en/2087/

<!-- readthedocs-preview python-packaging-user-guide end -->