### PR TITLE
Clarify handling of script metadata

### DIFF
--- a/source/specifications/inline-script-metadata.rst
+++ b/source/specifications/inline-script-metadata.rst
@@ -75,11 +75,11 @@ recognised as containing metadata. However, parsing Python code is non-trivial,
 and therefore:
 
 * Tools MAY choose to do a simple textual scan, rather than a full Python parse.
-  For example, the canonical regular expression provided above does a textual
-  scan.
 * As a result of the previous point, the behaviour of scripts that contain data
   that looks like metadata within another Python construct such as a multi-line
   string is tool-dependent and should not be relied on.
+* The canonical regular expression provided above is an example of an
+  implementation that does a simple textual scan.
 
 script type
 -----------

--- a/source/specifications/inline-script-metadata.rst
+++ b/source/specifications/inline-script-metadata.rst
@@ -70,6 +70,17 @@ and the regular expression, the text specification takes precedence.
 Tools MUST NOT read from metadata blocks with types that have not been
 standardized by this specification.
 
+Note that the specification only requires that *top-level* comment blocks are
+recognised as containing metadata. However, parsing Python code is non-trivial,
+and therefore:
+
+* Tools MAY choose to do a simple textual scan, rather than a full Python parse.
+  For example, the canonical regular expression provided above does a textual
+  scan.
+* As a result of the previous point, the behaviour of scripts that contain data
+  that looks like metadata within another Python construct such as a multi-line
+  string is tool-dependent and should not be relied on.
+
 script type
 -----------
 


### PR DESCRIPTION
The specification states that only top-level comments define script metadata. But recognising precisely top-level comments is difficult, and requires a full Python parse, which (for example) the canonical regex does not do.

Clarify that tools MAY use a simple textual scan, like the regex does, but that users must not rely on comments within other Python constructs being ignored.

See https://discuss.python.org/t/clarify-that-pep-723-inline-script-metadata-recognition-is-textual/108089 for a discussion of this issue.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2089.org.readthedocs.build/en/2089/

<!-- readthedocs-preview python-packaging-user-guide end -->