### PR TITLE
Update description of wheels to "built distributions"

### DIFF
--- a/source/discussions/package-formats.rst
+++ b/source/discussions/package-formats.rst
@@ -8,7 +8,7 @@ This page discusses the file formats that are used to distribute Python packages
 and the differences between them.
 
 You will find files in two formats on package indices such as PyPI_: **source
-distributions**, or **sdists** for short, and **binary distributions**, commonly
+distributions**, or **sdists** for short, and **built distributions**, commonly
 called **wheels**.  For example, the `PyPI page for pip 23.3.1 <pip-pypi_>`_
 lets you download two files, ``pip-23.3.1.tar.gz`` and
 ``pip-23.3.1-py3-none-any.whl``.  The former is an sdist, the latter is a


### PR DESCRIPTION
Context:

I am working on a new design for the PyPI release files page.

At the top of the page, we will direct users to https://packaging.python.org/en/latest/discussions/package-formats/#package-formats for more information about source distributions and built distributions:

<img width="1920" height="2777" alt="Screenshot 2026-07-30 at 22-11-05 Versio · Warehouse" src="https://github.com/user-attachments/assets/4220e7e5-7804-44f5-862e-de714b814de0" />

This PR updates the package formats documentation to refer to wheels as "built distributions" instead of "binary distributions"

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2099.org.readthedocs.build/en/2099/

<!-- readthedocs-preview python-packaging-user-guide end -->