### PR TITLE
sdist format: qualify pax compatibility

### DIFF
--- a/source/specifications/source-distribution-format.rst
+++ b/source/specifications/source-distribution-format.rst
@@ -74,10 +74,19 @@ at their respective paths relative to the root directory of the sdist
 No other content of a sdist is required or defined. Build systems can store
 whatever information they need in the sdist to build the project.
 
-The tarball must use the modern POSIX.1-2001 pax tar format, which specifies
+The tarball MUST use the modern POSIX.1-2001 pax tar format, which specifies
 UTF-8 based file names. In particular, source distribution files must be readable
 using the standard library tarfile module with the open flag 'r:gz'.
 
+Source distributions MUST NOT use non-pax features, even if those features are
+structurally compatible with the pax standard. Installers and other consumers MAY
+reject source distributions that are not strictly pax-conforming.
+
+Examples of non-pax features include GNU-style or legacy ("V7")-style tar members
+and sparse member encodings (e.g. ``GNU.sparse`` extensions or ``S`` typeflag members).
+
+The use of pax-style vendor extensions (such as ``SCHILY.xattr`` or ``LIBARCHIVE.xattr``)
+is NOT RECOMMENDED for interoperability reasons.
 
 .. _sdist-archive-features:
 

--- a/source/specifications/source-distribution-format.rst
+++ b/source/specifications/source-distribution-format.rst
@@ -75,11 +75,11 @@ No other content of a sdist is required or defined. Build systems can store
 whatever information they need in the sdist to build the project.
 
 The tarball MUST use the modern POSIX.1-2001 pax tar format, which specifies
-UTF-8 based file names. In particular, source distribution files must be readable
+UTF-8 based file names. In particular, source distribution files MUST be readable
 using the standard library tarfile module with the open flag 'r:gz'.
 
 Source distributions MUST NOT use non-pax features, even if those features are
-structurally compatible with the pax standard. Installers and other consumers MAY
+structurally compatible with the pax standard. Installers and other consumers SHOULD
 reject source distributions that are not strictly pax-conforming.
 
 Examples of non-pax features include GNU-style or legacy ("V7")-style tar members


### PR DESCRIPTION
I'm opening this as a direct living spec PR, since it's _arguably_ just a clarification of the existing requirement, not a new one 🙂. However, if there's disagreement about that, I'm happy to take this to DPO for discussion first.

My rationale: the sdist spec already says that the tarball must be a POSIX.1-2001 pax archive. This implies a bunch of things that people may not realize, but are already fully covered by that requirement. For example, GNU-style tar files are not pax-conforming (they use a different magic and have special extended value encoding rules), and the `S` typeflag is GNU-specific.

There's a passable argument to be made that `GNU.sparse.*` is pax-conforming, since they're pax-style records. However:

1. Some versions of `GNU.sparse.*` are illegal to represent in pax, since they use duplicated record names;
2. `GNU.sparse.*` in general changes the framing logic, making it hard to correctly model the parse of a sparse member with a standard pax-conforming parser.

Finally, I think the most controversial part of this is adding a `NOT RECOMMENDED` for other pax-style (but not standard) vendor records. These are technically allowed in pax, just not defined by the standard themselves. However, they're also subject to a bunch of interoperability problems. For example, `SCHILY.xattr` is sometimes encoded as raw binary, which is not pax-conforming and causes problems for standard parsers. 

(And more generally, Python source distributions have no business encoding xattrs or anything like that, from what I can tell 🙂)



<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2108.org.readthedocs.build/en/2108/

<!-- readthedocs-preview python-packaging-user-guide end -->