### PR TITLE
Clarify autobuild extra arguments definition

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,10 +33,12 @@ def build(session, autobuild=False):
     Make the website.
     """
     session.install("-r", "requirements.txt")
-
-    if autobuild:
-        command = "sphinx-autobuild"
-        extra_args = "--host", "0.0.0.0"
+if autobuild:
+    command = "sphinx-autobuild"
+    extra_args = (
+        "--host",
+        "0.0.0.0",
+    )
     else:
         # NOTE: This branch adds options that are unsupported by autobuild
         command = "sphinx-build"


### PR DESCRIPTION
Explicitly define the autobuild extra arguments as a tuple to improve code readability and consistency.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2116.org.readthedocs.build/en/2116/

<!-- readthedocs-preview python-packaging-user-guide end -->