### PR TITLE
docs: clarify pip index configuration during PyPI migration

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -135,6 +135,21 @@ Downloading packages
 
 ``pypi.org`` is the default host for downloading packages.
 
+If you have configured pip to use a custom ``index-url``, that setting can
+override the default PyPI index. Check your pip configuration files if pip
+continues to use the old PyPI URL after migration. The command ``pip config
+list -v`` can be used to show the configuration files pip is loading.
+
+For example, a configuration containing::
+
+    [global]
+    index-url = https://pypi.python.org/pypi
+
+should be updated to use the current PyPI URL::
+
+    [global]
+    index-url = https://pypi.org/simple
+
 Managing published packages and releases
 ----------------------------------------
 

--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -135,20 +135,15 @@ Downloading packages
 
 ``pypi.org`` is the default host for downloading packages.
 
-If you have configured pip to use a custom ``index-url``, that setting can
-override the default PyPI index. Check your pip configuration files if pip
-continues to use the old PyPI URL after migration. The command ``pip config
-list -v`` can be used to show the configuration files pip is loading.
+If downloads still use the old ``pypi.python.org`` host, check whether your
+installer is configured to override its default package index. Configuration
+files, environment variables, and command-line options can all change the
+index used by an installer. Remove or update any override that points at the
+old host, using that installer's documentation to locate its active
+configuration.
 
-For example, a configuration containing::
-
-    [global]
-    index-url = https://pypi.python.org/pypi
-
-should be updated to use the current PyPI URL::
-
-    [global]
-    index-url = https://pypi.org/simple
+For pip, see its :ref:`configuration documentation <pip:config-file>` for the
+supported configuration files, environment variables, and commands.
 
 Managing published packages and releases
 ----------------------------------------

--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -142,9 +142,6 @@ index used by an installer. Remove or update any override that points at the
 old host, using that installer's documentation to locate its active
 configuration.
 
-For pip, see its :ref:`configuration documentation <pip:config-file>` for the
-supported configuration files, environment variables, and commands.
-
 Managing published packages and releases
 ----------------------------------------
 


### PR DESCRIPTION
Summary

* document that pip index-url configuration can override the default PyPI index
* show how to locate active pip configuration files with pip config list -v
* document updating a legacy [pypi.python.org](http://pypi.python.org/) index URL to [pypi.org/simple](http://pypi.org/simple)

Fixes #463

Validation

* Focused documentation-only change in source/guides/migrating-to-pypi-org.rst
* Verified the commit diff contains only the intended documentation addition

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2119.org.readthedocs.build/en/2119/

<!-- readthedocs-preview python-packaging-user-guide end -->