### PR TITLE
docs: clarify entry point support :)

### DIFF
--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -165,7 +165,7 @@ Now the module of your choice can be imported by executing
     section on :doc:`entry points <setuptools:userguide/entry_point>` .
 
 .. note:: Since this specification is part of the :doc:`standard library
-   <python:library/importlib.metadata>`, most packaging tools other than setuptools
+   <python:library/importlib.metadata>`, packaging tools including setuptools
    provide support for defining entry points.
 
 .. _backport: https://importlib-metadata.readthedocs.io/en/latest/


### PR DESCRIPTION
Hi , this is my first self-PR, hope this help :))).   :                                                                                                                                              Info: Clarify the documentation wording around entry point support.                                                                                                         Changed: Reworded the note in: creating-and-discovering-plugins.rst creating-and-discovering-plugins.rstRelated issue              **CLOSES #2115**                                                              

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2123.org.readthedocs.build/en/2123/guides/creating-and-discovering-plugins/#using-package-metadata

<!-- readthedocs-preview python-packaging-user-guide end -->