### PR TITLE
Document hashes for manually hosted package indexes

### DIFF
--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -52,6 +52,26 @@ directory with autoindex enabled. For an example using the built in Web server
 in `Twisted`_, you would simply run ``twistd -n web --path .`` and then
 instruct users to add the URL to their installer's configuration.
 
+An automatically generated directory listing usually doesn't include artifact
+hashes. Without hashes in the repository links, tools may be unable to record
+them in lock files. To include a SHA-256 hash, generate an ``index.html`` file
+in each project directory and append the hash to each artifact URL as described
+by the :ref:`Simple Repository API <simple-repository-html-project-detail>`:
+
+.. code-block:: html
+
+   <!DOCTYPE html>
+   <html lang="en">
+     <head><title>Links for foo</title></head>
+     <body>
+       <h1>Links for foo</h1>
+       <a href="Foo-1.0.tar.gz#sha256=3571b...">Foo-1.0.tar.gz</a>
+     </body>
+   </html>
+
+Replace ``3571b...`` with the full SHA-256 digest of the artifact. You can use
+:ref:`dumb-pypi` to generate a static repository with hashes and other Simple
+Repository API metadata from a directory of package artifacts.
 
 Existing projects
 =================
@@ -104,11 +124,6 @@ Existing projects
      -
      -
      - also mirroring; manual synchronisation
-
-   * - :ref:`dumb-pypi`
-     -
-     -
-     - not a server, but a static file site generator
 
    * - :ref:`httpserver`
      -

--- a/source/guides/hosting-your-own-index.rst
+++ b/source/guides/hosting-your-own-index.rst
@@ -52,11 +52,12 @@ directory with autoindex enabled. For an example using the built in Web server
 in `Twisted`_, you would simply run ``twistd -n web --path .`` and then
 instruct users to add the URL to their installer's configuration.
 
-An automatically generated directory listing usually doesn't include artifact
-hashes. Without hashes in the repository links, tools may be unable to record
-them in lock files. To include a SHA-256 hash, generate an ``index.html`` file
-in each project directory and append the hash to each artifact URL as described
-by the :ref:`Simple Repository API <simple-repository-html-project-detail>`:
+A bare, automatically generated directory listing, such as one produced by a
+generic autoindex module, may not include artifact hashes. Without hashes in
+the repository links, tools may be unable to record them in lock files. To
+include a SHA-256 hash, generate an ``index.html`` file in each project
+directory and append the hash to each artifact URL as described by the
+:ref:`Simple Repository API <simple-repository-html-project-detail>`:
 
 .. code-block:: html
 
@@ -71,7 +72,9 @@ by the :ref:`Simple Repository API <simple-repository-html-project-detail>`:
 
 Replace ``3571b...`` with the full SHA-256 digest of the artifact. You can use
 :ref:`dumb-pypi` to generate a static repository with hashes and other Simple
-Repository API metadata from a directory of package artifacts.
+Repository API metadata from a directory of package artifacts. Full repository
+implementations should prefer the JSON variant of the Simple Repository API,
+which requires a (possibly empty) ``hashes`` mapping for each file.
 
 Existing projects
 =================


### PR DESCRIPTION
The manual repository example currently recommends serving an automatically
generated directory listing, but those listings usually do not include artifact
hashes. This can leave package-manager lock files without hashes for artifacts
downloaded from the repository.

This adds a hash-bearing project detail page example, links to the Simple
Repository API contract, and points readers to `dumb-pypi` when they want a
static site generator that supplies hashes and other repository metadata.

Closes #1951.

Validation:

- `git diff --check`
- `nox -s build` (strict Sphinx HTML build with missing-reference warnings treated as errors)



<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2126.org.readthedocs.build/en/2126/

<!-- readthedocs-preview python-packaging-user-guide end -->

<!-- hermes-labs:attribution v1 -->
This contribution was produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->