### PR TITLE
Add `security` as a well-known project URL label

### DIFF
--- a/source/specifications/well-known-project-urls.rst
+++ b/source/specifications/well-known-project-urls.rst
@@ -129,6 +129,9 @@ specializing the presentation of ``Project-URL`` metadata:
    * - ``funding`` (Funding)
      - Funding Information
      - ``sponsor``, ``donate``, ``donation``
+   * - ``security`` (Security Policy)
+     - The project's security policy or vulnerability reporting page
+     - ``securitypolicy``
 
 Package metadata consumers may choose to render aliased labels the same as
 their "parent" well known label, or further specialize them.


### PR DESCRIPTION
This PR adds `security` (with `securitypolicy` as a normalisation
alias) to the well-known project URL labels specification.

Live PyPI data shows 573+ projects already using security-related
URL labels, but with 19 different non-normalised strings. This
standardises the most common usage into a single well-known label.

Background research: https://github.com/BHUVANSH855/pypi-security-url-research
Forum discussion: https://discuss.python.org/t/adding-security-as-a-well-known-url-label-and-project-security-table-to-pyproject-toml/108826

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2127.org.readthedocs.build/en/2127/

<!-- readthedocs-preview python-packaging-user-guide end -->