### PR TITLE
Don't block merges on linkcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,10 @@ jobs:
         - false
         include:
         - noxenv: linkcheck
-          continue-on-error: >-  # Don't block PRs on linkcheck unrelated failures
-            ${{ toJSON(github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+          # Don't block PRs, merge groups, or non-main pushes on unrelated linkcheck failures.
+          continue-on-error: >-
+            ${{ toJSON(github.event_name == 'pull_request' || github.event_name == 'merge_group' ||
+              (github.event_name == 'push' && github.ref != 'refs/heads/main')) }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         - noxenv: linkcheck
           # Don't block PRs, merge groups, or non-main pushes on unrelated linkcheck failures.
           continue-on-error: >-
-            ${{ toJSON(github.event_name == 'pull_request' || github.event_name == 'merge_group' ||
+            ${{ toJSON(contains(['merge_group', 'pull_request'], github.event_name) ||
               (github.event_name == 'push' && github.ref_name != github.event.repository.default_branch)) }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           # Don't block PRs, merge groups, or non-main pushes on unrelated linkcheck failures.
           continue-on-error: >-
             ${{ toJSON(github.event_name == 'pull_request' || github.event_name == 'merge_group' ||
-              (github.event_name == 'push' && github.ref != 'refs/heads/main')) }}
+              (github.event_name == 'push' && github.ref_name != github.event.repository.default_branch)) }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         include:
         - noxenv: linkcheck
           continue-on-error: >-  # Don't block PRs on linkcheck unrelated failures
-            ${{ toJSON(github.event_name == 'pull_request') }}
+            ${{ toJSON(github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
I believe this was an oversight in https://github.com/pypa/packaging.python.org/pull/2035 -- it doesn't make sense to allow linkchecks to pass PR gates, only to bounce them at the merge group.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2128.org.readthedocs.build/en/2128/

<!-- readthedocs-preview python-packaging-user-guide end -->