### PR TITLE
Fix setuptools-scm RTD links to no-locale deployment

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -230,6 +230,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "python-guide": ("https://docs.python-guide.org", None),
     "setuptools": ("https://setuptools.pypa.io/en/latest/", None),
+    "setuptools-scm": ("https://setuptools-scm.rtfd.io/latest", None),
     "spack": ("https://spack.readthedocs.io/en/latest/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master", None),
     "tox": ("https://tox.wiki/en/latest/", None),

--- a/source/discussions/setup-py-deprecated.rst
+++ b/source/discussions/setup-py-deprecated.rst
@@ -115,7 +115,7 @@ A possible replacement solution (among others) is to rely on setuptools-scm_:
 
 * ``python -m setuptools_scm``
 
-.. _setuptools-scm: https://setuptools-scm.readthedocs.io/en/latest/usage#as-cli-tool
+.. _setuptools-scm: https://setuptools-scm.readthedocs.io/latest/usage/#as-cli-tool
 
 
 Remaining commands

--- a/source/discussions/single-source-version.rst
+++ b/source/discussions/single-source-version.rst
@@ -59,4 +59,4 @@ The following are links to some build system's documentation for handling versio
 
 * `Setuptools <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata>`_
 
-  -  `setuptools_scm <https://setuptools-scm.readthedocs.io/en/latest/>`_
+  -  `setuptools_scm <https://setuptools-scm.rtfd.io/latest>`_


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2129.org.readthedocs.build/en/2129/

<!-- readthedocs-preview python-packaging-user-guide end -->