### PR TITLE
Fix formatting in PyPI-friendly README guide

### DIFF
--- a/source/guides/making-a-pypi-friendly-readme.rst
+++ b/source/guides/making-a-pypi-friendly-readme.rst
@@ -1,5 +1,5 @@
 Making a PyPI-friendly README
-=============================
+=============================,
 
 README files can help your users understand your project and can be used to set your project's description on PyPI.
 This guide helps you create a README in a PyPI-friendly format and include your README in your package so it appears on PyPI.


### PR DESCRIPTION

[PyPI-Recovery-Codes-cba067-2026-09-09T04_52_36.758322.txt](https://github.com/user-attachments/files/32002387/PyPI-Recovery-Codes-cba067-2026-09-09T04_52_36.758322.txt)


<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--2130.org.readthedocs.build/en/2130/

<!-- readthedocs-preview python-packaging-user-guide end -->