### PR TITLE
ci: validate newly added documentation links

### DIFF
--- a/.github/workflows/pr-linkcheck.yml
+++ b/.github/workflows/pr-linkcheck.yml
@@ -1,0 +1,59 @@
+name: Check new documentation links
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  new-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Collect added documentation lines
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+          import subprocess
+
+          # Compare the merge result with its base parent, not the PR parent.
+          diff = subprocess.check_output(
+              ["git", "diff", "--no-ext-diff", "--no-textconv", "--unified=0",
+               "HEAD^1", "HEAD", "--", "*.md", "*.rst"],
+              text=True, encoding="utf-8",
+          )
+          added = []
+          in_hunk = False
+          for line in diff.splitlines():
+              if line.startswith("diff --git "):
+                  in_hunk = False
+              elif line.startswith("@@ "):
+                  in_hunk = True
+              elif in_hunk and line.startswith("+"):
+                  added.append(line[1:])
+
+          # Never load configuration or write results inside the PR checkout.
+          directory = Path(os.environ["RUNNER_TEMP"]) / "new-links"
+          directory.mkdir()
+          (directory / "added-lines.txt").write_text("\n".join(added), encoding="utf-8")
+          (directory / "lychee.toml").write_text("", encoding="utf-8")
+
+      - name: Check links in added lines
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          workingDirectory: ${{ runner.temp }}/new-links
+          args: --config lychee.toml --verbose --no-progress --scheme http --scheme https --exclude-all-private added-lines.txt
+          token: ""
+          fail: true
+          failIfEmpty: false

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: read
@@ -17,17 +19,19 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 2
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Extract links added by the pull request
         run: |
-          git diff --unified=0 "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- '*.md' '*.rst' \
+          git diff --unified=0 HEAD^1 HEAD^2 -- '*.md' '*.rst' \
+            | grep '^+' | grep -v '^+++' \
             | grep -Eo 'https?://[^ )>]+' | sort -u > added-links.txt || true
 
       - name: Check links added by the pull request
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --verbose --no-progress --exclude-mail added-links.txt
           fail: true

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - reopened
-      - synchronize
 
 permissions:
   contents: read
@@ -19,23 +17,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 2
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-
-      - name: Extract links added by the pull request
-        run: |
-          git diff --unified=0 HEAD^1 HEAD^2 -- '*.md' '*.rst' \
-            | grep '^+' | grep -v '^+++' \
-            | grep -Eo 'https?://[^ )>]+' | sort -u > added-links.txt || true
-
-      - name: Check links added by the pull request
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
-        with:
-          args: --verbose --no-progress --exclude-mail added-links.txt
-          fail: true
-
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:
           project-slug: "python-packaging-user-guide"

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -17,6 +17,21 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract links added by the pull request
+        run: |
+          git diff --unified=0 "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- '*.md' '*.rst' \
+            | grep -Eo 'https?://[^ )>]+' | sort -u > added-links.txt || true
+
+      - name: Check links added by the pull request
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress --exclude-mail added-links.txt
+          fail: true
+
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:
           project-slug: "python-packaging-user-guide"


### PR DESCRIPTION
## Summary

Validate links added to Markdown and reStructuredText files in pull requests, including reopened and updated pull requests. The workflow checks out the pull-request merge ref, scans added lines only, and pins third-party actions to immutable commits.

## Validation

actionlint v1.7.12 and git diff --check passed.

Closes #2037